### PR TITLE
docs(github): add private repository app setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,10 @@ Contents read and write. Production Compose mounts the root-owned host
 directory `/etc/cloud-harness-mcp` read-only at `/run/cloud-harness-secrets`,
 so the maintained container path is
 `/run/cloud-harness-secrets/github-app-private-key.pem`. Prefer the file form
-instead of placing a private key directly in an environment variable.
+instead of placing a private key directly in an environment variable. Follow
+the [private GitHub repository setup guide](docs/github-app-private-repositories.md)
+for App creation, least-privilege permissions, installation, key handling,
+verification, troubleshooting, and rotation.
 
 ### Compose overrides
 
@@ -525,6 +528,7 @@ with operational rationale in the [configuration guide](docs/configuration.md).
 - [System architecture](docs/system-architecture.md)
 - [MCP usage and tool semantics](docs/mcp-api.md)
 - [Configuration](docs/configuration.md)
+- [GitHub App setup for private repositories](docs/github-app-private-repositories.md)
 - [Security model](docs/security-model.md)
 - [Development and testing](docs/development.md)
 - [Operations, backup, rollback, and cleanup](docs/operations.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,10 @@ read and write permission.
 Private repository access is optional. Do not report it as live-verified until
 an owner has supplied valid credentials and completed a sanitized clone and
 transfer leak check. The broker and transfer boundary are described in
-[`mcp-api.md`](mcp-api.md#repository-opening-policy).
+[`mcp-api.md`](mcp-api.md#repository-opening-policy). Follow the
+[GitHub App setup guide](github-app-private-repositories.md) to create the App,
+grant least-privilege repository access, install the key, and verify the
+integration.
 
 ## Compose and logging overrides
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,7 +53,8 @@ before any rerun.
 Review `/etc/cloud-harness-mcp/runtime.env` as root. Do not print or transfer
 its tokens through logs or shell history. Configure the optional GitHub App
 private-key file only if private clone is required; see
-[configuration](configuration.md#optional-private-github-clone).
+[GitHub App setup for private repositories](github-app-private-repositories.md)
+and the [configuration rationale](configuration.md#optional-private-github-clone).
 
 The current bootstrap sudoers rule grants the fixed deploy commands to the
 `dev` account. Verify that this is the intended `VPS_USER`; if not, change the

--- a/docs/github-app-private-repositories.md
+++ b/docs/github-app-private-repositories.md
@@ -1,0 +1,221 @@
+# GitHub App setup for private repositories
+
+Cloud Harness uses a GitHub App only inside the trusted runner to clone, fetch,
+pull, and optionally push private GitHub repositories. The runner exchanges the
+App credentials for a short-lived installation token scoped to the repository
+being operated on. The credential is not placed in the checkout, Git remote,
+executor environment, or MCP result.
+
+This guide covers GitHub.com. It assumes the private, single-owner deployment
+described by the [security model](security-model.md).
+
+## Decide the required access
+
+Before creating the App, list the repositories Cloud Harness must access and
+choose the narrowest permission level:
+
+| Intended operation | Repository permission |
+|---|---|
+| Clone, fetch, and pull | **Contents: Read-only** |
+| Push ordinary repository changes | **Contents: Read and write** |
+| Push changes under `.github/workflows/` | **Contents: Read and write** and **Workflows: Read and write** |
+
+Leave every other repository, organization, and account permission at **No
+access**. GitHub recommends minimum permissions and documents `Contents` as the
+permission for HTTP Git access. `Workflows` is needed only when the App must
+access or edit GitHub Actions workflow files. See GitHub's
+[permission guide](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/choosing-permissions-for-a-github-app).
+
+## 1. Register the GitHub App
+
+Create the App under the account that owns the target repositories, or under
+their organization:
+
+1. Open the personal or organization **Settings** page.
+2. Select **Developer settings** → **GitHub Apps** → **New GitHub App**.
+3. Enter a unique name and a homepage URL. The Cloud Harness repository URL is
+   sufficient when the App has no separate website.
+4. Leave callback and setup URLs empty. Cloud Harness does not use GitHub user
+   authorization.
+5. Clear **Active** under **Webhook**. This integration does not consume
+   webhooks.
+6. Under **Repository permissions**, grant the level selected above and leave
+   all unrelated permissions at **No access**.
+7. Under **Where can this GitHub App be installed?**, select **Only on this
+   account** for an owner-operated private App.
+8. Select **Create GitHub App**.
+
+GitHub's current UI and field descriptions are documented in
+[Registering a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app).
+
+## 2. Install it on selected repositories
+
+From the new App's settings page:
+
+1. Select **Install App** in the sidebar.
+2. Select **Install** next to the user or organization that owns the target
+   repositories.
+3. Choose **Only select repositories**.
+4. Select only the private repositories Cloud Harness needs, then finish the
+   installation.
+
+Use **All repositories** only when that broader and future access is an
+explicit owner decision. GitHub documents this flow in
+[Installing your own GitHub App](https://docs.github.com/en/apps/using-github-apps/installing-your-own-github-app).
+
+## 3. Collect the App ID, installation ID, and private key
+
+Cloud Harness requires three values together:
+
+- **App ID**: copy the numeric **App ID** from the App settings page. Do not use
+  the Client ID.
+- **Installation ID**: from **Install App**, open **Configure** for the installed
+  account. The numeric final segment of the installation settings URL is the
+  installation ID. GitHub also exposes it as `id` from authenticated App
+  endpoints such as `GET /repos/{owner}/{repo}/installation`; see the
+  [GitHub Apps REST reference](https://docs.github.com/en/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app).
+- **Private key**: under **Private keys**, select **Generate a private key** and
+  save the downloaded PEM file securely. GitHub retains only the public half,
+  so the downloaded file cannot be recovered later.
+
+Private keys do not expire automatically. Protect, rotate, and revoke them as
+long-lived secrets. GitHub's [private-key guidance](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps)
+recommends a key vault or protected file instead of hardcoding the key.
+
+## 4. Configure a production deployment
+
+Production Compose mounts `/etc/cloud-harness-mcp` read-only into the runner at
+`/run/cloud-harness-secrets`. Install the PEM on the host without printing it:
+
+```bash
+sudo install -d -m 700 -o root -g root /etc/cloud-harness-mcp
+sudo test ! -e /etc/cloud-harness-mcp/github-app-private-key.pem && \
+sudo install -m 600 -o root -g root \
+  /absolute/path/to/downloaded-github-app-key.pem \
+  /etc/cloud-harness-mcp/github-app-private-key.pem
+```
+
+The `test` command intentionally stops a first-install procedure rather than
+overwriting an existing active key. If the destination already exists, follow
+[Rotate or revoke a key](#rotate-or-revoke-a-key) and install the replacement
+under a new filename. Then edit the root-owned runtime file with
+`sudoedit /etc/cloud-harness-mcp/runtime.env` and add:
+
+```dotenv
+GITHUB_APP_ID=123456
+GITHUB_APP_INSTALLATION_ID=78901234
+GITHUB_APP_PRIVATE_KEY_FILE=/run/cloud-harness-secrets/github-app-private-key.pem
+```
+
+Replace both example IDs. The private-key path is the **runner container path**,
+not the host path. Do not paste the PEM contents into the runtime file. The
+supported `GITHUB_APP_PRIVATE_KEY` fallback is less safe and should be used only
+when a file mount is unavailable. When both forms are present, the `_FILE`
+value wins.
+
+All three values must resolve successfully. If an ID or both key forms are
+absent, the runner treats GitHub App access as disabled. If `_FILE` is set but
+the target cannot be read, the runner fails during startup instead. Restart
+through the maintained [deployment workflow](deployment.md#deploy-a-release)
+so the runner reloads the configuration. Validate Compose without rendering
+secrets to the terminal:
+
+```bash
+sudo docker compose \
+  -f compose.yaml \
+  -f compose.production.yaml \
+  config --quiet
+```
+
+Do not paste `docker compose config` output into logs or support requests; it
+may contain resolved environment values.
+
+## Local Compose testing
+
+For a local test, keep the PEM outside the repository and mount it only into
+the runner. Create a private Compose override outside the checkout, for
+example `/absolute/private/path/compose.github-app.yaml`:
+
+```yaml
+services:
+  runner:
+    volumes:
+      - /absolute/private/path/github-app-private-key.pem:/run/cloud-harness-secrets/github-app-private-key.pem:ro
+```
+
+Protect the host file with `chmod 600`, set the same three environment values
+in the ignored local runtime file, then include the override in Compose calls:
+
+```bash
+docker compose \
+  -f compose.yaml \
+  -f /absolute/private/path/compose.github-app.yaml \
+  up -d runner api ingress
+```
+
+Use the same `-f` arguments when stopping this local stack. Never add the PEM,
+override, or runtime environment file to Git.
+
+## 5. Verify private repository access
+
+Verification is a live GitHub operation. Use a disposable repository or branch
+and a credential-free URL such as `https://github.com/OWNER/REPOSITORY.git`:
+
+1. Call `workspace_open` through an authenticated MCP client.
+2. Confirm `workspace_status`, `files_list`, and `git_fetch` work without a
+   credential appearing in the remote URL, logs, or tool results.
+3. If write access is intended, create a disposable branch and push a harmless
+   commit. Do not test against a protected default branch.
+4. Close the workspace with `workspace_close`.
+
+A successful public-repository test does not prove the App is configured. A
+successful private clone proves read access only; it does not prove push access.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| GitHub App access appears disabled | Confirm both IDs and one key form are present in the runner's runtime environment, then restart the runner. |
+| Runner fails while reading the key | Confirm the environment uses the container path, the production mount exists, and the host PEM is root-owned with mode `600`. |
+| Repository not found or clone returns `404` | Confirm the App is installed on the repository's owning account and that the repository is included in **Only select repositories**. |
+| Token minting returns `UNAVAILABLE` | Recheck App ID versus Client ID, installation ID, PEM/App pairing, key revocation, and runner DNS/egress to `api.github.com`; Git transport also needs `github.com`. |
+| Clone works but push returns `403` | Change `Contents` to **Read and write**, approve the changed installation permission, and check branch/ruleset restrictions. |
+| A push touching `.github/workflows/` fails | Add **Workflows: Read and write** only if modifying workflow files is intended, then approve the updated installation permission. |
+
+The broker deliberately returns a sanitized error instead of GitHub's raw
+credential-bearing response. Use GitHub's installation settings and runner
+health logs for diagnosis; never enable logging that prints tokens or PEM data.
+
+## Rotate or revoke a key
+
+1. Generate a second private key in the GitHub App settings. GitHub does not
+   allow deletion of an App's only private key, so create the replacement
+   before revoking the old key.
+2. Choose a new unique filename and confirm it does not already exist. For
+   example:
+
+   ```bash
+   sudo test ! -e /etc/cloud-harness-mcp/github-app-private-key-20260817T081500Z.pem && \
+   sudo install -m 600 -o root -g root \
+     /absolute/path/to/replacement-github-app-key.pem \
+     /etc/cloud-harness-mcp/github-app-private-key-20260817T081500Z.pem
+   ```
+
+3. Update `GITHUB_APP_PRIVATE_KEY_FILE` to the corresponding runner path,
+   restart the runner, and repeat the private clone and leak check.
+4. Revoke the old key in GitHub only after the replacement succeeds, then
+   remove the exact superseded host file.
+
+For a suspected compromise, generate and activate a replacement immediately.
+If that cannot be done safely, uninstall the App from the affected account to
+contain access before rebuilding the integration. Review the installation's
+repository selection and permissions as part of the incident response.
+
+## Configuration authority
+
+The maintained environment names and production mount are owned by the
+environment template, [`apps/runner/src/config.ts`](../apps/runner/src/config.ts),
+[`packages/contracts/src/config.ts`](../packages/contracts/src/config.ts), and
+[`compose.production.yaml`](../compose.production.yaml). Repository token
+scoping is implemented by
+[`apps/runner/src/github-app-broker.ts`](../apps/runner/src/github-app-broker.ts).

--- a/plans/journals/2026-08-17-document-github-app-private-repository-setup.md
+++ b/plans/journals/2026-08-17-document-github-app-private-repository-setup.md
@@ -1,0 +1,34 @@
+---
+title: Document GitHub App private repository setup
+date: 2026-08-17
+summary: Recorded the official private-repository setup runbook and its runner-only credential boundary.
+---
+
+# Document GitHub App private repository setup
+
+## What happened
+
+- Added a dedicated GitHub App runbook for private repository clone, fetch, pull, and optional push operations, then linked it from the README, configuration guide, and deployment guide.
+- Documented least privilege: `Contents: Read-only` for clone/fetch/pull, `Contents: Read and write` for ordinary pushes, and `Workflows: Read and write` only when pushes must modify `.github/workflows/`.
+- Clarified that Cloud Harness needs the numeric App ID, not the Client ID, plus the installation ID and matching PEM private key.
+
+## Configuration boundary
+
+- Production and local Compose instructions keep the PEM outside the repository and mount it read-only into the runner only. The runtime uses the runner-container file path; the API and executor do not receive the GitHub App credential.
+- The privacy hook approval was obtained before referencing the maintained environment template as configuration authority. No environment values, PEM data, tokens, or private repository URLs were copied into the documentation or this journal.
+
+## Verification and operations
+
+- Added sanitized verification guidance for private clone/fetch and optional disposable-branch push, with explicit distinctions between public access, private read access, and write access.
+- Added troubleshooting for disabled configuration, unreadable keys, installation selection, App ID versus Client ID, installation ID, permission failures, and workflow-file pushes.
+- Added a two-key rotation path: install and verify the replacement before revoking the old key, with immediate revocation guidance for suspected compromise.
+
+## Release decision
+
+The repository uses semantic-release, so no manual version or changelog bump was made for this documentation ship. Release metadata remains owned by the automated release workflow.
+
+## Follow-up
+
+AgentWiki publish skipped; this local entry is the chronological source of truth for the session only. Current behavior and operating guidance remain owned by the linked repository docs, schemas, Compose files, and runner code.
+
+> Historical work record — not durable authority. Prefer docs/specs/ADRs for current decisions.


### PR DESCRIPTION
## End-to-end work summary
Added a dedicated operator runbook for creating and installing a least-privilege GitHub App, configuring runner-only credentials for private repositories, verifying access, troubleshooting failures, and rotating keys safely. Linked the guide from the README, configuration guide, and deployment guide. Merged the latest `origin/main`, ran post-merge verification, completed a two-pass pre-landing review, fixed the destructive key-overwrite finding, and re-ran the final gates.

## Subagent delegation
- Count: 4
- tester: ran final post-merge link, lint, typecheck, test, and build gates — DONE — 55/55 links and 43/43 tests passed.
- code-reviewer: reviewed security, secret handling, auth boundaries, GitHub accuracy, and command safety — DONE — key rotation blocker fixed; no remaining findings.
- journal-writer: recorded the chronological ship entry — DONE — no secrets or private repository URLs included.
- docs-manager: checked evergreen documentation ownership and navigation — DONE — no additional docs changes required.

## Technical decisions
- Keep GitHub App credentials runner-only and prefer a read-only PEM mount over a multiline environment value.
- Grant `Contents` at the minimum required level and add `Workflows` only when pushes must modify `.github/workflows/`.
- Guard first-install and rotation key writes with chained nonexistence checks, use distinct rotation filenames, and revoke the old key only after replacement verification.
- Leave version and changelog updates to the repository's semantic-release workflow; this documentation commit does not trigger a package release.

## Deviations from plan
No active plan was associated with this branch. `ak plan resolve` returned unrelated project plans, so no plan state was changed.

## Completion evidence
- Acceptance: operators can create the App, obtain IDs/key, configure production or local Compose, verify private access, troubleshoot, and rotate/revoke keys → `docs/github-app-private-repositories.md`.
- Tests: Node v24.19.0 `npm run verify` passed all 5 stages; Vitest passed 17/17 files and 43/43 tests.
- Links: 55/55 local Markdown links passed; `git diff --check` passed.
- Review: final two-pass review found no remaining critical or informational blockers; `npm run verify:compose` passed.
- CI: pending at PR creation.
- UI screenshots: N/A (non-UI documentation change).
- Changes: 5 files changed, 266 insertions, 3 deletions.

## Checklist
- [x] Add complete GitHub App setup and environment-variable runbook.
- [x] Add README, configuration, and deployment navigation.
- [x] Protect key install and rotation commands from overwrite.
- [x] Run post-merge tests and pre-landing review.
- [ ] Live private repository verification — reason: owner GitHub App credentials were intentionally not supplied or accessed.

## Human actions required
None for merge. A production operator must perform the documented credential setup and sanitized live private-clone check before claiming private access is operational.

## Linked Issues
- Relates to #22 — P2: Create a cloudharness skill for expert Cloud Harness MCP workflows

## Ship Mode
- Mode: official
- Target: main
- Writing language: en (source: default; fallback: resolver unavailable)