### PR TITLE
fix(auth): materialize owner bearer principal

### DIFF
--- a/apps/runner/src/principal-store.ts
+++ b/apps/runner/src/principal-store.ts
@@ -47,6 +47,8 @@ type PrincipalRelinkRow = {
   principal_id: string;
 };
 
+const ownerBearerIssuer = 'https://owner-bearer.invalid';
+
 const fromRow = (row: PrincipalRow): PrincipalRecord => ({
   id: row.id,
   issuer: row.issuer,
@@ -171,6 +173,25 @@ export function principalByLegacyOwnerId(database: DatabaseSync, legacyOwnerId: 
   return row ? fromRow(row) : undefined;
 }
 
+export function resolveOwnerPrincipal(database: DatabaseSync, ownerId: string): string {
+  if (!ownerId || ownerId.length > 100) throw new Error('invalid owner identity');
+  return transaction(database, () => {
+    if (database.prepare('SELECT 1 FROM principals WHERE id = ?').get(ownerId)) return ownerId;
+    const existing = principalByLegacyOwnerId(database, ownerId);
+    if (existing) return existing.id;
+
+    const principalId = `prn_${randomBytes(24).toString('base64url')}`;
+    const now = Date.now();
+    database.prepare(`INSERT INTO principals
+      (id, issuer, subject, email, name, legacy_owner_id, created_at, updated_at)
+      VALUES (?, ?, ?, NULL, NULL, ?, ?, ?)`).run(
+      principalId, ownerBearerIssuer, ownerId, ownerId, now, now
+    );
+    database.prepare('UPDATE workspaces SET owner_id = ? WHERE owner_id = ?').run(principalId, ownerId);
+    return principalId;
+  });
+}
+
 export function resolveExternalPrincipal(
   database: DatabaseSync,
   selector: ExternalPrincipalSelector,
@@ -203,6 +224,21 @@ function resolveExternalPrincipalInTransaction(
       database.prepare('UPDATE workspaces SET owner_id = ? WHERE owner_id = ?').run(existing.id, legacyOwnerId);
     }
     return existing.id;
+  }
+
+  if (legacyOwnerId) {
+    const legacy = principalByLegacyOwnerId(database, legacyOwnerId);
+    if (legacy) {
+      if (legacy.issuer !== ownerBearerIssuer || legacy.subject !== legacyOwnerId) {
+        throw new Error('legacy owner is already mapped to a different external identity');
+      }
+      database.prepare(`UPDATE principals
+        SET issuer = ?, subject = ?, email = ?, name = ?, updated_at = ?
+        WHERE id = ?`).run(
+        selector.issuer, selector.subject, selector.email ?? null, selector.name ?? null, now, legacy.id
+      );
+      return legacy.id;
+    }
   }
 
   const principalId = `prn_${randomBytes(24).toString('base64url')}`;

--- a/apps/runner/src/state-store.ts
+++ b/apps/runner/src/state-store.ts
@@ -8,8 +8,8 @@ import {
   applyPrincipalRelinks,
   migratePrincipalSchema,
   principalByExternalIdentity,
-  principalByLegacyOwnerId,
   resolveExternalPrincipal,
+  resolveOwnerPrincipal,
   type ExternalPrincipalSelector,
   type PrincipalRecord,
   type PrincipalRelinkMapping,
@@ -108,7 +108,7 @@ export class StateStore {
   resolvePrincipal(selector: PrincipalSelector): string {
     const parsed = RunnerPrincipalSelectorSchema.parse(selector);
     if (parsed.kind === 'owner') {
-      return principalByLegacyOwnerId(this.database, parsed.ownerId)?.id ?? parsed.ownerId;
+      return resolveOwnerPrincipal(this.database, parsed.ownerId);
     }
     return this.resolveExternalPrincipal(parsed);
   }

--- a/apps/runner/test/state-store.test.ts
+++ b/apps/runner/test/state-store.test.ts
@@ -121,6 +121,25 @@ describe('StateStore', () => {
     store.close();
   });
 
+  it('materializes owner-bearer identity and preserves it through an explicit Access cutover', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-owner-principal-'));
+    temporaryDirectories.push(directory);
+    const store = new StateStore(join(directory, 'state.db'));
+    const workspace = record();
+    store.create(workspace);
+
+    const ownerPrincipal = store.resolvePrincipal({ kind: 'owner', ownerId: 'owner' });
+    expect(ownerPrincipal).toMatch(/^prn_[A-Za-z0-9_-]{32}$/);
+    expect(store.resolvePrincipal({ kind: 'owner', ownerId: ownerPrincipal })).toBe(ownerPrincipal);
+    expect(store.byOwnerAndId(ownerPrincipal, workspace.id)?.id).toBe(workspace.id);
+
+    const access = { kind: 'external' as const, issuer: 'https://access.example.com', subject: 'subject-123' };
+    expect(store.resolveExternalPrincipal(access, { legacyOwnerId: 'owner' })).toBe(ownerPrincipal);
+    expect(store.resolvePrincipal({ kind: 'owner', ownerId: 'owner' })).toBe(ownerPrincipal);
+    expect(store.principalByExternalIdentity(access)?.id).toBe(ownerPrincipal);
+    store.close();
+  });
+
   it('rolls back a legacy claim that would merge two active workspaces', () => {
     const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-'));
     temporaryDirectories.push(directory);

--- a/apps/runner/test/workspace-audit.test.ts
+++ b/apps/runner/test/workspace-audit.test.ts
@@ -81,6 +81,24 @@ const mutations: Array<[RunnerOperation, Record<string, unknown>]> = [
 ];
 
 describe('workspace mutation audit', () => {
+  it('records owner-bearer mutations against a durable principal', async () => {
+    const { metadata, record, service, store } = fixture('o');
+    const legacyOwner = 'owner-bearer-canary';
+    const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: legacyOwner });
+    store.database.prepare('UPDATE workspaces SET owner_id = ? WHERE id = ?').run(ownerId, record.id);
+    try {
+      await expect(service.execute(legacyOwner, 'files_write', {
+        workspaceId: record.id, path: 'deploy-canary.txt', content: 'canary-ok'
+      })).resolves.toMatchObject({ ok: true });
+      expect(metadata.listAudit(ownerId, 100).map((event) => event.action)).toEqual([
+        'workspace.file_mutation.succeeded', 'workspace.file_mutation.requested'
+      ]);
+    } finally {
+      metadata.close();
+      store.close();
+    }
+  });
+
   it('audits every file mutation without persisting paths or content', async () => {
     const { metadata, ownerId, record, service, store } = fixture();
     try {

--- a/test/e2e/coding-workflow.docker.test.ts
+++ b/test/e2e/coding-workflow.docker.test.ts
@@ -63,7 +63,7 @@ beforeAll(async () => {
 }, 30_000);
 
 afterAll(async () => {
-  if (workspaceId) await service.close('owner', workspaceId).catch(() => undefined);
+  if (workspaceId) await service.execute('owner', 'workspace_close', { workspaceId }).catch(() => undefined);
   await client.close().catch(() => undefined);
   await apiRuntime.close();
   await service.stop();

--- a/test/integration/docker-sandbox.docker.test.ts
+++ b/test/integration/docker-sandbox.docker.test.ts
@@ -30,7 +30,7 @@ beforeAll(async () => {
 }, 20_000);
 
 afterAll(async () => {
-  if (workspaceId) await service.close('owner', workspaceId).catch(() => undefined);
+  if (workspaceId) await service.execute('owner', 'workspace_close', { workspaceId }).catch(() => undefined);
   if (orphanContainer) await removeContainer(orphanContainer).catch(() => undefined);
   if (foreignOrphanContainer) await removeContainer(foreignOrphanContainer).catch(() => undefined);
   await service.stop();
@@ -155,7 +155,7 @@ describe('real Docker sandbox', () => {
     expect(store.byId(workspaceId)?.status).toBe('ACTIVE');
     expect(existsSync(cancellableRecord.workspacePath)).toBe(true);
     expect(JSON.stringify((await service.execute('owner', 'files_list', { workspaceId, path: '.', limit: 100 })).data)).not.toContain('aborted-command.txt');
-    await service.close('owner', workspaceId);
+    await service.execute('owner', 'workspace_close', { workspaceId });
     workspaceId = undefined;
   }, 120_000);
 });


### PR DESCRIPTION
## Outcome

Restores the production owner-bearer path after the v0.6.0 principal/audit rollout while preserving the explicit Cloudflare Access migration boundary.

Relates to #13 and #18.

## Production failure and root cause

The first post-merge production canary opened a workspace, then `files_write` failed with `FOREIGN KEY constraint failed`. Rollback restored the prior release and the live service remained healthy on release `c3fc0f6e4aecf7769916a578833cce547cd1f03d`.

`StateStore.resolvePrincipal({ kind: "owner" })` returned the raw legacy owner ID when no principal row existed. The new audit records reference `principals`, so the first owner-bearer mutation could not insert its audit event.

## Fix

- atomically materialize a reserved synthetic principal for legacy owner-bearer deployments
- remap legacy workspaces to the durable principal ID
- preserve stable existing principal mappings
- permit only the exact reserved synthetic identity to be repurposed by an explicit Access legacy mapping
- fail closed on every other mapping collision

## Verification

- focused principal/state/audit tests: 21 passed
- `npm run verify`: 42 files / 214 tests passed
- `npm run verify:compose`: passed
- typecheck, lint, build, and diff check: passed
- independent security review: GO; no Critical, High, or Medium findings

## Rollout

After merge, deploy in the unchanged owner-bearer mode, verify the production canary, then redeploy the exact same SHA once so the newly installed rollback tooling records the compatible last-known-good configuration snapshot. Cloudflare Access, GitHub SSO, and Google SSO activation remains a separately evidenced provider rollout.
