### PR TITLE
fix(ci): pin E2E repository fixture

### DIFF
--- a/scripts/verify-production.mjs
+++ b/scripts/verify-production.mjs
@@ -4,6 +4,7 @@ import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/cli
 const endpoint = new URL(process.env.MCP_URL ?? '');
 const token = process.env.MCP_BEARER_TOKEN;
 const repositoryUrl = process.env.VERIFY_REPOSITORY_URL ?? 'https://github.com/bestagentkits/cloud-harness-mcp.git';
+const repositoryRef = process.env.VERIFY_REPOSITORY_REF ?? (process.env.VERIFY_REPOSITORY_URL ? undefined : 'test-fixture-v1');
 
 if (!endpoint.href || !token) throw new Error('MCP_URL and MCP_BEARER_TOKEN are required');
 
@@ -79,12 +80,12 @@ try {
   const suffix = randomUUID();
   const opened = data(await modern.callTool({
     name: 'workspace_open',
-    arguments: { repositoryUrl, idempotencyKey: `production-${suffix}`, networkMode: 'none' }
+    arguments: { repositoryUrl, ...(repositoryRef ? { ref: repositoryRef } : {}), idempotencyKey: `production-${suffix}`, networkMode: 'none' }
   }), 'workspace_open');
   workspaceId = opened.workspaceId;
   const replayed = data(await modern.callTool({
     name: 'workspace_open',
-    arguments: { repositoryUrl, idempotencyKey: `production-${suffix}`, networkMode: 'none' }
+    arguments: { repositoryUrl, ...(repositoryRef ? { ref: repositoryRef } : {}), idempotencyKey: `production-${suffix}`, networkMode: 'none' }
   }), 'workspace_open replay');
   ensure(replayed.workspaceId === workspaceId, 'workspace idempotency replay changed the handle');
 

--- a/test/e2e/coding-workflow.docker.test.ts
+++ b/test/e2e/coding-workflow.docker.test.ts
@@ -13,6 +13,7 @@ import { WorkspaceService } from '../../apps/runner/src/workspace-service.js';
 
 const bearer = 'e2e-bearer-token-that-is-longer-than-32-characters';
 const serviceToken = 'e2e-runner-token-that-is-longer-than-32-characters';
+const fixtureRef = 'test-fixture-v1';
 let directory: string;
 let store: StateStore;
 let service: WorkspaceService;
@@ -30,7 +31,7 @@ async function listen(server: Server): Promise<number> {
 }
 
 function structured(result: CallToolResult): Record<string, any> {
-  expect(result.isError).toBe(false);
+  expect(result.isError, JSON.stringify(result.structuredContent)).toBe(false);
   return result.structuredContent as Record<string, any>;
 }
 
@@ -76,9 +77,9 @@ afterAll(async () => {
 
 describe('complete coding workflow through MCP', () => {
   it('uses every required coding domain in a persistent sandbox', async () => {
-    const opened = await call('workspace_open', { repositoryUrl: 'https://github.com/bestagentkits/cloud-harness-mcp.git', idempotencyKey: 'e2e-workspace-1', networkMode: 'none' });
+    const opened = await call('workspace_open', { repositoryUrl: 'https://github.com/bestagentkits/cloud-harness-mcp.git', ref: fixtureRef, idempotencyKey: 'e2e-workspace-1', networkMode: 'none' });
     workspaceId = opened.data.workspaceId;
-    const replayed = await call('workspace_open', { repositoryUrl: 'https://github.com/bestagentkits/cloud-harness-mcp.git', idempotencyKey: 'e2e-workspace-1', networkMode: 'none' });
+    const replayed = await call('workspace_open', { repositoryUrl: 'https://github.com/bestagentkits/cloud-harness-mcp.git', ref: fixtureRef, idempotencyKey: 'e2e-workspace-1', networkMode: 'none' });
     expect(replayed.data.workspaceId).toBe(workspaceId);
     expect(JSON.stringify((await call('workspace_list')).data)).toContain(workspaceId);
     expect((await call('workspace_status', { workspaceId })).data.status).toBe('ACTIVE');
@@ -144,11 +145,12 @@ describe('complete coding workflow through MCP', () => {
     expect(JSON.stringify((await call('git_diff', { workspaceId, staged: false })).data)).toContain('Verified remote coding harness');
     await call('git_commit', { workspaceId, message: 'test: verify harness workflow', authorName: 'Harness Test', authorEmail: 'harness@example.invalid', all: true });
     expect(JSON.stringify((await call('git_log', { workspaceId, limit: 5 })).data)).toContain('verify harness workflow');
+    await call('git_checkout', { workspaceId, ref: 'e2e-base', create: true });
     const branches = await call('git_branch', { workspaceId, action: 'list', force: false });
-    const initialBranch = branches.data.output.trim().split('\n')[0];
+    expect(branches.data.output).toContain('e2e-base');
     await call('git_branch', { workspaceId, action: 'create', name: 'e2e-branch', startPoint: 'HEAD', force: false });
     await call('git_checkout', { workspaceId, ref: 'e2e-branch', create: false });
-    await call('git_checkout', { workspaceId, ref: initialBranch, create: false });
+    await call('git_checkout', { workspaceId, ref: 'e2e-base', create: false });
     await call('git_branch', { workspaceId, action: 'delete', name: 'e2e-branch', force: false });
     const fetchResult = await client.callTool({ name: 'git_fetch', arguments: { workspaceId, remote: 'origin' } });
     expect(fetchResult.isError).toBe(true);
@@ -160,7 +162,7 @@ describe('complete coding workflow through MCP', () => {
     await call('workspace_close', { workspaceId });
     workspaceId = undefined;
 
-    const expiring = await call('workspace_open', { repositoryUrl: 'https://github.com/bestagentkits/cloud-harness-mcp.git', idempotencyKey: 'e2e-workspace-ttl', networkMode: 'none' });
+    const expiring = await call('workspace_open', { repositoryUrl: 'https://github.com/bestagentkits/cloud-harness-mcp.git', ref: fixtureRef, idempotencyKey: 'e2e-workspace-ttl', networkMode: 'none' });
     workspaceId = expiring.data.workspaceId;
     const expiringRecord = store.byId(workspaceId)!;
     store.update(workspaceId, { expiresAt: Date.now() - 1 });


### PR DESCRIPTION
## Summary
- pin the public coding workflow fixture to the immutable `test-fixture-v1` tag
- make tagged detached-HEAD branch checks deterministic
- preserve custom production verifier repository behavior and expose structured MCP errors in test diagnostics

## Root cause
The post-merge `main` CI cloned the repository's mutable default branch while asserting text that only existed before the MVP README landed.

## Verification
- `npm run test:e2e` (3 consecutive passes)
- `npm run verify` (10 files, 19 tests)
- `npm run test:docker`
- `npm run lint`
- `node --check scripts/verify-production.mjs`
- zero managed/ephemeral containers
- independent review: PASS