### PR TITLE
fix(deploy): make runtime scripts readable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: docker compose --profile images build executor-image api runner
+      - name: Verify runtime scripts are readable by the non-root API user
+        run: docker run --rm --entrypoint node cloud-harness-api:local -e "const fs=require('node:fs'); for (const file of ['/app/scripts/deploy-canary.mjs','/app/deploy/ingress-proxy.mjs']) fs.accessSync(file, fs.constants.R_OK)"
       - run: npm run test:docker
       - run: npm run test:e2e
       - name: Assert managed-container cleanup

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -18,8 +18,8 @@ COPY --from=build /app/apps/api/package.json ./apps/api/package.json
 COPY --from=build /app/apps/api/dist ./apps/api/dist
 COPY --from=build /app/packages/contracts/package.json ./packages/contracts/package.json
 COPY --from=build /app/packages/contracts/dist ./packages/contracts/dist
-COPY scripts/deploy-canary.mjs ./scripts/deploy-canary.mjs
-COPY deploy/ingress-proxy.mjs ./deploy/ingress-proxy.mjs
+COPY --chown=node:node --chmod=0555 scripts/deploy-canary.mjs ./scripts/deploy-canary.mjs
+COPY --chown=node:node --chmod=0555 deploy/ingress-proxy.mjs ./deploy/ingress-proxy.mjs
 USER node
 EXPOSE 3000
 CMD ["node", "apps/api/dist/index.js"]


### PR DESCRIPTION
## Summary
- make directly copied runtime scripts traversable/readable by the non-root API user
- add an image-level regression check in CI

## Root cause
The deployment script uses umask 077. Git-created source directories were preserved as root-only by Docker COPY, so the ingress process failed with EACCES on /app/deploy/ingress-proxy.mjs.

## Verification
- npm run verify
- npm run verify:compose
- ingress proxy integration test
- API image build and non-root fs.accessSync check