### PR TITLE
fix(deploy): serialize production releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 24.11.0
           cache: npm
       - run: npm ci
-      - run: bash -n worker/clone-helper.sh worker/task-runner.sh worker/shell-runner.sh worker/worker-runner.sh deploy/scripts/bootstrap-vps.sh deploy/scripts/deploy-release.sh deploy/scripts/release-runtime.sh deploy/scripts/rollback-release.sh deploy/scripts/deploy-ssh-wrapper.sh
+      - run: bash -n worker/clone-helper.sh worker/task-runner.sh worker/shell-runner.sh worker/worker-runner.sh deploy/scripts/bootstrap-vps.sh deploy/scripts/deploy-release.sh deploy/scripts/release-runtime.sh deploy/scripts/rollback-release.sh deploy/scripts/deploy-ssh-wrapper.sh deploy/scripts/upgrade-nginx-dashboard.sh
       - run: npm run verify:compose
       - run: npm run verify
 

--- a/deploy/scripts/deploy-release.sh
+++ b/deploy/scripts/deploy-release.sh
@@ -2,10 +2,18 @@
 set -euo pipefail
 umask 077
 
+state=/var/lib/cloud-harness
+install -d -o root -g root -m 0700 "$state"
+deploy_lock="$state/deploy.lock"
+exec 9>"$deploy_lock"
+if ! flock -n 9; then
+  echo "another Cloud Harness deployment is already running" >&2
+  exit 75
+fi
+
 release_sha=${1:-}
 repo=/opt/cloud-harness-mcp/repo
 origin=https://github.com/bestagentkits/cloud-harness-mcp.git
-state=/var/lib/cloud-harness
 install -d -m 0700 "$state/state" "$state/backups"
 install -d -m 0750 "$state/jobs" "$state/artifacts"
 env_file=/etc/cloud-harness-mcp/runtime.env

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -187,6 +187,12 @@ the unchanged live configuration; the config/key copy is retained for coherent
 manual recovery. A failed first install is disabled. Active job checkouts are
 not part of the snapshot.
 
+The deploy command takes a nonblocking host lock before reading or mutating the
+shared checkout, service, snapshots, or release metadata. A concurrent manual
+or automated invocation exits with status 75 and performs no rollback; rerun it
+only after the active deployment finishes. This prevents one release from
+rolling back another release's in-progress state.
+
 Release deployment installs the fixed `cloud-harness-upgrade-nginx` command.
 In Access mode it invokes the same fail-closed operation before the public
 canary; owner-bearer deployments do not change nginx. If a later manual

--- a/test/deploy-release-runtime.test.ts
+++ b/test/deploy-release-runtime.test.ts
@@ -5,6 +5,7 @@ import { spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 
 const runtime = join(process.cwd(), 'deploy/scripts/release-runtime.sh');
+const deployScript = join(process.cwd(), 'deploy/scripts/deploy-release.sh');
 const previousSha = 'a'.repeat(40);
 
 function runRollback(failureStep = 'none') {
@@ -76,6 +77,16 @@ cat "$state/release-config-current/mode"
 }
 
 describe('release rollback orchestration', () => {
+  it('takes a nonblocking host lock before touching the shared deployment checkout', () => {
+    const source = readFileSync(deployScript, 'utf8');
+    const lock = source.indexOf('flock -n 9');
+    expect(source).toContain('install -d -o root -g root -m 0700 "$state"');
+    expect(source).toContain('deploy_lock="$state/deploy.lock"');
+    expect(lock).toBeGreaterThan(source.indexOf('exec 9>"$deploy_lock"'));
+    expect(source.indexOf('exit 75', lock)).toBeGreaterThan(lock);
+    expect(lock).toBeLessThan(source.indexOf('git fetch --force --prune origin main'));
+  });
+
   it('restores and records the coherent runtime configuration snapshot', () => {
     const result = runConfigRestore();
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary
- take a nonblocking root-only host lock before any shared checkout, service, snapshot, or release-state mutation
- make concurrent deploys exit 75 without entering rollback
- cover lock ordering and path invariants in release runtime tests
- include the nginx upgrader in CI shell syntax validation and document contention behavior

## Live failure addressed
A manual deployment and the automatic production workflow overlapped on the same SHA. The second process encountered the shared checkout lock, entered rollback, changed the checkout beneath the successful deploy, and restored an older config snapshot. The service remained healthy, but the race removed canary-only configuration and the dashboard nginx change.

## Verification
- focused deploy runtime: 19/19 passed
- repository verify: 42 files / 215 tests passed; lint, typecheck, build passed
- `npm run verify:compose` passed
- shell syntax and diff check passed
- independent review: GO, no Critical or Important findings
