### PR TITLE
feat: add Cloudflare Pages landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ docker compose down
 - [Development and testing](docs/development.md)
 - [Operations, backup, rollback, and cleanup](docs/operations.md)
 - [VPS deployment with nginx and Certbot](docs/deployment.md)
+- [Cloudflare Pages landing page](docs/cloudflare-pages.md)
 - [Troubleshooting](docs/troubleshooting.md)
 
 The repository is public at

--- a/docs/cloudflare-pages.md
+++ b/docs/cloudflare-pages.md
@@ -1,0 +1,62 @@
+# Cloudflare Pages landing page
+
+The landing page is a static artifact in [`site/`](../site/). It is a separate
+public surface from the private MCP service: do not bind, redirect, or proxy
+`cloud-harness-mcp.46-250-239-227.sslip.io` through Pages. That hostname stays
+with the VPS nginx deployment described in [VPS deployment](deployment.md).
+
+## First-time setup
+
+1. Authenticate the intended Cloudflare account with `npx wrangler login`.
+2. In Cloudflare Workers & Pages, create the direct-upload Pages project named
+   `cloud-harness-mcp`. Use the generated `cloud-harness-mcp.pages.dev`
+   hostname until an owner explicitly approves a different custom domain.
+3. Do not add Pages secrets, environment variables, Functions, API tokens,
+   MCP bearer tokens, runner tokens, or GitHub App credentials. The page has no
+   runtime configuration.
+
+The authenticated account must have access to that exact project. The preflight
+does not create a project, which prevents uploading the page to an unintended
+account or project.
+
+## Deploy
+
+Install the repository dependencies, then run:
+
+```bash
+npm run pages:deploy
+```
+
+The command first inventories `site/` for environment files, credential
+markers, and files over the Pages upload limit. It then verifies the active
+Cloudflare identity and project before uploading production assets. Do not
+place generated runtime artifacts beneath `site/`.
+
+After upload, the command verifies
+`https://cloud-harness-mcp.pages.dev`. This expected Pages hostname is separate
+from the MCP hostname. Check the page's outbound documentation links too.
+
+To inspect production deployment history:
+
+```bash
+npm run pages:list
+```
+
+## Rollback
+
+Cloudflare Pages rollbacks are performed from the dashboard rather than a
+Wrangler command. In **Workers & Pages** open **cloud-harness-mcp**, choose
+**Deployments**, find a previous successful **production** deployment in **All
+deployments**, use its actions menu, then choose **Rollback to this deployment**.
+Preview deployments are not valid rollback targets. Confirm the restored
+`cloud-harness-mcp.pages.dev` page after the rollback.
+
+## Troubleshooting
+
+- If `npm run pages:preflight` says Wrangler is unauthenticated, run
+  `npx wrangler login` in the owner-controlled browser session.
+- If the named project is absent, create it in the intended account before
+  deploying. Do not change the repository's project name to match a different
+  account.
+- If the artifact check fails, remove the named file or credential marker from
+  `site/`; never suppress the check or upload a broader directory.

--- a/docs/cloudflare-pages.md
+++ b/docs/cloudflare-pages.md
@@ -5,12 +5,15 @@ public surface from the private MCP service: do not bind, redirect, or proxy
 `cloud-harness-mcp.46-250-239-227.sslip.io` through Pages. That hostname stays
 with the VPS nginx deployment described in [VPS deployment](deployment.md).
 
+Production URL: <https://cloud-harness-mcp.pages.dev>
+
 ## First-time setup
 
 1. Authenticate the intended Cloudflare account with `npx wrangler login`.
-2. In Cloudflare Workers & Pages, create the direct-upload Pages project named
-   `cloud-harness-mcp`. Use the generated `cloud-harness-mcp.pages.dev`
-   hostname until an owner explicitly approves a different custom domain.
+2. Create the direct-upload Pages project with
+   `npx wrangler pages project create cloud-harness-mcp --production-branch main`.
+   Use the generated `cloud-harness-mcp.pages.dev` hostname until an owner
+   explicitly approves a different custom domain.
 3. Do not add Pages secrets, environment variables, Functions, API tokens,
    MCP bearer tokens, runner tokens, or GitHub App credentials. The page has no
    runtime configuration.
@@ -29,8 +32,8 @@ npm run pages:deploy
 
 The command first inventories `site/` for environment files, credential
 markers, and files over the Pages upload limit. It then verifies the active
-Cloudflare identity and project before uploading production assets. Do not
-place generated runtime artifacts beneath `site/`.
+Cloudflare identity and project before uploading assets to the Pages production
+branch, `main`. Do not place generated runtime artifacts beneath `site/`.
 
 After upload, the command verifies
 `https://cloud-harness-mcp.pages.dev`. This expected Pages hostname is separate

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "eslint": "9.39.5",
         "typescript": "5.9.3",
         "typescript-eslint": "8.67.0",
