### PR TITLE
fix(deploy): send valid smoke payload

### DIFF
--- a/deploy/scripts/deploy-release.sh
+++ b/deploy/scripts/deploy-release.sh
@@ -83,14 +83,14 @@ wait_ready
 
 set +x
 source "$env_file"
-curl --fail --silent --show-error --max-time 10 --config - >/dev/null <<EOF
+smoke_payload='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"deploy-smoke","version":"1.0.0"}}}'
+curl --fail --silent --show-error --max-time 10 --data-binary "$smoke_payload" --config - >/dev/null <<EOF
 url = "http://127.0.0.1:3100/mcp"
 request = "POST"
 header = "Host: 127.0.0.1"
 header = "Authorization: Bearer $MCP_BEARER_TOKEN"
 header = "Content-Type: application/json"
 header = "Accept: application/json, text/event-stream"
-data = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"deploy-smoke","version":"1.0.0"}}}'
 EOF
 
 CLOUD_HARNESS_ENV_FILE="$env_file" HOST_JOBS_ROOT="$state/jobs" HOST_STATE_ROOT="$state/state" docker compose -f compose.yaml -f compose.production.yaml exec -T api node /app/scripts/deploy-canary.mjs


### PR DESCRIPTION
## Summary
- pass the MCP initialize JSON via curl data-binary
- keep the bearer token in curl config so it does not appear in process arguments

## Root cause
Single quotes in curl config values are literal, so the deployed smoke request body began with a quote and failed JSON parsing with HTTP 400.

## Verification
- shell syntax check
- exact corrected smoke command returned MCP initialize HTTP 200 against the isolated production stack
- API journal confirmed the former payload had literal quote characters