### PR TITLE
fix(api): make dashboard assets readable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - run: npm ci
       - run: docker compose --profile images build executor-image api runner
       - name: Verify non-root API runtime dependencies
-        run: docker run --rm --entrypoint node cloud-harness-api:local -e "const fs=require('node:fs'); for (const file of ['/app/package.json','/app/apps/api/package.json','/app/packages/contracts/package.json','/app/scripts/deploy-canary.mjs','/app/deploy/ingress-proxy.mjs']) fs.accessSync(file, fs.constants.R_OK); import('@cloud-harness/contracts')"
+        run: docker run --rm --entrypoint node cloud-harness-api:local -e "const fs=require('node:fs'); for (const file of ['/app/package.json','/app/apps/api/package.json','/app/apps/api/dashboard/index.html','/app/packages/contracts/package.json','/app/scripts/deploy-canary.mjs','/app/deploy/ingress-proxy.mjs']) fs.accessSync(file, fs.constants.R_OK); import('@cloud-harness/contracts')"
       - run: npm run test:docker
       - run: npm run test:e2e
       - name: Assert managed-container cleanup

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -19,7 +19,9 @@ COPY --from=build --chmod=0444 /app/package.json /app/package-lock.json ./
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build --chmod=0444 /app/apps/api/package.json ./apps/api/package.json
 COPY --from=build /app/apps/api/dist ./apps/api/dist
-COPY --from=build --chmod=0444 /app/apps/api/dashboard ./apps/api/dashboard
+COPY --from=build /app/apps/api/dashboard ./apps/api/dashboard
+RUN find /app/apps/api/dashboard -type d -exec chmod 0555 {} + \
+  && find /app/apps/api/dashboard -type f -exec chmod 0444 {} +
 COPY --from=build --chmod=0444 /app/packages/contracts/package.json ./packages/contracts/package.json
 COPY --from=build /app/packages/contracts/dist ./packages/contracts/dist
 COPY --chown=node:node --chmod=0555 scripts/deploy-canary.mjs ./scripts/deploy-canary.mjs


### PR DESCRIPTION
## Summary
- preserve execute permission on dashboard directories while keeping static assets read-only
- verify the dashboard entry file from the API image's default non-root user in CI

## Live failure addressed
Cloudflare Access authentication reached the production origin, but `/dashboard` returned 500. The API log showed `EACCES` while statting the dashboard index because recursive `COPY --chmod=0444` removed directory traversal permission.

## Verification
- built `cloud-harness-api:local`
- exact non-root runtime file-access check passed, including dashboard index
- `npm run verify:compose` passed
- focused prior timeout files passed 25/25 after Docker contention cleared
- `npm run verify` passed: 42 files / 215 tests, lint, typecheck, build
- independent review: GO, no Critical or Important findings