-        "vitest": "4.1.10"
+        "vitest": "4.1.10",
+        "wrangler": "4.123.0"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -59,6 +60,583 @@
     "node_modules/@cloud-harness/runner": {
       "resolved": "apps/runner",
       "link": true
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz",
+      "integrity": "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz",
+      "integrity": "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz",
+      "integrity": "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.10.1",
@@ -282,12 +860,608 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@modelcontextprotocol/client": {
       "version": "2.0.0",
@@ -528,6 +1702,48 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -792,6 +2008,26 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1427,6 +2663,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -1711,6 +2954,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1746,6 +2999,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {
@@ -2482,6 +3777,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2859,6 +4164,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260811.1-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260811.1-alpha.tgz",
+      "integrity": "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260811.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/minimatch": {
@@ -3422,6 +4745,51 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3694,6 +5062,14 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3776,12 +5152,32 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
     },
     "node_modules/universal-github-app-jwt": {
       "version": "2.2.2",
@@ -4034,11 +5430,97 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/workerd": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260811.1.tgz",
+      "integrity": "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260811.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260811.1",
+        "@cloudflare/workerd-linux-64": "1.20260811.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260811.1",
+        "@cloudflare/workerd-windows-64": "1.20260811.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.123.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.123.0.tgz",
+      "integrity": "sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260811.1-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260811.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260811.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -4051,6 +5533,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
     "test:docker": "vitest run test/integration/docker-sandbox.docker.test.ts --testTimeout=120000",
     "pretest:e2e": "npm run build -w @cloud-harness/contracts",
     "test:e2e": "vitest run test/e2e --testTimeout=120000",
+    "pages:check": "node scripts/verify-pages-artifact.mjs",
+    "pages:preflight": "npm run pages:check && node scripts/verify-pages-project.mjs && npm run pages:links",
+    "pages:deploy": "npm run pages:preflight && wrangler pages deploy site --project-name cloud-harness-mcp && npm run pages:smoke",
+    "pages:list": "wrangler pages deployment list --project-name cloud-harness-mcp --environment production --json",
+    "pages:links": "node scripts/verify-pages-links.mjs",
+    "pages:smoke": "node scripts/verify-pages-url.mjs",
     "verify:production": "node scripts/verify-production.mjs",
     "verify:compose": "node scripts/verify-compose-boundaries.mjs",
     "verify": "npm run lint && npm run typecheck && npm test && npm run build"
@@ -36,6 +42,7 @@
     "eslint": "9.39.5",
     "typescript": "5.9.3",
     "typescript-eslint": "8.67.0",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "wrangler": "4.123.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:e2e": "vitest run test/e2e --testTimeout=120000",
     "pages:check": "node scripts/verify-pages-artifact.mjs",
     "pages:preflight": "npm run pages:check && node scripts/verify-pages-project.mjs && npm run pages:links",
-    "pages:deploy": "npm run pages:preflight && wrangler pages deploy site --project-name cloud-harness-mcp && npm run pages:smoke",
+    "pages:deploy": "npm run pages:preflight && wrangler pages deploy site --project-name cloud-harness-mcp --branch main && npm run pages:smoke",
     "pages:list": "wrangler pages deployment list --project-name cloud-harness-mcp --environment production --json",
     "pages:links": "node scripts/verify-pages-links.mjs",
     "pages:smoke": "node scripts/verify-pages-url.mjs",

--- a/plans/260817-0854-cloud-harness-landing-page/phase-01-start.md
+++ b/plans/260817-0854-cloud-harness-landing-page/phase-01-start.md
@@ -1,0 +1,32 @@
+---
+title: "Phase 1: Define the static surface"
+status: todo
+---
+
+# Phase 1: Define the static surface
+
+## Overview
+
+Identify the landing-page facts and create an intentionally small static-site boundary.
+
+## Requirements
+
+- [x] Use README, MCP API, system architecture, and security model as product-claim sources.
+- [x] Keep the landing page separate from the VPS-hosted Docker application.
+- [x] Use a static HTML/CSS/JavaScript surface with no secrets, API credentials, analytics, or build-time configuration.
+- [x] Reserve the existing MCP hostname for nginx; Pages may use only its generated hostname or a separately approved custom domain.
+
+## Implementation Steps
+
+1. Extract product vocabulary, tool semantics, topology, and restrictions from project documentation into a claim-to-source checklist.
+2. Define a compact `site/` artifact and Cloudflare Pages configuration.
+3. Confirm the visual direction, content sections, accessibility requirements, and deployment boundary.
+
+## Todo
+
+- [x] Establish the copy and security guardrails, including non-hostile-tenant, default-network, lifecycle, and Git-push qualifiers.
+- [x] Establish the static-site and deployment-file ownership.
+
+## Success Criteria
+
+The scope names exact source documents, contains no unverified product claims, and avoids interaction with the private runtime.

--- a/plans/260817-0854-cloud-harness-landing-page/phase-02-implement-static-landing.md
+++ b/plans/260817-0854-cloud-harness-landing-page/phase-02-implement-static-landing.md
@@ -1,0 +1,35 @@
+---
+title: "Phase 2: Implement static landing"
+status: todo
+---
+
+# Phase 2: Implement static landing
+
+## Overview
+
+Build the static landing page and its responsive, accessible visual system.
+
+## Requirements
+
+- [x] Create semantic HTML with a memorable MCP-to-executor “operation lane” visual.
+- [x] Use design tokens, a two-family font system, responsive layouts, keyboard focus states, and reduced-motion support.
+- [x] Link to real repository documentation and preserve the single-owner warning.
+- [x] Use absolute GitHub URLs for documentation links because the Pages artifact deploys independently.
+- [x] Include a skip link, landmarks, ordered heading hierarchy, keyboard-visible focus, text alternatives, verified contrast, and a static reduced-motion path.
+- [x] State that arbitrary repository code runs in an executor, the service is not a hostile multi-tenant sandbox, egress is off by default, and executor Git push is unavailable.
+
+## Implementation Steps
+
+1. Add the static site artifact under `site/` and a minimal Pages configuration.
+2. Implement the hero, capability inventory, architecture lane, owner-boundary message, and getting-started call to action.
+3. Verify visual composition at desktop and 375px mobile widths, then run manual accessibility checks for keyboard navigation, focus, landmarks, contrast, and reduced motion.
+
+## Todo
+
+- [x] Write page content grounded in current project docs.
+- [x] Implement responsive CSS, interactions, focus states, and reduced-motion behavior.
+- [x] Run a local static-server smoke test, static HTML validation, and inspect the rendered page.
+
+## Success Criteria
+
+The static surface renders without JavaScript dependencies, is readable at 375px, has no horizontal overflow, supports keyboard and reduced-motion users, and accurately presents the product limitations.

--- a/plans/260817-0854-cloud-harness-landing-page/phase-03-verify-and-publish-cloudflare-pages.md
+++ b/plans/260817-0854-cloud-harness-landing-page/phase-03-verify-and-publish-cloudflare-pages.md
@@ -1,0 +1,35 @@
+---
+title: "Phase 3: Verify and publish Cloudflare Pages"
+status: todo
+---
+
+# Phase 3: Verify and publish Cloudflare Pages
+
+## Overview
+
+Validate the artifact, document its independent Cloudflare Pages deployment, then publish it.
+
+## Requirements
+
+- [ ] Verify HTML/CSS behavior, artifact inventory, outbound links, and the repository quality gate appropriate to static-file changes.
+- [ ] Pin Wrangler and document the Pages project name, generated/custom hostname decision, deploy command, environment-variable policy, deployment-list command, and Cloudflare dashboard rollback procedure without recording credentials.
+- [ ] Deploy using the authenticated Cloudflare account and smoke-test the returned URL.
+- [ ] Confirm that `site/` contains no environment files, credentials, generated runtime state, bearer tokens, runner tokens, or GitHub App material before upload.
+
+## Implementation Steps
+
+1. Add pinned `wrangler` scripts for account/project preflight, deployment listing, and production upload. Document the Cloudflare dashboard rollback flow, because Pages rollbacks are a dashboard/API action rather than a Wrangler command.
+2. Run static checks, artifact/secret inventory, deployed-link validation, and inspect the landing page at desktop and mobile viewport widths.
+3. Add `docs/cloudflare-pages.md`, update README navigation, and keep the VPS deployment guide unchanged.
+4. Run the account/project preflight, deploy `site/` to `cloud-harness-mcp`, and verify the returned Pages hostname is not the MCP hostname.
+5. List deployments to demonstrate the rollback target can be selected, then smoke-test the production URL.
+6. If Cloudflare authentication or project permission is unavailable, record the exact prerequisite as an external blocker; leave the plan incomplete and do not substitute another provider.
+
+## Todo
+
+- [ ] Validate the artifact, accessibility, links, and repo integration.
+- [ ] Publish or identify the exact authentication/project-permission blocker.
+
+## Success Criteria
+
+The public deployment is available at Cloudflare Pages with a safe, reproducible deployment/rollback workflow. Missing authentication or project permission is a blocked, incomplete state; no unrelated provider is used.

--- a/plans/260817-0854-cloud-harness-landing-page/phase-03-verify-and-publish-cloudflare-pages.md
+++ b/plans/260817-0854-cloud-harness-landing-page/phase-03-verify-and-publish-cloudflare-pages.md
@@ -11,10 +11,10 @@ Validate the artifact, document its independent Cloudflare Pages deployment, the
 
 ## Requirements
 
-- [ ] Verify HTML/CSS behavior, artifact inventory, outbound links, and the repository quality gate appropriate to static-file changes.
-- [ ] Pin Wrangler and document the Pages project name, generated/custom hostname decision, deploy command, environment-variable policy, deployment-list command, and Cloudflare dashboard rollback procedure without recording credentials.
-- [ ] Deploy using the authenticated Cloudflare account and smoke-test the returned URL.
-- [ ] Confirm that `site/` contains no environment files, credentials, generated runtime state, bearer tokens, runner tokens, or GitHub App material before upload.
+- [x] Verify HTML/CSS behavior, artifact inventory, outbound links, and the repository quality gate appropriate to static-file changes.
+- [x] Pin Wrangler and document the Pages project name, generated/custom hostname decision, deploy command, environment-variable policy, deployment-list command, and Cloudflare dashboard rollback procedure without recording credentials.
+- [x] Deploy using the authenticated Cloudflare account and smoke-test the returned URL.
+- [x] Confirm that `site/` contains no environment files, credentials, generated runtime state, bearer tokens, runner tokens, or GitHub App material before upload.
 
 ## Implementation Steps
 
@@ -27,8 +27,8 @@ Validate the artifact, document its independent Cloudflare Pages deployment, the
 
 ## Todo
 
-- [ ] Validate the artifact, accessibility, links, and repo integration.
-- [ ] Publish or identify the exact authentication/project-permission blocker.
+- [x] Validate the artifact, accessibility, links, and repo integration.
+- [x] Publish or identify the exact authentication/project-permission blocker.
 
 ## Success Criteria
 

--- a/plans/260817-0854-cloud-harness-landing-page/plan.md
+++ b/plans/260817-0854-cloud-harness-landing-page/plan.md
@@ -1,0 +1,72 @@
+---
+title: "Cloud Harness landing page"
+description: ""
+status: in-progress
+priority: P1
+effort: "1d"
+branch: feat/cloud-harness-landing
+tags: [landing-page, static-site, cloudflare-pages]
+created: 2026-08-17
+---
+
+# Cloud Harness landing page
+
+## Overview
+
+Create a production-ready static landing page that explains Cloud Harness MCP's
+remote coding workflow, preserves the project's single-owner security message,
+and can be deployed independently to Cloudflare Pages.
+
+## Goals
+
+| # | Goal | Priority |
+|---|------|----------|
+| 1 | Present the harness as a clear, technically credible developer product. | P1 |
+| 2 | Keep marketing copy aligned with the README and security-model claims. | P1 |
+| 3 | Publish the static artifact through Cloudflare Pages without changing the VPS service. | P1 |
+
+## Phases
+
+| # | Phase | Status |
+|---|-------|--------|
+| 1 | [Define the static surface](./phase-01-start.md) | Pending |
+| 2 | [Implement the landing page](./phase-02-implement-static-landing.md) | Pending |
+| 3 | [Verify and publish](./phase-03-verify-and-publish-cloudflare-pages.md) | Pending |
+
+## Success Criteria
+
+- [ ] The page communicates the MCP-to-executor workflow and its single-owner, non-hostile-tenant boundary accurately.
+- [ ] The website is responsive, accessible, visually distinctive, and needs no runtime secret or backend.
+- [ ] A reproducible Cloudflare Pages deployment command and rollback process are documented.
+- [ ] The page is published to an isolated Cloudflare Pages hostname and its public URL, links, and owner-boundary copy are smoke-tested.
+
+## Non-goals
+
+- Moving or proxying the MCP API through Cloudflare Pages.
+- Changing Docker, API, runner, authentication, or VPS deployment behavior.
+- Claiming multi-tenant isolation, hosted credentials, or functionality that the repository does not implement.
+- Binding or redirecting the existing MCP hostname, which remains owned by the VPS nginx deployment.
+
+## Claim guardrails
+
+- Product claims are sourced from `README.md`, `docs/system-architecture.md`, `docs/security-model.md`, and `docs/mcp-api.md`.
+- The page must say that it is a private, single-owner service, repository code remains untrusted execution input, and the Docker/shared-kernel controls are not a hostile multi-tenant boundary.
+- It must not imply persistent workspaces, default executor egress, Git push, or executor access to deployment or repository credentials.
+
+## Red Team Review
+
+### Accepted findings
+
+- Make the single-owner/non-hostile-tenant limitation visible alongside the architecture story.
+- Use `docs/mcp-api.md` for capability claims and explicit lifecycle/network/Git qualifiers.
+- Pin the Pages CLI in the project, add preflight/deploy/rollback scripts, and document the target project and rollback selection.
+- Use absolute GitHub documentation URLs and validate every deployed outbound link.
+- Add a static-artifact secret inventory, accessibility checklist, and explicit Pages-hostname/DNS safeguard.
+- Keep the Pages guide separate from the VPS deployment guide and add it to README navigation.
+
+### Whole-Plan Consistency Sweep
+
+- Reconciled the completion rule: unavailable Cloudflare credentials block publication rather than count as success.
+- Reconciled page copy, verification, and deployment work so they all prohibit misleading isolation claims and control-plane secrets.
+
+<!-- slug: cloud-harness-landing-page -->

--- a/plans/260817-0854-cloud-harness-landing-page/plan.md
+++ b/plans/260817-0854-cloud-harness-landing-page/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Cloud Harness landing page"
 description: ""
-status: in-progress
+status: completed
 priority: P1
 effort: "1d"
 branch: feat/cloud-harness-landing

--- a/scripts/verify-pages-artifact.mjs
+++ b/scripts/verify-pages-artifact.mjs
@@ -1,0 +1,42 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const siteRoot = join(process.cwd(), 'site');
+const forbiddenNames = /(^|\/)(?:\.env(?:\..*)?|\.envrc|.*\.(?:pem|key|p12|db|sqlite|log))$/i;
+const forbiddenValues = /(?:MCP_BEARER_TOKEN|RUNNER_TOKEN|GITHUB_APP_(?:ID|INSTALLATION_ID|PRIVATE_KEY)|CLOUDFLARE_API_TOKEN|(?:ghp|gho|ghs|github_pat)_[A-Za-z0-9_]+|-----BEGIN [A-Z ]*PRIVATE KEY-----|Authorization\s*:\s*Bearer\s+[A-Za-z0-9._-]{20,})/i;
+
+async function files(root) {
+  const entries = await readdir(root, { withFileTypes: true });
+  return (await Promise.all(entries.map(async (entry) => {
+    const file = join(root, entry.name);
+    return entry.isDirectory() ? await files(file) : [file];
+  }))).flat();
+}
+
+let artifact;
+try {
+  artifact = await files(siteRoot);
+} catch (error) {
+  console.error(`Cloudflare Pages artifact check failed: site/ is unavailable (${error.code ?? error.message}).`);
+  process.exit(1);
+}
+const invalid = [];
+
+for (const file of artifact) {
+  const display = relative(process.cwd(), file).replaceAll('\\', '/');
+  if (forbiddenNames.test(display)) invalid.push(`${display}: forbidden artifact filename`);
+  if ((await stat(file)).size > 25 * 1024 * 1024) invalid.push(`${display}: exceeds the 25 MiB Pages upload limit`);
+  const content = await readFile(file);
+  const text = content.toString('utf8');
+  if (!text.includes('\uFFFD') && forbiddenValues.test(text)) {
+    invalid.push(`${display}: contains a forbidden credential marker`);
+  }
+}
+
+if (invalid.length) {
+  console.error('Cloudflare Pages artifact check failed.');
+  for (const message of invalid) console.error(`- ${message}`);
+  process.exit(1);
+}
+
+console.log(`Cloudflare Pages artifact check passed (${artifact.length} files).`);

--- a/scripts/verify-pages-links.mjs
+++ b/scripts/verify-pages-links.mjs
@@ -1,0 +1,23 @@
+import { readFile } from 'node:fs/promises';
+
+const page = await readFile(new URL('../site/index.html', import.meta.url), 'utf8');
+const urls = [...page.matchAll(/<a\b[^>]*\bhref="(https:\/\/[^"#]+)"/g)].map((match) => match[1]);
+const failures = [];
+
+for (const url of [...new Set(urls)]) {
+  try {
+    let response = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+    if (response.status === 405) response = await fetch(url, { redirect: 'follow' });
+    if (!response.ok) failures.push(`${url}: HTTP ${response.status}`);
+  } catch {
+    failures.push(`${url}: request failed`);
+  }
+}
+
+if (failures.length) {
+  console.error('Cloudflare Pages link check failed.');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(`Cloudflare Pages link check passed (${urls.length} links).`);

--- a/scripts/verify-pages-project.mjs
+++ b/scripts/verify-pages-project.mjs
@@ -12,7 +12,7 @@ try {
   process.exit(1);
 }
 
-if (!projects.some((project) => project.name === projectName)) {
+if (!projects.some((project) => project.name === projectName || project.project_name === projectName || project['Project Name'] === projectName)) {
   console.error(`Cloudflare Pages project "${projectName}" was not found in the authenticated account.`);
   process.exit(1);
 }

--- a/scripts/verify-pages-project.mjs
+++ b/scripts/verify-pages-project.mjs
@@ -1,0 +1,20 @@
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const projectName = 'cloud-harness-mcp';
+const wranglerCli = join(process.cwd(), 'node_modules', 'wrangler', 'bin', 'wrangler.js');
+let projects;
+try {
+  const output = execFileSync(process.execPath, [wranglerCli, 'pages', 'project', 'list', '--json'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  projects = JSON.parse(output);
+} catch {
+  console.error('Cloudflare Pages project preflight failed. Authenticate the intended account and verify it can list Pages projects.');
+  process.exit(1);
+}
+
+if (!projects.some((project) => project.name === projectName)) {
+  console.error(`Cloudflare Pages project "${projectName}" was not found in the authenticated account.`);
+  process.exit(1);
+}
+
+console.log(`Cloudflare Pages project "${projectName}" belongs to the authenticated account.`);

--- a/scripts/verify-pages-url.mjs
+++ b/scripts/verify-pages-url.mjs
@@ -1,0 +1,9 @@
+const hostname = 'cloud-harness-mcp.pages.dev';
+const response = await fetch(`https://${hostname}`, { redirect: 'error' });
+
+if (!response.ok) {
+  console.error(`Cloudflare Pages smoke test failed for ${hostname}: HTTP ${response.status}.`);
+  process.exit(1);
+}
+
+console.log(`Cloudflare Pages smoke test passed for ${hostname}.`);

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Cloud Harness MCP is a private remote coding harness for one trusted owner.">
+    <meta name="theme-color" content="oklch(13% 0.02 252)">
+    <title>Cloud Harness MCP | One trusted operator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=Source+Sans+3:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+
+    <header class="site-header">
+      <a class="brand" href="#top" aria-label="Cloud Harness MCP home">
+        <svg class="brand-mark" viewBox="0 0 40 40" aria-hidden="true"><path d="M6 6h12v4h-8v20h8v4H6zM22 6h12v28H22v-4h8V10h-8zM16 16h8v8h-8z"/></svg>
+        <span>Cloud Harness <b>MCP</b></span>
+      </a>
+      <nav aria-label="Primary navigation">
+        <a href="#operation-lane">Architecture</a>
+        <a href="#boundaries">Boundaries</a>
+        <a href="#start">Start</a>
+      </nav>
+      <a class="header-link" href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank" rel="noreferrer">Repository <span aria-hidden="true">↗</span></a>
+    </header>
+
+    <main id="main-content">
+      <section class="hero" id="top" aria-labelledby="hero-title">
+        <div class="hero-copy">
+          <p class="overline">Remote coding, under one owner</p>
+          <h1 id="hero-title">Keep the controls close.</h1>
+          <p class="hero-lede">Cloud Harness MCP opens an isolated repository workspace in a time-limited Docker executor for one trusted operator.</p>
+          <div class="hero-actions">
+            <a class="button button-primary" href="#start">See the workflow <span aria-hidden="true">↓</span></a>
+            <a class="button button-quiet" href="https://github.com/bestagentkits/cloud-harness-mcp/blob/main/docs/mcp-api.md" target="_blank" rel="noreferrer">Read MCP usage <span aria-hidden="true">↗</span></a>
+          </div>
+        </div>
+        <div class="hero-plate" aria-label="An abstract control panel showing a trusted owner, contained executor, and bounded workspace">
+          <div class="plate-line plate-line-top"></div>
+          <div class="plate-line plate-line-bottom"></div>
+          <p class="plate-label">Control plane</p>
+          <div class="operator-symbol" aria-hidden="true"><span></span><span></span><span></span></div>
+          <p class="plate-state">Trusted owner</p>
+          <div class="plate-divider" aria-hidden="true"></div>
+          <p class="plate-label plate-label-lower">Execution plane</p>
+          <div class="executor-symbol" aria-hidden="true"><i></i><i></i><i></i><i></i></div>
+          <p class="plate-state plate-state-lower">TTL-bound workspace</p>
+        </div>
+      </section>
+
+      <section class="statement" aria-labelledby="statement-title">
+        <div class="statement-grid">
+          <h2 id="statement-title">Repository code is an input, not a peer.</h2>
+          <p>Commands, dependencies, hooks, skills, and Git metadata from a repository can execute inside the executor. The control plane stays separate from Docker authority and repository credentials.</p>
+        </div>
+      </section>
+
+      <section class="lane-section" id="operation-lane" aria-labelledby="lane-title">
+        <div class="section-heading">
+          <h2 id="lane-title">A narrow route to execution.</h2>
+          <p>Each service has a job. Authority moves forward only where it is required.</p>
+        </div>
+        <ol class="operation-lane">
+          <li class="lane-node client">
+            <span class="lane-index">01</span>
+            <div><h3>MCP client</h3><p>The owner begins with an authenticated request.</p></div>
+          </li>
+          <li class="lane-node ingress">
+            <span class="lane-index">02</span>
+            <div><h3>Ingress</h3><p>A credential-free proxy accepts the loopback route.</p></div>
+          </li>
+          <li class="lane-node api">
+            <span class="lane-index">03</span>
+            <div><h3>API</h3><p>Request policy and MCP translation stay off the Docker socket.</p></div>
+          </li>
+          <li class="lane-node runner">
+            <span class="lane-index">04</span>
+            <div><h3>Runner</h3><p>Lifecycle, repository materialization, and cleanup live here.</p></div>
+          </li>
+          <li class="lane-node executor">
+            <span class="lane-index">05</span>
+            <div><h3>Docker executor</h3><p>Repository-controlled work runs non-root in a bounded workspace.</p></div>
+          </li>
+        </ol>
+        <a class="text-link" href="https://github.com/bestagentkits/cloud-harness-mcp/blob/main/docs/system-architecture.md" target="_blank" rel="noreferrer">Inspect the architecture documentation <span aria-hidden="true">↗</span></a>
+      </section>
+
+      <section class="capabilities" aria-labelledby="capability-title">
+        <div class="capability-intro">
+          <h2 id="capability-title">Useful controls. Bounded handles.</h2>
+        </div>
+        <div class="capability-list">
+          <article>
+            <span class="capability-number">A</span>
+            <h3>Open with intent</h3>
+            <p>Open a credential-free HTTPS repository URL with an idempotency key. Keep the opaque workspace ID for later calls.</p>
+          </article>
+          <article>
+            <span class="capability-number">B</span>
+            <h3>Inspect and change</h3>
+            <p>Use bounded file, search, command, shell, task, Git, worktree, skill, hook, and memory tools within that workspace.</p>
+          </article>
+          <article>
+            <span class="capability-number">C</span>
+            <h3>Close the lane</h3>
+            <p>Close when the work is complete. Workspace files expire after close or TTL cleanup, while durable metadata records the outcome.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="boundary-section" id="boundaries" aria-labelledby="boundary-title">
+        <div class="boundary-copy">
+          <p class="overline">Read this before use</p>
+          <h2 id="boundary-title">A private harness, not a tenant boundary.</h2>
+          <p>Cloud Harness MCP is for one authenticated, trusted owner using owner-approved repositories. It is not an anonymous service, shared team sandbox, or hostile multi-tenant platform.</p>
+          <a class="button button-copper" href="https://github.com/bestagentkits/cloud-harness-mcp/blob/main/docs/security-model.md" target="_blank" rel="noreferrer">Read the security model <span aria-hidden="true">↗</span></a>
+        </div>
+        <dl class="limit-list">
+          <div><dt>Untrusted input</dt><dd>Repository content and supplied commands may execute inside the executor.</dd></div>
+          <div><dt>Network</dt><dd>Executor networking is <strong>none</strong> by default. Bridge mode is an explicit weakening.</dd></div>
+          <div><dt>Git credentials</dt><dd>Executors have no GitHub App token, deployment credential, SSH key, or Git push tool.</dd></div>
+          <div><dt>Lifetime</dt><dd>Close or TTL cleanup removes the executor and workspace directory.</dd></div>
+        </dl>
+      </section>
+
+      <section class="start-section" id="start" aria-labelledby="start-title">
+        <div>
+          <h2 id="start-title">Open. Work. Close.</h2>
+        </div>
+        <div class="start-content">
+          <p>Connect Codex with an owner-provided bearer token kept in the environment, then call <code>workspace_open</code> with a credential-free HTTPS repository URL and fresh idempotency key.</p>
+          <div class="start-actions">
+            <a class="button button-primary" href="https://github.com/bestagentkits/cloud-harness-mcp#connect-from-codex" target="_blank" rel="noreferrer">Connect from Codex <span aria-hidden="true">↗</span></a>
+            <a class="text-link" href="https://github.com/bestagentkits/cloud-harness-mcp/blob/main/docs/mcp-api.md" target="_blank" rel="noreferrer">Tool semantics <span aria-hidden="true">↗</span></a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>Cloud Harness MCP. Remote execution, operated with intent.</p>
+      <div>
+        <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank" rel="noreferrer">GitHub</a>
+        <a href="https://github.com/bestagentkits/cloud-harness-mcp/blob/main/LICENSE" target="_blank" rel="noreferrer">MIT License</a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,171 @@
+:root {
+  color-scheme: dark;
+  --ink-950: oklch(0.13 0.02 252);
+  --ink-900: oklch(0.17 0.025 252);
+  --ink-800: oklch(0.22 0.028 252);
+  --slate-700: oklch(0.37 0.025 252);
+  --slate-500: oklch(0.57 0.025 252);
+  --ice-300: oklch(0.82 0.018 252);
+  --ice-100: oklch(0.94 0.012 252);
+  --copper-500: oklch(0.62 0.11 50);
+  --copper-400: oklch(0.71 0.1 58);
+  --lime-500: oklch(0.84 0.19 126);
+  --line: oklch(0.39 0.028 252);
+  --line-soft: oklch(0.28 0.026 252);
+  --font-display: "Barlow Condensed", sans-serif;
+  --font-body: "Source Sans 3", "Trebuchet MS", sans-serif;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --space-16: 64px;
+  --space-24: 96px;
+  --radius: 0;
+  --border: 1px;
+  --content: 1200px;
+  --focus: 3px;
+  --ease-out: cubic-bezier(0.25, 1, 0.5, 1);
+  --speed-fast: 150ms;
+  --speed: 250ms;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; background: var(--ink-950); }
+body { min-width: 320px; margin: 0; overflow-x: hidden; background: var(--ink-950); color: var(--ice-100); font-family: var(--font-body); font-size: 1.125rem; font-weight: 400; line-height: 1.6; letter-spacing: 0.01em; }
+a { color: inherit; text-decoration-thickness: var(--border); text-underline-offset: var(--space-1); }
+a:hover { color: var(--lime-500); }
+a:focus-visible { outline: var(--focus) solid var(--lime-500); outline-offset: var(--space-1); }
+button:focus-visible { outline: var(--focus) solid var(--lime-500); outline-offset: var(--space-1); }
+h1, h2, h3, p { margin-top: 0; }
+h1, h2, h3 { font-family: var(--font-display); font-weight: 600; line-height: 1.05; letter-spacing: 0.015em; text-wrap: balance; }
+h1 { max-width: 9ch; margin-bottom: var(--space-6); font-size: clamp(4rem, 7vw, 6rem); }
+h2 { margin-bottom: var(--space-6); font-size: clamp(2.75rem, 5vw, 4.5rem); }
+h3 { margin-bottom: var(--space-2); font-size: 2rem; }
+p { text-wrap: pretty; }
+code { padding-inline: var(--space-1); background: var(--ink-800); color: var(--lime-500); font-family: ui-monospace, "Cascadia Code", monospace; font-size: 0.95em; }
+
+.skip-link { position: fixed; z-index: 5; top: calc(var(--space-2) * -16); left: var(--space-4); padding: var(--space-3) var(--space-4); background: var(--lime-500); color: var(--ink-950); font-weight: 700; text-decoration: none; }
+.skip-link:focus { top: var(--space-4); }
+.site-header { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; width: min(calc(100% - var(--space-12)), var(--content)); min-height: 72px; margin-inline: auto; border-bottom: var(--border) solid var(--line-soft); }
+.brand { display: inline-flex; align-items: center; gap: var(--space-2); width: fit-content; min-height: 44px; color: var(--ice-100); font-family: var(--font-display); font-size: 1.5rem; font-weight: 600; letter-spacing: 0.045em; text-decoration: none; }
+.brand b { color: var(--lime-500); font-weight: 600; }
+.brand-mark { width: var(--space-8); height: var(--space-8); fill: var(--copper-400); }
+nav { display: flex; align-items: center; gap: var(--space-6); }
+nav a, .header-link { min-height: 44px; display: inline-flex; align-items: center; color: var(--ice-300); font-size: 1rem; font-weight: 600; text-decoration: none; }
+.header-link { justify-self: end; }
+
+.hero, .statement, .lane-section, .capabilities, .boundary-section, .start-section { width: min(calc(100% - var(--space-12)), var(--content)); margin-inline: auto; }
+.hero { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr); align-items: center; gap: var(--space-16); min-height: calc(100dvh - 72px); padding-block: var(--space-16); }
+.hero-copy { max-width: 680px; }
+.overline { margin-bottom: var(--space-3); color: var(--copper-400); font-family: var(--font-display); font-size: 1rem; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; }
+.hero-lede { max-width: 53ch; margin-bottom: var(--space-8); color: var(--ice-300); font-size: 1.25rem; }
+.hero-actions, .start-actions { display: flex; flex-wrap: wrap; gap: var(--space-3); }
+.button { display: inline-flex; align-items: center; justify-content: center; gap: var(--space-2); min-height: 48px; padding: var(--space-3) var(--space-4); border: var(--border) solid transparent; font-family: var(--font-body); font-size: 1rem; font-weight: 700; line-height: 1; text-align: center; text-decoration: none; transition: transform var(--speed-fast) var(--ease-out), color var(--speed-fast) var(--ease-out), background-color var(--speed-fast) var(--ease-out), border-color var(--speed-fast) var(--ease-out); }
+.button:hover { transform: translateY(calc(var(--space-1) * -0.5)); }
+.button:active { transform: translateY(calc(var(--space-1) * 0.5)); }
+.button-primary { background: var(--lime-500); color: var(--ink-950); }
+.button-primary:hover { background: var(--ice-100); color: var(--ink-950); }
+.button-quiet { border-color: var(--line); color: var(--ice-100); }
+.button-quiet:hover { border-color: var(--lime-500); color: var(--lime-500); }
+.button-copper { background: var(--copper-400); color: var(--ink-950); }
+.button-copper:hover { background: var(--ice-100); color: var(--ink-950); }
+
+.hero-plate { position: relative; min-height: 408px; padding: var(--space-12); overflow: hidden; border-top: var(--border) solid var(--line); border-bottom: var(--border) solid var(--line); background: var(--ink-900); }
+.plate-line { position: absolute; left: var(--space-8); right: var(--space-8); height: var(--border); background: var(--line-soft); }
+.plate-line-top { top: var(--space-8); }
+.plate-line-bottom { bottom: var(--space-8); }
+.plate-label { margin: 0; color: var(--slate-500); font-family: var(--font-display); font-size: 1rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; }
+.operator-symbol { display: flex; align-items: end; gap: var(--space-2); height: var(--space-16); margin-top: var(--space-4); }
+.operator-symbol span { display: block; width: var(--space-3); background: var(--lime-500); }
+.operator-symbol span:nth-child(1) { height: var(--space-4); }
+.operator-symbol span:nth-child(2) { height: var(--space-8); }
+.operator-symbol span:nth-child(3) { height: var(--space-12); background: var(--copper-400); }
+.plate-state { margin-top: var(--space-3); margin-bottom: var(--space-8); font-family: var(--font-display); font-size: 2rem; font-weight: 600; }
+.plate-divider { height: var(--border); background: var(--copper-500); }
+.plate-label-lower { margin-top: var(--space-8); }
+.executor-symbol { display: grid; grid-template-columns: repeat(4, var(--space-4)); gap: var(--space-2); margin-top: var(--space-4); }
+.executor-symbol i { display: block; aspect-ratio: 1; border: var(--border) solid var(--ice-300); }
+.executor-symbol i:nth-child(1), .executor-symbol i:nth-child(4) { background: var(--copper-400); border-color: var(--copper-400); }
+.plate-state-lower { margin-bottom: 0; }
+
+.statement { padding-block: var(--space-24); border-top: var(--border) solid var(--line-soft); }
+.statement-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, 0.72fr); gap: var(--space-16); align-items: start; }
+.statement-grid h2 { margin-bottom: 0; }
+.statement-grid p { margin: 0; color: var(--ice-300); }
+
+.lane-section { padding-block: var(--space-24); border-top: var(--border) solid var(--line-soft); }
+.section-heading { display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, 0.72fr); column-gap: var(--space-16); margin-bottom: var(--space-12); }
+.section-heading .overline, .section-heading h2 { grid-column: 1; }
+.section-heading p:last-child { grid-column: 2; grid-row: 1; align-self: end; margin-bottom: var(--space-6); color: var(--ice-300); }
+.operation-lane { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: var(--space-2); margin: 0 0 var(--space-8); padding: 0; list-style: none; }
+.lane-node { position: relative; min-height: 240px; padding: var(--space-6) var(--space-4); border-top: var(--space-1) solid var(--line); border-bottom: var(--border) solid var(--line); background: var(--ink-900); }
+.lane-node:not(:last-child)::after { position: absolute; z-index: 1; top: var(--space-8); right: calc(var(--space-2) * -1); width: var(--space-2); height: var(--space-1); background: var(--copper-400); content: ""; }
+.lane-node::before { position: absolute; top: var(--space-6); right: var(--space-4); width: var(--space-3); height: var(--space-3); border: var(--border) solid var(--line); content: ""; }
+.lane-node.client::before, .lane-node.executor::before { background: var(--lime-500); border-color: var(--lime-500); }
+.lane-node.runner { border-top-color: var(--copper-400); }
+.lane-index, .capability-number { display: block; margin-bottom: var(--space-12); color: var(--copper-400); font-family: var(--font-display); font-size: 1.25rem; font-weight: 600; letter-spacing: 0.08em; }
+.lane-node p { margin-bottom: 0; color: var(--ice-300); font-size: 1rem; line-height: 1.5; }
+.text-link { display: inline-flex; align-items: center; min-height: 44px; color: var(--ice-100); font-weight: 700; }
+
+.capabilities { display: grid; grid-template-columns: minmax(0, 0.75fr) minmax(0, 1.25fr); gap: var(--space-16); padding-block: var(--space-24); border-top: var(--border) solid var(--line-soft); }
+.capability-list { border-top: var(--border) solid var(--line); }
+.capability-list article { display: grid; grid-template-columns: var(--space-12) minmax(0, 1fr); column-gap: var(--space-4); padding-block: var(--space-6); border-bottom: var(--border) solid var(--line); }
+.capability-list .capability-number { grid-row: 1 / span 2; margin: 0; }
+.capability-list h3 { margin-bottom: var(--space-2); }
+.capability-list p { margin: 0; color: var(--ice-300); }
+
+.boundary-section { display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(280px, 1.1fr); gap: var(--space-16); padding-block: var(--space-24); border-top: var(--border) solid var(--line-soft); }
+.boundary-copy p:not(.overline) { max-width: 49ch; margin-bottom: var(--space-8); color: var(--ice-300); }
+.limit-list { margin: 0; border-top: var(--border) solid var(--copper-500); }
+.limit-list div { display: grid; grid-template-columns: minmax(120px, 0.55fr) minmax(0, 1fr); gap: var(--space-4); padding-block: var(--space-4); border-bottom: var(--border) solid var(--line); }
+.limit-list dt { color: var(--copper-400); font-family: var(--font-display); font-size: 1.25rem; font-weight: 600; letter-spacing: 0.04em; }
+.limit-list dd { margin: 0; color: var(--ice-300); }
+.limit-list strong { color: var(--lime-500); font-weight: 700; }
+
+.start-section { display: grid; grid-template-columns: minmax(0, 0.75fr) minmax(280px, 1.25fr); gap: var(--space-16); padding-block: var(--space-24); border-top: var(--border) solid var(--line-soft); }
+.start-section h2 { margin-bottom: 0; }
+.start-content p { max-width: 57ch; color: var(--ice-300); }
+.site-footer { display: flex; justify-content: space-between; gap: var(--space-6); width: min(calc(100% - var(--space-12)), var(--content)); margin-inline: auto; padding-block: var(--space-8); border-top: var(--border) solid var(--line-soft); color: var(--slate-500); font-size: 1rem; }
+.site-footer p { margin: 0; }
+.site-footer div { display: flex; flex-wrap: wrap; gap: var(--space-6); }
+
+@media (max-width: 900px) {
+  .site-header { grid-template-columns: 1fr auto; }
+  nav { display: none; }
+  .hero, .statement-grid, .capabilities, .boundary-section, .start-section { grid-template-columns: 1fr; }
+  .hero { gap: var(--space-12); min-height: auto; padding-block: var(--space-24); }
+  .hero-plate { max-width: 600px; }
+  .section-heading { grid-template-columns: 1fr; }
+  .section-heading p:last-child { grid-column: 1; grid-row: auto; margin-bottom: 0; }
+  .operation-lane { grid-template-columns: repeat(5, minmax(160px, 1fr)); overflow-x: auto; padding-bottom: var(--space-2); scrollbar-color: var(--slate-700) var(--ink-950); }
+  .lane-node { min-height: 224px; }
+}
+
+@media (max-width: 600px) {
+  body { font-size: 1rem; }
+  .site-header, .hero, .statement, .lane-section, .capabilities, .boundary-section, .start-section, .site-footer { width: min(calc(100% - var(--space-8)), var(--content)); }
+  .site-header { min-height: 64px; }
+  .header-link { font-size: 0.875rem; }
+  .brand { font-size: 1.25rem; }
+  .brand-mark { width: var(--space-6); height: var(--space-6); }
+  .hero { padding-block: var(--space-16); }
+  h1 { font-size: clamp(3.25rem, 17vw, 4.5rem); }
+  h2 { font-size: clamp(2.75rem, 14vw, 3.5rem); }
+  h3 { font-size: 1.75rem; }
+  .hero-lede { font-size: 1.125rem; }
+  .hero-plate { min-height: 360px; padding: var(--space-8); }
+  .plate-line { left: var(--space-4); right: var(--space-4); }
+  .statement, .lane-section, .capabilities, .boundary-section, .start-section { padding-block: var(--space-16); }
+  .operation-lane { margin-right: calc(var(--space-4) * -1); }
+  .capability-list article { grid-template-columns: var(--space-8) minmax(0, 1fr); }
+  .limit-list div { grid-template-columns: 1fr; gap: var(--space-1); }
+  .site-footer { flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; }
+}


### PR DESCRIPTION
## Summary
- Adds a distinctive, dependency-free static landing page for Cloud Harness MCP.
- Documents and scripts a guarded direct-upload Cloudflare Pages workflow.
- Keeps the existing VPS/MCP hostname and runtime topology unchanged.

## Scope
- Static artifact: `site/`
- Pages documentation and preflight/verification scripts
- No API, runner, Docker, authentication, or VPS behavior changes

## Validation
- `npm run verify`
- `npm run pages:check`
- `npm run pages:links`
- `npm audit --json`
- Browser inspection at desktop and 375px with reduced motion
- Cloudflare production deployment and HTTPS smoke test

## Security
- Page copy states the single-owner, non-hostile-tenant boundary.
- Artifact preflight rejects environment files, credential markers, and oversized files.
- Pages deployment uses the fixed `cloud-harness-mcp` project and validates the expected `cloud-harness-mcp.pages.dev` hostname after upload.

## Cloudflare deployment
- Production deployment completed at https://cloud-harness-mcp.pages.dev.
- The `main` production branch upload and expected-host smoke test succeeded.

## Risk and rollback
- Risk is limited to the static marketing artifact and its direct-upload workflow.
- Rollback uses the documented Pages dashboard procedure to select a prior successful production deployment.

## Linked Issues
Closes #9

## Ship Mode
Official