### PR TITLE
docs: record Cloudflare Access production rollout

### DIFF
--- a/.agents/skills/cloudharness/references/installation-and-security.md
+++ b/.agents/skills/cloudharness/references/installation-and-security.md
@@ -41,10 +41,10 @@ separately below.
 
 ## MCP endpoint and bearer
 
-The owner-operated endpoint is:
+An owner-bearer deployment uses an owner-controlled endpoint such as:
 
 ```text
-https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp
+https://<owner-bearer-hostname>/mcp
 ```
 
 Direct clients must send the owner-provided bearer token. Keep it in a local
@@ -63,7 +63,7 @@ Add this to trusted user configuration:
 
 ```toml
 [mcp_servers.cloud_harness]
-url = "https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp"
+url = "https://<owner-bearer-hostname>/mcp"
 bearer_token_env_var = "CLOUD_HARNESS_MCP_TOKEN"
 required = true
 tool_timeout_sec = 300
@@ -77,7 +77,7 @@ Restart Codex and inspect `/mcp` or run `codex mcp list`.
 ```bash
 claude mcp add --transport http --scope user \
   --header "Authorization: Bearer $CLOUD_HARNESS_MCP_TOKEN" \
-  cloud-harness https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp
+  cloud-harness https://<owner-bearer-hostname>/mcp
 ```
 
 Inspect with `claude mcp get cloud-harness`, then confirm it in `/mcp`.
@@ -89,18 +89,19 @@ Inspect with `claude mcp get cloud-harness`, then confirm it in `/mcp`.
 - Claude Code and Codex can use the private bearer-backed endpoint from local
   trusted configuration.
 - A public hosted ChatGPT/Claude connector must use a supported per-user
-  authorization flow. The current deployment is static-bearer, single-owner,
-  and is **not** a public multi-user MCP service. Do not publish the bearer or
-  claim OAuth support.
+  authorization flow. The owner deployment at `https://harness.zuey.me/mcp`
+  uses Cloudflare Access Managed OAuth with allowlisted mutually trusted
+  operators; it is not a hostile multi-tenant service.
 - Marketplace installation and marketplace review/publication are different
   states. Local validation does not prove an approved public listing.
 
 ## Intended trust model
 
-Cloud Harness is for one authenticated, trusted owner operating approved
-repositories. It is not an anonymous service, shared tenant sandbox, or hostile
-multi-tenant boundary. Rootful Docker and a shared kernel remain material trust
-limitations even though the executor is constrained.
+Cloud Harness is for one authenticated owner or named mutually trusted
+operators in one security domain, operating approved repositories. It is not
+an anonymous service, shared tenant sandbox, or hostile multi-tenant boundary.
+Rootful Docker and a shared kernel remain material trust limitations even
+though the executor is constrained.
 
 The trusted control plane owns ingress, authentication, repository validation,
 Docker lifecycle, optional GitHub App brokering, state, and cleanup. Repository

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ worktree, skill, hook, memory, and repository-defined deployment tools.
 The public MCP URL is:
 
 ```text
-https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp
+https://harness.zuey.me/mcp
 ```
 
 ## Architecture
@@ -187,9 +187,9 @@ The OpenAI package contains the portable skill, store metadata, logo, privacy
 policy, and terms. It intentionally does not embed an app registration ID,
 bearer token, or MCP authorization. OpenAI reviews skills-only and MCP-only
 plugins, but a public authenticated remote MCP listing requires a supported
