### PR TITLE
fix(deploy): preserve private API loopback ingress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: bash -n worker/clone-helper.sh worker/task-runner.sh worker/shell-runner.sh worker/worker-runner.sh deploy/scripts/bootstrap-vps.sh deploy/scripts/deploy-release.sh deploy/scripts/rollback-release.sh deploy/scripts/deploy-ssh-wrapper.sh
-      - run: docker compose -f compose.yaml -f compose.production.yaml config --quiet
-        env:
-          CLOUD_HARNESS_ENV_FILE: .env.example
+      - run: npm run verify:compose
       - run: npm run verify
 
   docker-integration:

--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ npm ci
 cp .env.example .env
 # Replace every change-me value in .env with an independent random secret.
 docker compose --profile images build executor-image api runner
-docker compose up -d api runner
+docker compose up -d runner api ingress
 curl --fail http://127.0.0.1:3100/readyz
 ```
 
-Local Compose publishes only the API on host loopback. It does not configure
-TLS. Stop it with:
+Local Compose publishes only a credential-free TCP ingress proxy on host
+loopback. The API and runner remain on separate internal networks; only the
+runner has Docker authority. Local Compose does not configure TLS. Stop it with:
 
 ```bash
 docker compose down

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -8,6 +8,14 @@ services:
       resources:
         limits: { cpus: "0.50", memory: 512M, pids: 128 }
 
+  ingress:
+    logging:
+      driver: json-file
+      options: { max-size: 10m, max-file: "3" }
+    deploy:
+      resources:
+        limits: { cpus: "0.25", memory: 128M, pids: 64 }
+
   runner:
     env_file: ${CLOUD_HARNESS_ENV_FILE:-/etc/cloud-harness-mcp/runtime.env}
     logging:

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,8 +16,6 @@ services:
       GITHUB_APP_INSTALLATION_ID: ""
       GITHUB_APP_PRIVATE_KEY: ""
       GITHUB_APP_PRIVATE_KEY_FILE: ""
-    ports:
-      - "127.0.0.1:${API_HOST_PORT:-3100}:3000"
     depends_on:
       runner:
         condition: service_healthy
