### PR TITLE
fix(deploy): enable Access JWKS and dashboard routing

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -30,7 +30,7 @@ services:
       - /tmp:rw,nosuid,nodev,noexec,size=32m
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
-    networks: [frontend, control]
+    networks: [frontend, control, api-egress]
     healthcheck:
       test: [CMD, node, -e, "fetch('http://127.0.0.1:3000/healthz').then(r=>{if(!r.ok)process.exit(1)})"]
       interval: 10s
@@ -100,6 +100,8 @@ networks:
   control:
     internal: true
   ingress:
+    driver: bridge
+  api-egress:
     driver: bridge
   runner-egress:
     driver: bridge

--- a/deploy/nginx/cloud-harness-mcp.conf
+++ b/deploy/nginx/cloud-harness-mcp.conf
@@ -29,4 +29,16 @@ server {
         proxy_read_timeout 3600s;
         add_header X-Accel-Buffering no always;
     }
+
+    location = /dashboard {
+        proxy_pass http://127.0.0.1:3100/dashboard;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ^~ /dashboard/ {
+        proxy_pass http://127.0.0.1:3100/dashboard/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }

--- a/deploy/scripts/bootstrap-vps.sh
+++ b/deploy/scripts/bootstrap-vps.sh
@@ -31,13 +31,14 @@ fi
 
 install -m 0755 "$project_root/deploy/scripts/deploy-release.sh" /usr/local/sbin/cloud-harness-deploy
 install -m 0755 "$project_root/deploy/scripts/rollback-release.sh" /usr/local/sbin/cloud-harness-rollback
+install -m 0755 "$project_root/deploy/scripts/upgrade-nginx-dashboard.sh" /usr/local/sbin/cloud-harness-upgrade-nginx
 install -m 0755 "$project_root/deploy/scripts/deploy-ssh-wrapper.sh" /usr/local/sbin/cloud-harness-deploy-ssh
 install -m 0644 "$project_root/deploy/systemd/cloud-harness-mcp.service" /etc/systemd/system/cloud-harness-mcp.service
 install -m 0644 "$project_root/deploy/nginx/cloud-harness-mcp.conf" /etc/nginx/sites-available/cloud-harness-mcp.conf
 ln -sfn /etc/nginx/sites-available/cloud-harness-mcp.conf /etc/nginx/sites-enabled/cloud-harness-mcp.conf
 
 cat > /etc/sudoers.d/cloud-harness-mcp-deploy <<'EOF'
-dev ALL=(root) NOPASSWD: /usr/local/sbin/cloud-harness-deploy [0-9a-f]*, /usr/local/sbin/cloud-harness-rollback
+dev ALL=(root) NOPASSWD: /usr/local/sbin/cloud-harness-deploy [0-9a-f]*, /usr/local/sbin/cloud-harness-rollback, /usr/local/sbin/cloud-harness-upgrade-nginx
 EOF
 chmod 0440 /etc/sudoers.d/cloud-harness-mcp-deploy
 visudo -cf /etc/sudoers.d/cloud-harness-mcp-deploy

--- a/deploy/scripts/deploy-release.sh
+++ b/deploy/scripts/deploy-release.sh
@@ -78,6 +78,7 @@ header = "Accept: application/json, text/event-stream"
 EOF
   compose exec -T api node /app/scripts/deploy-canary.mjs
 elif [[ $auth_mode == cloudflare-access ]]; then
+  deploy/scripts/upgrade-nginx-dashboard.sh
   [[ -f $canary_credentials_file ]] || { echo "$canary_credentials_file is required for Access canary" >&2; false; }
   set -a
   source "$canary_credentials_file"
@@ -102,6 +103,7 @@ if [[ $previous_sha =~ ^[0-9a-f]{40}$ && $previous_sha != "$release_sha" ]]; the
 fi
 install -m 0755 deploy/scripts/deploy-release.sh /usr/local/sbin/cloud-harness-deploy
 install -m 0755 deploy/scripts/rollback-release.sh /usr/local/sbin/cloud-harness-rollback
+install -m 0755 deploy/scripts/upgrade-nginx-dashboard.sh /usr/local/sbin/cloud-harness-upgrade-nginx
 printf '%s\n' "$release_sha" > "$state/release-current"
 trap - ERR
 echo "deployed $release_sha"

--- a/deploy/scripts/upgrade-nginx-dashboard.sh
+++ b/deploy/scripts/upgrade-nginx-dashboard.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  echo "upgrade-nginx-dashboard.sh must run as root" >&2
+  exit 1
+fi
+
+site=/etc/nginx/sites-available/cloud-harness-mcp.conf
+enabled=/etc/nginx/sites-enabled/cloud-harness-mcp.conf
+runtime_config=/etc/cloud-harness-mcp/runtime."env"
+backup_root=/etc/cloud-harness-mcp/nginx-backups
+
+[[ -f $site && -f $runtime_config ]] || { echo "Cloud Harness nginx site or runtime configuration is missing" >&2; exit 2; }
+[[ -L $enabled && $(readlink -f "$enabled") == "$site" ]] || { echo "enabled Cloud Harness nginx site is not the managed target" >&2; exit 3; }
+
+public_hosts=$(awk -F= '$1 == "API_PUBLIC_HOSTS" { print substr($0, index($0, "=") + 1); found++ } END { if (found != 1) exit 1 }' "$runtime_config") || {
+  echo "API_PUBLIC_HOSTS must appear exactly once" >&2
+  exit 4
+}
+IFS=, read -ra configured_hosts <<< "$public_hosts"
+[[ ${#configured_hosts[@]} -gt 0 ]] || { echo "API_PUBLIC_HOSTS must not be empty" >&2; exit 4; }
+for host in "${configured_hosts[@]}"; do
+  [[ $host =~ ^[A-Za-z0-9.-]+$ && $host != *..* && $host != .* && $host != *. ]] || {
+    echo "API_PUBLIC_HOSTS contains an invalid hostname" >&2
+    exit 4
+  }
+done
+
+mapfile -t blocks < <(awk -v configured="$public_hosts" '
+  function brace_count(value, needle, count, pos) {
+    count = 0
+    while ((pos = index(value, needle)) > 0) {
+      count++
+      value = substr(value, pos + 1)
+    }
+    return count
+  }
+  BEGIN {
+    count = split(configured, names, ",")
+    for (cursor = 1; cursor <= count; cursor++) wanted[names[cursor]] = 1
+  }
+  /^[[:space:]]*server[[:space:]]*\{/ && depth == 0 {
+    in_server = 1
+    start = NR
+    matches_host = 0
+    tls = 0
+  }
+  in_server {
+    if ($1 == "server_name") {
+      for (i = 2; i <= NF; i++) {
+        name = $i
+        sub(/;$/, "", name)
+        if (wanted[name]) matches_host = 1
+      }
+    }
+    if ($1 == "ssl_certificate" || ($1 == "listen" && $0 ~ /(^|[[:space:]])443([[:space:];]|$)/)) tls = 1
+    depth += brace_count($0, "{") - brace_count($0, "}")
+    if (depth == 0) {
+      if (matches_host) print start ":" NR ":" tls
+      in_server = 0
+    }
+  }
+' "$site")
+
+selected=
+tls_count=0
+for block in "${blocks[@]}"; do
+  if [[ $block == *:1 ]]; then
+    selected=$block
+    ((tls_count += 1))
+  fi
+done
+if [[ $tls_count -gt 1 || ($tls_count -eq 0 && ${#blocks[@]} -ne 1) ]]; then
+  echo "could not select one unambiguous nginx server block from API_PUBLIC_HOSTS" >&2
+  exit 5
+fi
+if [[ $tls_count -eq 0 ]]; then selected=${blocks[0]:-}; fi
+[[ -n $selected ]] || { echo "nginx server block for API_PUBLIC_HOSTS was not found" >&2; exit 5; }
+
+IFS=: read -r start_line end_line _ <<< "$selected"
+block_file=$(mktemp)
+rendered=$(mktemp)
+trap 'rm -f -- "$block_file" "$rendered"' EXIT
+sed -n "${start_line},${end_line}p" "$site" > "$block_file"
+
+dashboard_entry_count=$(grep -Fxc '    location = /dashboard {' "$block_file" || true)
+dashboard_prefix_count=$(grep -Fxc '    location ^~ /dashboard/ {' "$block_file" || true)
+if [[ $dashboard_entry_count -eq 1 && $dashboard_prefix_count -eq 1 ]] &&
+   grep -Fq 'proxy_pass http://127.0.0.1:3100/dashboard;' "$block_file" &&
+   grep -Fq 'proxy_pass http://127.0.0.1:3100/dashboard/;' "$block_file"; then
+  nginx -t
+  echo "Cloud Harness dashboard nginx routes are already installed"
+  exit 0
+fi
+if [[ $dashboard_entry_count -ne 0 || $dashboard_prefix_count -ne 0 ]] || grep -Fq '127.0.0.1:3100/dashboard' "$block_file"; then
+  echo "existing dashboard nginx routing is not the managed shape; refusing to overwrite it" >&2
+  exit 6
+fi
+
+awk -v closing="$end_line" '
+  NR == closing {
+    print "    location = /dashboard {"
+    print "        proxy_pass http://127.0.0.1:3100/dashboard;"
+    print "        proxy_set_header Host $host;"
+    print "        proxy_set_header X-Forwarded-Proto $scheme;"
+    print "    }"
+    print ""
+    print "    location ^~ /dashboard/ {"
+    print "        proxy_pass http://127.0.0.1:3100/dashboard/;"
+    print "        proxy_set_header Host $host;"
+    print "        proxy_set_header X-Forwarded-Proto $scheme;"
+    print "    }"
+  }
+  { print }
+' "$site" > "$rendered"
+
+install -d -m 0700 "$backup_root"
+backup="$backup_root/cloud-harness-mcp.conf.$(date -u +%Y%m%dT%H%M%SZ)"
+cp -a "$site" "$backup"
+restore() {
+  cp -a "$backup" "$site"
+  nginx -t && systemctl reload nginx || true
+}
+trap 'status=$?; if [[ $status -ne 0 ]]; then restore; fi; rm -f -- "$block_file" "$rendered"; exit "$status"' EXIT
+
+chmod --reference="$site" "$rendered"
+chown --reference="$site" "$rendered"
+cp --preserve=mode,ownership "$rendered" "$site"
+nginx -t
+systemctl reload nginx
+trap 'rm -f -- "$block_file" "$rendered"' EXIT
+echo "installed Cloud Harness dashboard nginx routes; backup: $backup"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -54,6 +54,22 @@ project's dedicated nginx target with the repository's HTTP template, including
 Certbot edits in that file. Back up and deliberately reapply TLS configuration
 before any rerun.
 
+For an existing TLS-enabled installation, the Access-mode release deploy runs
+the dedicated dashboard-route upgrade before its public canary. It can also be
+run idempotently after deploying a release that contains it:
+
+```bash
+sudo /usr/local/sbin/cloud-harness-upgrade-nginx
+```
+
+This command reads the configured `API_PUBLIC_HOSTS` allowlist without sourcing
+the runtime file, selects the unique matching TLS server block, and refuses
+ambiguous or pre-existing nonstandard dashboard routing. It backs up the live
+site under `/etc/cloud-harness-mcp/nginx-backups/`, changes only the two
+`/dashboard` locations, validates with `nginx -t`, and reloads nginx. A failed
+validation or reload restores the exact backup and attempts to reload it. The
+operation is idempotent. Do not use bootstrap for this upgrade.
+
 Review `/etc/cloud-harness-mcp/runtime.env` as root. Do not print or transfer
 its tokens through logs or shell history. Configure the optional GitHub App
 private-key file only if private clone is required; see
@@ -170,6 +186,14 @@ prior recorded release plus the database and artifacts when available, reusing
 the unchanged live configuration; the config/key copy is retained for coherent
 manual recovery. A failed first install is disabled. Active job checkouts are
 not part of the snapshot.
+
+Release deployment installs the fixed `cloud-harness-upgrade-nginx` command.
+In Access mode it invokes the same fail-closed operation before the public
+canary; owner-bearer deployments do not change nginx. If a later manual
+rollback must remove those routes, restore the printed backup path to
+`/etc/nginx/sites-available/cloud-harness-mcp.conf`, run `nginx -t`, and reload
+nginx; normal application rollback can leave the backward-compatible routes in
+place.
 
 Owner-bearer canary uses the private bearer path. Access canary requires an
 owner-provisioned Access service-token client ID/secret and the public HTTPS

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -31,7 +31,10 @@ Untrusted execution input:
 The API is deliberately separated from Docker authority. A credential-free
 TCP proxy is the only Compose service with a loopback-published port. It joins
 the API frontend network but not the API/runner control network, and the API
-itself joins only internal networks. The runner has no
+joins the internal frontend and control networks plus a dedicated egress
+network required to retrieve the configured Cloudflare Access JWKS. JWKS
+fetching remains limited by the verifier's fixed URL, redirect rejection,
+timeouts, response bounds, and key-cache controls. The runner has no
 published port and is the only service with `/var/run/docker.sock`; it uses a
 separate egress network for DNS validation and optional GitHub App calls while
 the API/runner control network remains internal.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -19,7 +19,9 @@ that Access application, not direct API integrations.
 The split is deliberate. The ingress proxy owns no secret or application
 logic; it only bridges host loopback to an internal frontend network. The API owns public HTTP, MCP negotiation, request
 security, and translation to a versioned private runner request. It has no
-published port, external network, Docker socket, or host job mount. The proxy
+published port, Docker socket, or host job mount. It has a dedicated egress
+network so the bounded Access verifier can retrieve the configured JWKS; its
+frontend and runner-control paths remain internal. The proxy
 cannot join the API/runner control network. The runner owns principal
 resolution, workspace lifecycle, SQLite metadata, repository materialization,
 retained artifact snapshots, secret encryption, GitHub App authorization,

--- a/scripts/verify-compose-boundaries.mjs
+++ b/scripts/verify-compose-boundaries.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 const result = spawnSync('docker', [
   'compose', '-f', 'compose.yaml', '-f', 'compose.production.yaml', 'config', '--format', 'json'
@@ -21,11 +22,11 @@ requireBoundary(!services.api.ports?.length, 'API must not publish a host port')
 requireBoundary(!services.runner.ports?.length, 'runner must not publish a host port');
 requireBoundary(!services.api.volumes?.length, 'API must not receive host mounts');
 requireBoundary(!services.ingress.volumes?.length, 'ingress must not receive host mounts');
-requireBoundary(JSON.stringify(networkNames(services.api)) === JSON.stringify(['control', 'frontend']), 'API network boundary changed');
+requireBoundary(JSON.stringify(networkNames(services.api)) === JSON.stringify(['api-egress', 'control', 'frontend']), 'API network boundary changed');
 requireBoundary(JSON.stringify(networkNames(services.runner)) === JSON.stringify(['control', 'runner-egress']), 'runner network boundary changed');
 requireBoundary(JSON.stringify(networkNames(services.ingress)) === JSON.stringify(['frontend', 'ingress']), 'ingress network boundary changed');
 requireBoundary(networks.control.internal === true && networks.frontend.internal === true, 'private networks must remain internal');
-requireBoundary(networks.ingress.internal !== true && networks['runner-egress'].internal !== true, 'gateway networks must remain routable');
+requireBoundary(networks.ingress.internal !== true && networks['api-egress'].internal !== true && networks['runner-egress'].internal !== true, 'gateway networks must remain routable');
 
 const published = services.ingress.ports ?? [];
 requireBoundary(published.length === 1, 'ingress must publish exactly one port');
@@ -43,5 +44,16 @@ for (const service of ['api', 'runner', 'ingress']) {
   for (const name of ['MCP_CANARY_URL', 'MCP_CANARY_ACCESS_CLIENT_ID', 'MCP_CANARY_ACCESS_CLIENT_SECRET']) {
     requireBoundary(!services[service].environment?.[name], `${service} must not receive ${name}`);
   }
+}
+
+const nginx = readFileSync('deploy/nginx/cloud-harness-mcp.conf', 'utf8');
+const locationBlock = (pattern) => nginx.match(pattern)?.[0] ?? '';
+const dashboardEntry = locationBlock(/location = \/dashboard \{[^}]+\}/s);
+const dashboardPrefix = locationBlock(/location \^~ \/dashboard\/ \{[^}]+\}/s);
+const mcp = locationBlock(/location = \/mcp \{[^}]+\}/s);
+requireBoundary(dashboardEntry.includes('proxy_pass http://127.0.0.1:3100/dashboard;'), 'nginx dashboard entry point must preserve its upstream path');
+requireBoundary(dashboardPrefix.includes('proxy_pass http://127.0.0.1:3100/dashboard/;'), 'nginx dashboard prefix must preserve asset and BFF paths');
+for (const directive of ['proxy_http_version 1.1;', 'proxy_buffering off;', 'proxy_request_buffering off;', 'proxy_read_timeout 3600s;']) {
+  requireBoundary(mcp.includes(directive), `nginx MCP streaming directive is missing: ${directive}`);
 }
 console.log('compose-boundaries=pass');


### PR DESCRIPTION
## Summary
- give the API a dedicated routable network for bounded Cloudflare Access JWKS retrieval while preserving private frontend/control boundaries
- proxy `/dashboard` and `/dashboard/*` through the host nginx site
- add a TLS-preserving, backup-and-rollback nginx upgrader invoked by Access deployments
- strengthen Compose/nginx boundary verification and update the deployment/security architecture guidance

## Production failure addressed
The first Access-mode deployment reached local readiness but its public canary returned 401 because the API could not fetch Cloudflare JWKS from internal-only networks. The live host also returned 404 for `/dashboard` because Certbot-managed nginx had no dashboard locations.

## Verification
- `npm run verify` — 42 files / 214 tests passed; lint, typecheck, build passed
- `npm run verify:compose` — passed
- `bash -n deploy/scripts/upgrade-nginx-dashboard.sh deploy/scripts/deploy-release.sh deploy/scripts/bootstrap-vps.sh` — passed
- `git diff --check` — passed
- independent review — GO, no Critical or Important findings

## Rollout
After exact-head CI is green and this PR is merged, deploy the merged SHA. Access-mode deployment will select the unique TLS server block matching `API_PUBLIC_HOSTS`, back it up, add only the dashboard routes, validate nginx, reload, and then run the public Access canary.

Closes the remaining live rollout blocker for #13 and #18; issue closure still requires successful production verification.