-OAuth flow. This private single-owner deployment still uses an owner bearer
-token, so connect it only through the local Codex configuration below; add an
-OAuth gateway before submitting the hosted MCP server as a public ChatGPT app.
+OAuth flow. The owner deployment uses Cloudflare Access Managed OAuth; the
+package itself still embeds no deployment-specific authorization or app
+registration.
 See OpenAI's [plugin packaging](https://developers.openai.com/plugins/build/plugins),
 [submission](https://developers.openai.com/plugins/deploy/submission), and
 [authentication](https://developers.openai.com/plugins/build/auth) guidance.
@@ -201,16 +201,22 @@ See OpenAI's [plugin packaging](https://developers.openai.com/plugins/build/plug
 This server exposes a remote Streamable HTTP MCP endpoint:
 
 ```text
-https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp
+https://harness.zuey.me/mcp
 ```
 
-`owner-bearer` is the default, and the direct-header examples below use the
-owner-provided `CLOUD_HARNESS_MCP_TOKEN`. Keep it in a local environment
-variable or client-local configuration; never put it in a repository, prompt,
-or shared project configuration.
+The owner deployment uses `cloudflare-access`: Managed OAuth clients connect to
+the URL above and complete GitHub or Google login in the browser. Its dashboard
+is `https://harness.zuey.me/dashboard`.
 
-An operator may instead deploy `cloudflare-access` on an eligible hostname in
-an owned Cloudflare zone. Access provides Managed OAuth and GitHub/Google SSO;
+`owner-bearer` remains the software default for separate private deployments.
+The direct-header examples below use the owner-provided
+`CLOUD_HARNESS_MCP_TOKEN` and the placeholder
+`https://<owner-bearer-hostname>/mcp`. Keep both in client-local private
+configuration; never put the token in a repository, prompt, or shared project
+configuration.
+
+Other operators may deploy `cloudflare-access` on an eligible hostname in an
+owned Cloudflare zone. Access provides Managed OAuth and GitHub/Google SSO;
 Cloud Harness verifies the forwarded assertion and exposes the dashboard at
 `/dashboard`. Treat client login as supported only after the exact client,
 Access policy, discovery, refresh, and revocation flow has been verified live.
@@ -258,7 +264,7 @@ Add this to `~/.codex/config.toml` (or a trusted project's
 
 ```toml
 [mcp_servers.cloud_harness]
-url = "https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp"
+url = "https://<owner-bearer-hostname>/mcp"
 bearer_token_env_var = "CLOUD_HARNESS_MCP_TOKEN"
 required = true
 tool_timeout_sec = 300
@@ -295,7 +301,7 @@ Set the token, then register the server for your user account:
 export CLOUD_HARNESS_MCP_TOKEN="<owner-provided-token>"
 claude mcp add --transport http --scope user \
   --header "Authorization: Bearer $CLOUD_HARNESS_MCP_TOKEN" \
-  cloud-harness https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp
+  cloud-harness https://<owner-bearer-hostname>/mcp
 ```
 
 Use `claude mcp get cloud-harness` to inspect the entry, then `/mcp` in a
@@ -313,7 +319,7 @@ Set the token, then add a remote HTTP MCP server:
 export CLOUD_HARNESS_MCP_TOKEN="<owner-provided-token>"
 gemini mcp add --transport http \
   --header "Authorization: Bearer $CLOUD_HARNESS_MCP_TOKEN" \
-  cloud-harness https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp
+  cloud-harness https://<owner-bearer-hostname>/mcp
 ```
 
 Restart Gemini CLI if it is already running and use its MCP management command
@@ -333,7 +339,7 @@ trusted project only):
 {
   "mcpServers": {
     "cloud-harness": {
-      "url": "https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp",
+      "url": "https://<owner-bearer-hostname>/mcp",
       "headers": {
         "Authorization": "Bearer ${env:CLOUD_HARNESS_MCP_TOKEN}"
       }
@@ -361,7 +367,7 @@ remote server entry:
 {
   "mcpServers": {
     "cloud-harness": {
-      "serverUrl": "https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp",
+      "serverUrl": "https://<owner-bearer-hostname>/mcp",
       "headers": {
         "Authorization": "Bearer <owner-provided-token>"
       }
@@ -393,7 +399,7 @@ this object to a Responses API request's `tools` array:
 ```json
 {
   "type": "mcp",
-  "server_url": "https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp",
+  "server_url": "https://<owner-bearer-hostname>/mcp",
   "server_label": "cloud-harness",
   "authorization": "Bearer <owner-provided-token>"
 }

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -3,11 +3,11 @@
 ## Connection
 
 The Streamable HTTP endpoint is
-`https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp` for the current
-operator deployment. `owner-bearer` is the default authentication contract.
-An opt-in `cloudflare-access` deployment instead requires the client to
-complete the Access Managed OAuth flow through an eligible owner-controlled
-hostname; the origin also verifies the forwarded Access assertion. The
+`https://harness.zuey.me/mcp` for the current operator deployment. That
+deployment requires the client to complete the Cloudflare Access Managed OAuth
+flow through GitHub or Google; the origin verifies the forwarded Access
+assertion. `owner-bearer` remains the default authentication contract for
+separate private deployments. The
 recommended client routes are in the
 [README](../README.md#connect-from-ai-clients). Do not treat implementation or
 configuration as proof that a specific client has completed live OAuth.

--- a/plans/260817-1321-13-cloudflare-oauth-dashboard/phase-04-deployment-verification-and-rollout.md
+++ b/plans/260817-1321-13-cloudflare-oauth-dashboard/phase-04-deployment-verification-and-rollout.md
@@ -1,7 +1,7 @@
 ---
 phase: 4
 title: "Deployment contract, verification, and rollout evidence"
-status: in-progress
+status: completed
 priority: P1
 effort: "1-2d plus operator rollout"
 dependencies: [1, 2, 3]
@@ -40,11 +40,20 @@ Wire optional Access mode without weakening topology, update owning docs, run re
 
 ## Success criteria
 
-- [ ] Repository gates pass and security topology changes only at explicit auth/dashboard surfaces.
+- [x] Repository gates pass and security topology changes only at explicit auth/dashboard surfaces.
 - [x] Docs separate implemented code, merged release, configured Cloudflare resources, and live rollout.
 - [x] Sanitized client/IdP/refresh/revocation/rollback checklist exists.
 - [x] No production/Access claim lacks current owner-authorized evidence.
 
 ## Risk and rollback
 
-Current `sslip.io` may be ineligible. Code ships disabled by default until an eligible hostname exists. Rollback follows the tested compatibility matrix; never restore an old DB snapshot while leaving newer jobs/artifacts live. Client incompatibility triggers a separate Managed OAuth vs Workers OAuth Provider decision; never add a second issuer silently.
+The owned-zone hostname resolves the earlier `sslip.io` eligibility risk. Code remains disabled by default for other deployments until an eligible hostname exists. Rollback follows the tested compatibility matrix; never restore an old DB snapshot while leaving newer jobs/artifacts live. Client incompatibility triggers a separate Managed OAuth vs Workers OAuth Provider decision; never add a second issuer silently.
+
+## Production rollout receipt
+
+- `harness.zuey.me` is protected by one Cloudflare Access self-hosted application with GitHub and Google IdPs and Managed OAuth enabled.
+- GitHub SSO and Google SSO both reach `/dashboard`; the pinned Google identity resolves the legacy principal and its existing workspaces.
+- `/dashboard/projects`, `/dashboard/artifacts`, `/dashboard/audit`, and `/dashboard/github` render through the authenticated BFF.
+- The protected-resource and authorization-server discovery documents return JSON from the public edge.
+- CI run `32112530628` and production run `32112756728` passed at merge SHA `06946e8e595a23e9a78e1a73055e43d12391ecab`.
+- The VPS records that exact release, all three long-lived services are healthy, and the root-owned runtime and canary files remain mode `0600`.

--- a/plans/260817-1321-13-cloudflare-oauth-dashboard/plan.md
+++ b/plans/260817-1321-13-cloudflare-oauth-dashboard/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Cloudflare OAuth principal model and dashboard"
 description: "Opt-in Cloudflare Access Managed OAuth with GitHub/Google SSO and a principal-scoped dashboard."
-status: in-progress
+status: completed
 priority: P1
 effort: "8-12d"
 issue: 13
@@ -36,7 +36,7 @@ Close #13 and #18 in one security-first delivery. Cloudflare Access Managed OAut
 | 1 | [Principal authentication and authorization core](./phase-01-principal-authentication-and-authorization-core.md) | — | Completed |
 | 2 | [Dashboard BFF and accessible workspace UI](./phase-02-dashboard-bff-and-workspace-ui.md) | 1 | Completed |
 | 3 | [Environment, secret, GitHub, artifact, and audit controls](./phase-03-environment-secret-github-artifact-audit.md) | 1, 2 | Completed |
-| 4 | [Deployment contract, verification, and rollout evidence](./phase-04-deployment-verification-and-rollout.md) | 1, 2, 3 | In progress |
+| 4 | [Deployment contract, verification, and rollout evidence](./phase-04-deployment-verification-and-rollout.md) | 1, 2, 3 | Completed |
 
 ## Acceptance criteria
 
@@ -45,8 +45,8 @@ Close #13 and #18 in one security-first delivery. Cloudflare Access Managed OAut
 - [x] Dashboard same-origin BFF reuses bounded runner operations and exposes no privileged terminal or second executor path.
 - [x] Browser responses/storage contain no MCP/runner token, Access assertion, raw secret, GitHub App credential, or provider token.
 - [x] Mutations require CSRF protection, optimistic concurrency, audit events, and accessible confirmation/error states.
-- [ ] GitHub/Google use Access-normalized `(issuer, subject)` identity; same-email IdP logins may converge, email is display-only, and changed subjects require an audited operator relink.
-- [ ] Focused tests, `npm run verify`, and applicable Compose/Docker gates pass.
+- [x] GitHub/Google use Access-normalized `(issuer, subject)` identity; email is display-only, and changed subjects require an audited operator relink.
+- [x] Focused tests, `npm run verify`, and applicable Compose/Docker gates pass.
 
 ## Existing-plan relationship
 
@@ -108,7 +108,7 @@ Executes the identity slice of `plans/260817-0848-2-cloud-harness-next-steps/pha
 
 - Independent re-review: `reports/code-review-phase3-remediation.md` — GO.
 - Focused remediation receipt: 42 tests passed; workspace typecheck passed.
-- Live Access, IdP, client, deployment, and production evidence remains Phase 4 owner work.
+- Live rollout completed on `harness.zuey.me`: GitHub and Google SSO reach the principal-scoped dashboard, Google resolves the pinned legacy principal, Managed OAuth discovery is live, the public service-token canary passes, and production runs the exact merge SHA verified by CI.
 
 ### Whole-Plan Consistency Sweep
 

--- a/plugins/cloud-harness/skills/cloudharness/references/installation-and-security.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/installation-and-security.md
@@ -41,10 +41,10 @@ separately below.
 
 ## MCP endpoint and bearer
 
-The owner-operated endpoint is:
+An owner-bearer deployment uses an owner-controlled endpoint such as:
 
 ```text
-https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp
+https://<owner-bearer-hostname>/mcp
 ```
 
 Direct clients must send the owner-provided bearer token. Keep it in a local
@@ -63,7 +63,7 @@ Add this to trusted user configuration:
 
 ```toml
 [mcp_servers.cloud_harness]
-url = "https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp"
+url = "https://<owner-bearer-hostname>/mcp"
 bearer_token_env_var = "CLOUD_HARNESS_MCP_TOKEN"
 required = true
 tool_timeout_sec = 300
@@ -77,7 +77,7 @@ Restart Codex and inspect `/mcp` or run `codex mcp list`.
 ```bash
 claude mcp add --transport http --scope user \
   --header "Authorization: Bearer $CLOUD_HARNESS_MCP_TOKEN" \
-  cloud-harness https://cloud-harness-mcp.46-250-239-227.sslip.io/mcp
+  cloud-harness https://<owner-bearer-hostname>/mcp
 ```
 
 Inspect with `claude mcp get cloud-harness`, then confirm it in `/mcp`.
@@ -89,18 +89,19 @@ Inspect with `claude mcp get cloud-harness`, then confirm it in `/mcp`.
 - Claude Code and Codex can use the private bearer-backed endpoint from local
   trusted configuration.
 - A public hosted ChatGPT/Claude connector must use a supported per-user
-  authorization flow. The current deployment is static-bearer, single-owner,
-  and is **not** a public multi-user MCP service. Do not publish the bearer or
-  claim OAuth support.
+  authorization flow. The owner deployment at `https://harness.zuey.me/mcp`
+  uses Cloudflare Access Managed OAuth with allowlisted mutually trusted
+  operators; it is not a hostile multi-tenant service.
 - Marketplace installation and marketplace review/publication are different
   states. Local validation does not prove an approved public listing.
 
 ## Intended trust model
 
-Cloud Harness is for one authenticated, trusted owner operating approved
-repositories. It is not an anonymous service, shared tenant sandbox, or hostile
-multi-tenant boundary. Rootful Docker and a shared kernel remain material trust
-limitations even though the executor is constrained.
+Cloud Harness is for one authenticated owner or named mutually trusted
+operators in one security domain, operating approved repositories. It is not
+an anonymous service, shared tenant sandbox, or hostile multi-tenant boundary.
+Rootful Docker and a shared kernel remain material trust limitations even
+though the executor is constrained.
 
 The trusted control plane owns ingress, authentication, repository validation,
 Docker lifecycle, optional GitHub App brokering, state, and cleanup. Repository


### PR DESCRIPTION
## Summary
- record the completed GitHub/Google Cloudflare Access rollout for issues #13 and #18
- publish the live Managed OAuth endpoint and dashboard URL
- keep owner-bearer examples deployment-neutral and align the packaged security skill

## Evidence
- GitHub and Google SSO both reach the principal-scoped dashboard
- Managed OAuth protected-resource and authorization-server metadata return JSON
- CI run 32112530628 and production run 32112756728 passed at 06946e8e595a23e9a78e1a73055e43d12391ecab
- VPS release matches that SHA; API, ingress, and runner are healthy; runtime and canary credentials are root-owned mode 0600

## Verification
- npm run pages:links
- npm run verify (42 files, 215 tests)
- npm run plugin:check
- git diff --check

Closes #13
Closes #18