@@ -26,9 +24,35 @@ services:
       - /tmp:rw,nosuid,nodev,noexec,size=32m
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
-    networks: [control]
+    networks: [frontend, control]
     healthcheck:
       test: [CMD, node, -e, "fetch('http://127.0.0.1:3000/healthz').then(r=>{if(!r.ok)process.exit(1)})"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+
+  ingress:
+    image: cloud-harness-api:local
+    restart: unless-stopped
+    command: ["node", "/app/deploy/ingress-proxy.mjs"]
+    environment:
+      INGRESS_HOST: 0.0.0.0
+      INGRESS_PORT: 3100
+      API_UPSTREAM_HOST: api
+      API_UPSTREAM_PORT: 3000
+    ports:
+      - "127.0.0.1:${API_HOST_PORT:-3100}:3100"
+    depends_on:
+      api:
+        condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,noexec,size=8m
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    networks: [frontend, ingress]
+    healthcheck:
+      test: [CMD, node, -e, "fetch('http://127.0.0.1:3100/readyz').then(r=>{if(!r.ok)process.exit(1)})"]
       interval: 10s
       timeout: 3s
       retries: 6
@@ -64,7 +88,11 @@ services:
     command: ["true"]
 
 networks:
+  frontend:
+    internal: true
   control:
     internal: true
+  ingress:
+    driver: bridge
   runner-egress:
     driver: bridge

--- a/deploy/ingress-proxy.mjs
+++ b/deploy/ingress-proxy.mjs
@@ -1,0 +1,26 @@
+import { createServer, connect } from 'node:net';
+
+const listenHost = process.env.INGRESS_HOST ?? '0.0.0.0';
+const listenPort = Number(process.env.INGRESS_PORT ?? 3100);
+const upstreamHost = process.env.API_UPSTREAM_HOST ?? 'api';
+const upstreamPort = Number(process.env.API_UPSTREAM_PORT ?? 3000);
+
+if (!Number.isInteger(listenPort) || listenPort < 1 || listenPort > 65_535) throw new Error('invalid ingress port');
+if (!Number.isInteger(upstreamPort) || upstreamPort < 1 || upstreamPort > 65_535) throw new Error('invalid API upstream port');
+
+const server = createServer((downstream) => {
+  const upstream = connect({ host: upstreamHost, port: upstreamPort });
+  downstream.pipe(upstream).pipe(downstream);
+  downstream.on('error', () => upstream.destroy());
+  upstream.on('error', () => downstream.destroy());
+  downstream.on('close', () => upstream.destroy());
+  upstream.on('close', () => downstream.destroy());
+});
+
+server.listen(listenPort, listenHost, () => {
+  process.stdout.write(`ingress proxy listening on ${listenHost}:${listenPort}\n`);
+});
+
+const shutdown = () => server.close(() => process.exit(0));
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -19,6 +19,7 @@ COPY --from=build /app/apps/api/dist ./apps/api/dist
 COPY --from=build /app/packages/contracts/package.json ./packages/contracts/package.json
 COPY --from=build /app/packages/contracts/dist ./packages/contracts/dist
 COPY scripts/deploy-canary.mjs ./scripts/deploy-canary.mjs
+COPY deploy/ingress-proxy.mjs ./deploy/ingress-proxy.mjs
 USER node
 EXPOSE 3000
 CMD ["node", "apps/api/dist/index.js"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,5 +87,5 @@ changes the loopback host port. `HOST_JOBS_ROOT` and `HOST_STATE_ROOT` select
 the host persistence paths. `LOG_LEVEL` is read by API and runner logging.
 
 `API_HOST`/`RUNNER_HOST`, service ports, and the private `RUNNER_URL` are wired
-by Compose. Avoid publishing the runner or changing the API bind from loopback
+by Compose. Avoid publishing the API or runner, or changing the ingress proxy from loopback
 on an Internet-facing host.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,8 +1,9 @@
 # VPS deployment
 
 This route installs the private single-owner service behind an existing nginx
-instance. Compose publishes the API only on `127.0.0.1:3100`; nginx remains the
-only public ingress. The bootstrap script installs an HTTP server block but
+instance. Compose publishes a credential-free TCP ingress proxy only on
+`127.0.0.1:3100`; the API and runner remain on private networks and nginx
+remains the only public ingress. The bootstrap script installs an HTTP server block but
 does not obtain a certificate. Certbot is a separate required step.
 
 ## Prerequisites and safe preflight
@@ -117,7 +118,8 @@ sudo ss -ltnp
 ```
 
 The unauthenticated MCP request should be rejected; readiness should succeed.
-Confirm `3100` is loopback-only and that no runner/executor port is public.
+Confirm `3100` is loopback-only, the ingress container has no runtime secrets,
+and no API, runner, or executor port is public.
 
 From a trusted operator checkout, run the authenticated production workflow
 with the bearer supplied only through the environment:

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,7 +74,7 @@ topology:
 
 ```bash
 docker compose --profile images build
-docker compose up -d api runner
+docker compose up -d runner api ingress
 docker compose ps
 docker compose down
 ```

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -25,7 +25,10 @@ Untrusted execution input:
 - repository content, dependencies, Git metadata, hook definitions, skills,
   memories, and commands supplied through tools.
 
-The API is deliberately separated from Docker authority. The runner has no
+The API is deliberately separated from Docker authority. A credential-free
+TCP proxy is the only Compose service with a loopback-published port. It joins
+the API frontend network but not the API/runner control network, and the API
+itself joins only internal networks. The runner has no
 published port and is the only service with `/var/run/docker.sock`; it uses a
 separate egress network for DNS validation and optional GitHub App calls while
 the API/runner control network remains internal.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -5,19 +5,30 @@
 ```text
 MCP client
   -> existing nginx (public TLS)
-  -> API (loopback-published, bearer + Host + Origin policy)
+  -> credential-free TCP ingress proxy (loopback-published)
+  -> API (private network, bearer + Host + Origin policy)
   -> runner (internal Compose network, service bearer)
   -> rootful Docker socket
   -> clone helper, then one executor for the workspace
 ```
 
-The split is deliberate. The API owns public HTTP, MCP negotiation, request
+The split is deliberate. The ingress proxy owns no secret or application
+logic; it only bridges host loopback to an internal frontend network. The API owns public HTTP, MCP negotiation, request
 security, and translation to a versioned private runner request. It has no
-Docker socket or host job mount. The runner owns workspace lifecycle, SQLite
+published port, external network, Docker socket, or host job mount. The proxy
+cannot join the API/runner control network. The runner owns workspace lifecycle, SQLite
 metadata, repository materialization, Docker policy, and cleanup. Only the
 runner receives the Docker socket and job/state mounts. The API and runner
 share an internal control network; the trusted runner also has a separate
 egress network for repository DNS validation and optional GitHub App calls.
+
+The extra byte-proxy hop is required because Docker does not activate a host
+port mapping for a service attached only to an `internal` network on the target
+Linux engine. Docker documents internal networks as having no connection to
+host network interfaces or external gateway in its
+[Compose networking guide](https://docs.docker.com/compose/how-tos/networking/#internal-networks).
+Publishing from a separate, secret-free proxy preserves the loopback listener
+without granting the API an external gateway.
 
 The executor is where repository-controlled code runs. It is non-root, has a
 read-only root filesystem, receives one writable repository mount, and has no
@@ -27,6 +38,8 @@ shares the host kernel.
 
 Executable owners:
 
+- Loopback-to-frontend byte proxy:
+  [`deploy/ingress-proxy.mjs`](../deploy/ingress-proxy.mjs)
 - Public HTTP and MCP assembly:
   [`apps/api/src/app.ts`](../apps/api/src/app.ts) and
   [`apps/api/src/mcp-server.ts`](../apps/api/src/mcp-server.ts)
@@ -71,8 +84,9 @@ cleanup authority.
 
 ## Deployment topology
 
-Production Compose binds the API to `127.0.0.1:3100`; the runner has no
-published host port. Runner egress does not expose an ingress port. Existing
+Production Compose binds the credential-free ingress proxy to
+`127.0.0.1:3100`; the API and runner have no published host ports. Runner
+egress does not expose an ingress port. Existing
 nginx is the only intended public listener and
 proxies `/mcp`, `/healthz`, and `/readyz` to loopback. The
 [deployment guide](deployment.md) explains the safe install order and the TLS

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,7 @@ export default tseslint.config(
     }
   },
   {
-    files: ['worker/**/*.mjs', 'scripts/**/*.mjs'],
+    files: ['worker/**/*.mjs', 'scripts/**/*.mjs', 'deploy/**/*.mjs'],
     languageOptions: {
       globals: {
         Buffer: 'readonly',

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "pretest:e2e": "npm run build -w @cloud-harness/contracts",
     "test:e2e": "vitest run test/e2e --testTimeout=120000",
     "verify:production": "node scripts/verify-production.mjs",
+    "verify:compose": "node scripts/verify-compose-boundaries.mjs",
     "verify": "npm run lint && npm run typecheck && npm test && npm run build"
   },
   "devDependencies": {

--- a/plans/2026-08-16-1-cloud-harness-mcp-mvp/phase-05-vps-deployment-and-end-to-end-verification.md
+++ b/plans/2026-08-16-1-cloud-harness-mcp-mvp/phase-05-vps-deployment-and-end-to-end-verification.md
@@ -22,7 +22,7 @@ Deploy the verified images to the VPS through a gated SSH workflow, reuse existi
 
 ## Requirements
 
-- Functional: production Compose keeps API on host loopback, runner on an internal network, and Docker socket/job root on runner only.
+- Functional: production Compose keeps a credential-free ingress proxy on host loopback, API and runner on private networks, and Docker socket/job root on runner only.
 - Functional: existing nginx terminates TLS and proxies `/mcp` plus health endpoints with streaming/cancellation semantics preserved.
 - Functional: GitHub Actions deploys an immutable tested image digest over SSH, health-checks it, and automatically restores the prior digest on failure.
 - Operational: host preflight verifies Ubuntu/Docker/cgroup/storage capacity, AppArmor/seccomp, firewall/listeners, nginx/certificate state, jobs root, service accounts, and reaper behavior.
@@ -30,7 +30,7 @@ Deploy the verified images to the VPS through a gated SSH workflow, reuse existi
 
 ## Architecture
 
-Public traffic reaches existing nginx on `80/443`; nginx proxies only to API at `127.0.0.1:3100`. Compose exposes no runner port and gives the runner an internal service network, the Docker socket, and the configured jobs root. A dedicated deploy identity may invoke only a fixed root-owned deployment script whose repository/origin are hardcoded and whose only release input is an exact approved commit SHA; runtime bearer and GitHub App material come from root-owned files/Compose secrets.
+Public traffic reaches existing nginx on `80/443`; nginx proxies only to a credential-free TCP ingress at `127.0.0.1:3100`. The proxy reaches API on an internal frontend network but cannot join the API/runner control network. Compose exposes no API or runner port and gives the runner the Docker socket and configured jobs root. A dedicated deploy identity may invoke only a fixed root-owned deployment script whose repository/origin are hardcoded and whose only release input is an exact approved commit SHA; runtime bearer and GitHub App material come from root-owned files/Compose secrets.
 
 ## Related Code Files
 
@@ -66,7 +66,7 @@ Public traffic reaches existing nginx on `80/443`; nginx proxies only to API at 
 ## Success Criteria
 
 - [ ] The named HTTPS endpoint is healthy and usable by the owner with modern and 2025 Streamable HTTP clients.
-- [ ] Existing nginx is the only public ingress; API is loopback-only and runner/executors are not publicly reachable.
+- [ ] Existing nginx is the only public ingress; the application ingress is loopback-only and API/runner/executors are not publicly reachable.
 - [ ] SSH deployment is gated, digest-pinned, least-privilege, repeatable, health-checked, and rollback-proven.
 - [ ] Every required tool completes a live remote workflow in a persistent sandbox and cleanup leaves no orphan.
 - [ ] The evidence report supports each MVP acceptance criterion without credentials or private data.

--- a/scripts/verify-compose-boundaries.mjs
+++ b/scripts/verify-compose-boundaries.mjs
@@ -1,0 +1,38 @@
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync('docker', [
+  'compose', '-f', 'compose.yaml', '-f', 'compose.production.yaml', 'config', '--format', 'json'
+], {
+  cwd: process.cwd(),
+  encoding: 'utf8',
+  env: { ...process.env, CLOUD_HARNESS_ENV_FILE: '.env.example' }
+});
+
+if (result.status !== 0) throw new Error(result.stderr || 'production Compose config failed');
+const config = JSON.parse(result.stdout);
+const services = config.services;
+const networks = config.networks;
+const requireBoundary = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+const networkNames = (service) => Object.keys(service.networks ?? {}).sort();
+
+requireBoundary(!services.api.ports?.length, 'API must not publish a host port');
+requireBoundary(!services.runner.ports?.length, 'runner must not publish a host port');
+requireBoundary(!services.api.volumes?.length, 'API must not receive host mounts');
+requireBoundary(!services.ingress.volumes?.length, 'ingress must not receive host mounts');
+requireBoundary(JSON.stringify(networkNames(services.api)) === JSON.stringify(['control', 'frontend']), 'API network boundary changed');
+requireBoundary(JSON.stringify(networkNames(services.runner)) === JSON.stringify(['control', 'runner-egress']), 'runner network boundary changed');
+requireBoundary(JSON.stringify(networkNames(services.ingress)) === JSON.stringify(['frontend', 'ingress']), 'ingress network boundary changed');
+requireBoundary(networks.control.internal === true && networks.frontend.internal === true, 'private networks must remain internal');
+requireBoundary(networks.ingress.internal !== true && networks['runner-egress'].internal !== true, 'gateway networks must remain routable');
+
+const published = services.ingress.ports ?? [];
+requireBoundary(published.length === 1, 'ingress must publish exactly one port');
+requireBoundary(published[0].host_ip === '127.0.0.1' && Number(published[0].target) === 3100, 'ingress must bind only loopback port 3100');
+const ingressEnvironment = Object.keys(services.ingress.environment ?? {});
+requireBoundary(!ingressEnvironment.some((name) => /TOKEN|SECRET|PASSWORD|GITHUB_APP/.test(name)), 'ingress must not receive secret variables');
+
+const runnerMounts = services.runner.volumes ?? [];
+requireBoundary(runnerMounts.some((mount) => mount.source === '/var/run/docker.sock' && mount.target === '/var/run/docker.sock'), 'runner Docker socket mount is missing');
+console.log('compose-boundaries=pass');

--- a/test/integration/ingress-proxy.test.ts
+++ b/test/integration/ingress-proxy.test.ts
@@ -1,0 +1,86 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+
+let proxy: ChildProcessWithoutNullStreams | undefined;
+let upstream: Server | undefined;
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('test server failed to listen');
+  return address.port;
+}
+
+async function reservePort(): Promise<number> {
+  const reservation = createServer();
+  const port = await listen(reservation);
+  await new Promise<void>((resolve, reject) => reservation.close((error) => error ? reject(error) : resolve()));
+  return port;
+}
+
+async function waitUntilListening(child: ChildProcessWithoutNullStreams): Promise<void> {
+  await Promise.race([
+    new Promise<void>((resolve, reject) => {
+      child.stdout.on('data', (chunk) => {
+        if (chunk.toString().includes('ingress proxy listening')) resolve();
+      });
+      child.once('exit', (code) => reject(new Error(`ingress proxy exited early with ${code}`)));
+    }),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('ingress proxy startup timed out')), 5_000))
+  ]);
+}
+
+afterEach(async () => {
+  if (proxy && proxy.exitCode === null) {
+    proxy.kill('SIGTERM');
+    await new Promise<void>((resolve) => proxy!.once('exit', () => resolve()));
+  }
+  proxy = undefined;
+  if (upstream) await new Promise<void>((resolve) => upstream!.close(() => resolve()));
+  upstream = undefined;
+});
+
+describe('credential-free loopback ingress proxy', () => {
+  it('forwards HTTP bytes to the private API upstream', async () => {
+    let confirmDisconnect: (() => void) | undefined;
+    const disconnected = new Promise<void>((resolve) => { confirmDisconnect = resolve; });
+    upstream = createServer((request, response) => {
+      if (request.url === '/stream') {
+        request.socket.once('close', () => confirmDisconnect?.());
+        response.writeHead(200, { 'content-type': 'text/plain' });
+        response.write('stream-open');
+        return;
+      }
+      response.writeHead(200, { 'content-type': 'text/plain', 'x-forwarded-method': request.method });
+      response.end('proxy-ok');
+    });
+    const upstreamPort = await listen(upstream);
+    const ingressPort = await reservePort();
+    proxy = spawn(process.execPath, ['deploy/ingress-proxy.mjs'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        INGRESS_HOST: '127.0.0.1',
+        INGRESS_PORT: String(ingressPort),
+        API_UPSTREAM_HOST: '127.0.0.1',
+        API_UPSTREAM_PORT: String(upstreamPort)
+      }
+    });
+    await waitUntilListening(proxy);
+
+    const response = await fetch(`http://127.0.0.1:${ingressPort}/readyz`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-forwarded-method')).toBe('GET');
+    expect(await response.text()).toBe('proxy-ok');
+
+    const controller = new AbortController();
+    const streaming = await fetch(`http://127.0.0.1:${ingressPort}/stream`, { signal: controller.signal });
+    await streaming.body?.getReader().read();
+    controller.abort();
+    await Promise.race([
+      disconnected,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('downstream cancellation did not close the API connection')), 2_000))
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- publish loopback ingress from a credential-free TCP proxy instead of the internal-only API network
- isolate proxy/API and API/runner on separate internal networks while keeping the API without host ports, egress, or mounts
- add streaming/disconnect coverage plus a machine-enforced production Compose boundary gate
- update architecture, deployment, security, development, and plan documentation

## Root cause
Production deploy run 31953561699 reached healthy API/runner containers, but Docker 28.3.3 left the API port binding inactive because the API was attached only to an `internal` network. `127.0.0.1:3100` had no listener and nginx returned 502. The first-install rollback disabled the unit and nginx route and removed all runtime containers as designed.

## Verification
- local loopback initialize 200; unauthenticated 401; foreign Host 403
- API has no host port, external network, or mounts
- ingress has only `127.0.0.1:3100`, no mounts, secret env, or control-network membership
- `npm run verify:compose`
- `npm run verify` (11 files, 20 tests)
- ingress streaming/disconnect test passed 5 consecutive runs
- API/runner/executor image builds
- Docker isolation and full MCP E2E
- zero managed/ephemeral containers
- independent pre-landing review: PASS

## Evidence
- failed deploy: https://github.com/bestagentkits/cloud-harness-mcp/actions/runs/31953561699