### PR TITLE
feat(auth): add dashboard-managed MCP API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ AUTH_MODE=owner-bearer
 # CLOUDFLARE_ACCESS_ISSUER=https://your-team.cloudflareaccess.com
 # CLOUDFLARE_ACCESS_AUDIENCE=
 # CLOUDFLARE_ACCESS_JWKS_URL=https://your-team.cloudflareaccess.com/cdn-cgi/access/certs
+# Optional managed API-key lane. Enable all four together only in cloudflare-access mode.
+# The gateway audience belongs to a separate Access application scoped exactly to /mcp-api-key.
+# API_KEY_AUTH_ENABLED=false
+# API_KEY_GATEWAY_ACCESS_AUDIENCE=
+# API_KEY_GATEWAY_SERVICE_SUBJECT=cf-service:base64url-cloudflare-service-token-client-id
+# API_KEY_GATEWAY_PUBLIC_URL=https://api.harness.zuey.me/mcp
+# Worker-only secrets CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET are configured with Wrangler, never here.
 # Exact one-time legacy owner binding for the first Access rollout:
 # ACCESS_LEGACY_OWNER_ID=owner
 # ACCESS_LEGACY_ISSUER=https://your-team.cloudflareaccess.com

--- a/README.md
+++ b/README.md
@@ -16,10 +16,16 @@ worktree, skill, hook, memory, and repository-defined deployment tools.
 > hostile multi-tenant sandbox. Read the [security model](docs/security-model.md)
 > before operating it.
 
-The public MCP URL is:
+The Managed OAuth MCP URL is:
 
 ```text
 https://harness.zuey.me/mcp
+```
+
+Static-header clients use dashboard-managed API keys at the separate gateway:
+
+```text
+https://api.harness.zuey.me/mcp
 ```
 
 ## Architecture
@@ -30,7 +36,9 @@ keeps repository credentials out of long-lived executors.
 
 ```mermaid
 flowchart LR
-  Client["AI coding client"] -->|"HTTPS · bearer or Access OAuth"| Nginx["nginx + loopback ingress"]
+  OAuthClient["Managed OAuth client"] -->|"Access OAuth"| Nginx["nginx + loopback ingress"]
+  StaticClient["Static-header client"] -->|"managed API key"| Gateway["Cloudflare Worker gateway"]
+  Gateway -->|"Access service assertion + API key"| Nginx
 
   subgraph Control["Trusted control plane"]
     Nginx --> API["Stateless MCP API"]
@@ -198,22 +206,38 @@ See OpenAI's [plugin packaging](https://developers.openai.com/plugins/build/plug
 
 ## Connect from AI clients
 
-This server exposes a remote Streamable HTTP MCP endpoint:
+The owner deployment exposes two remote Streamable HTTP MCP lanes:
 
 ```text
-https://harness.zuey.me/mcp
+Managed OAuth: https://harness.zuey.me/mcp
+Static API key: https://api.harness.zuey.me/mcp
 ```
 
 The owner deployment uses `cloudflare-access`: Managed OAuth clients connect to
-the URL above and complete GitHub or Google login in the browser. Its dashboard
-is `https://harness.zuey.me/dashboard`.
+the first URL and complete GitHub or Google login in the browser. Static-header
+clients use only the second URL with `Authorization: Bearer <dashboard-api-key>`.
+Its dashboard is `https://harness.zuey.me/dashboard`.
+
+Create, list, and revoke API keys under **Dashboard → API keys**. A new key is
+shown once and cannot be recovered; store it only in the client's private
+credential store. Keys expire after 1–365 days, and each identity may have at
+most 10 active keys. There are no per-tool scopes or rotation endpoint: replace
+a key by creating a new one and then revoking the old one. Every key has the
+creator's full MCP authority, including arbitrary command execution in the
+executor. Revocation or expiry denies the next request.
+
+The API-key gateway is not an alternate dashboard login and does not accept
+Managed OAuth. Conversely, `https://harness.zuey.me/mcp` does not accept a
+dashboard-managed API key. See the [security model](docs/security-model.md) for
+the independent Worker/Access/key checks.
 
 `owner-bearer` remains the software default for separate private deployments.
-The direct-header examples below use the owner-provided
-`CLOUD_HARNESS_MCP_TOKEN` and the placeholder
-`https://<owner-bearer-hostname>/mcp`. Keep both in client-local private
-configuration; never put the token in a repository, prompt, or shared project
-configuration.
+The direct-header examples below use `CLOUD_HARNESS_MCP_TOKEN`. For this owner
+deployment, set it to a dashboard-managed key and use
+`https://api.harness.zuey.me/mcp`. For a separate `owner-bearer` deployment,
+use the owner-provided token and `https://<owner-bearer-hostname>/mcp`. Keep the
+credential and URL in client-local private configuration; never put the token
+in a repository, prompt, or shared project configuration.
 
 Other operators may deploy `cloudflare-access` on an eligible hostname in an
 owned Cloudflare zone. Access provides Managed OAuth and GitHub/Google SSO;

--- a/apps/api-key-gateway/package.json
+++ b/apps/api-key-gateway/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@cloud-harness/api-key-gateway",
+  "version": "0.6.4",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json && wrangler deploy --dry-run --outdir dist/worker",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/apps/api-key-gateway/src/gateway.ts
+++ b/apps/api-key-gateway/src/gateway.ts
@@ -1,0 +1,137 @@
+const UPSTREAM_URL = 'https://harness.zuey.me/mcp-api-key';
+
+const REQUEST_HEADER_POLICIES = new Map<string, { limit: number; single?: true }>([
+  ['accept', { limit: 512 }],
+  ['authorization', { limit: 512, single: true }],
+  ['content-type', { limit: 256, single: true }],
+  ['last-event-id', { limit: 256 }],
+  ['mcp-protocol-version', { limit: 64, single: true }],
+  ['mcp-session-id', { limit: 256, single: true }]
+]);
+
+const RESPONSE_HEADERS = new Set([
+  'content-type',
+  'mcp-protocol-version',
+  'mcp-session-id',
+  'retry-after',
+  'www-authenticate'
+]);
+
+const ALLOWED_METHODS = new Set(['DELETE', 'GET', 'POST']);
+export interface GatewayEnv {
+  CF_ACCESS_CLIENT_ID: string;
+  CF_ACCESS_CLIENT_SECRET: string;
+  API_KEY_RATE_LIMITER: {
+    limit(input: { key: string }): Promise<{ success: boolean }>;
+  };
+}
+
+export type UpstreamFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+function errorResponse(status: number, code: string): Response {
+  return new Response(JSON.stringify({ error: code }), {
+    status,
+    headers: {
+      'cache-control': 'no-store',
+      'content-type': 'application/json; charset=utf-8'
+    }
+  });
+}
+
+function hasValidSecrets(env: GatewayEnv): boolean {
+  return [env.CF_ACCESS_CLIENT_ID, env.CF_ACCESS_CLIENT_SECRET].every((value) =>
+    typeof value === 'string'
+      && value.length > 0
+      && value.length <= 2_048
+      && !/[\r\n]/u.test(value)
+  );
+}
+
+function buildUpstreamHeaders(request: Request, env: GatewayEnv): Headers | null {
+  const headers = new Headers();
+
+  for (const [name, policy] of REQUEST_HEADER_POLICIES) {
+    const value = request.headers.get(name);
+    if (value === null) continue;
+    if (value.length === 0 || value.length > policy.limit || /[\r\n]/u.test(value)) return null;
+    if (policy.single && value.includes(',')) return null;
+    headers.set(name, value);
+  }
+
+  const authorization = headers.get('authorization');
+  if (authorization === null || !/^Bearer [^\s,]+$/u.test(authorization)) return null;
+
+  headers.set('cache-control', 'no-store');
+  headers.set('cf-access-client-id', env.CF_ACCESS_CLIENT_ID);
+  headers.set('cf-access-client-secret', env.CF_ACCESS_CLIENT_SECRET);
+  return headers;
+}
+
+function buildClientHeaders(upstream: Response): Headers {
+  const headers = new Headers({ 'cache-control': 'no-store' });
+  for (const name of RESPONSE_HEADERS) {
+    const value = upstream.headers.get(name);
+    if (value !== null) headers.set(name, value);
+  }
+  return headers;
+}
+
+export function createGatewayHandler(upstreamFetch: UpstreamFetch): (
+  request: Request,
+  env: GatewayEnv
+) => Promise<Response> {
+  return async (request, env) => {
+    const url = new URL(request.url);
+    if (url.pathname !== '/mcp' || url.search !== '') {
+      return errorResponse(404, 'not_found');
+    }
+    if (!ALLOWED_METHODS.has(request.method)) {
+      return errorResponse(405, 'method_not_allowed');
+    }
+    try {
+      const limited = await env.API_KEY_RATE_LIMITER.limit({ key: 'mcp-api-key-gateway' });
+      if (!limited.success) {
+        const response = errorResponse(429, 'rate_limited');
+        response.headers.set('retry-after', '60');
+        return response;
+      }
+    } catch {
+      return errorResponse(503, 'gateway_unavailable');
+    }
+    if (!hasValidSecrets(env)) {
+      return errorResponse(503, 'gateway_unavailable');
+    }
+
+    const headers = buildUpstreamHeaders(request, env);
+    if (headers === null) return errorResponse(400, 'invalid_request');
+
+    const init: RequestInit = {
+      method: request.method,
+      headers,
+      redirect: 'manual',
+      cache: 'no-store'
+    };
+    if (request.method === 'POST') init.body = request.body;
+
+    let upstream: Response;
+    try {
+      upstream = await upstreamFetch(UPSTREAM_URL, init);
+    } catch {
+      return errorResponse(502, 'bad_gateway');
+    }
+
+    if (upstream.status >= 300 && upstream.status < 400) {
+      await upstream.body?.cancel().catch(() => undefined);
+      return errorResponse(502, 'bad_gateway');
+    }
+
+    return new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: buildClientHeaders(upstream)
+    });
+  };
+}

--- a/apps/api-key-gateway/src/index.ts
+++ b/apps/api-key-gateway/src/index.ts
@@ -1,0 +1,13 @@
+import {
+  createGatewayHandler,
+  type GatewayEnv,
+  type UpstreamFetch
+} from './gateway.js';
+
+const handler = createGatewayHandler(fetch as UpstreamFetch);
+
+export default {
+  fetch(request: Request, env: GatewayEnv): Promise<Response> {
+    return handler(request, env);
+  }
+};

--- a/apps/api-key-gateway/test/gateway.test.ts
+++ b/apps/api-key-gateway/test/gateway.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createGatewayHandler,
+  type GatewayEnv,
+  type UpstreamFetch
+} from '../src/gateway.js';
+
+const ENV: GatewayEnv = {
+  CF_ACCESS_CLIENT_ID: '[redacted-client-id]',
+  CF_ACCESS_CLIENT_SECRET: '[redacted-client-secret]',
+  API_KEY_RATE_LIMITER: { limit: async () => ({ success: true }) }
+};
+
+function request(
+  path = '/mcp',
+  init: RequestInit & { duplex?: 'half' } = {}
+): Request {
+  return new Request(`https://api.harness.zuey.me${path}`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer [redacted-api-key]' },
+    ...init
+  } as RequestInit);
+}
+
+function handlerReturning(response = new Response('{}', {
+  headers: { 'content-type': 'application/json' }
+})) {
+  const upstreamFetch = vi.fn<UpstreamFetch>().mockResolvedValue(response);
+  return { handler: createGatewayHandler(upstreamFetch), upstreamFetch };
+}
+
+describe('API-key gateway boundary', () => {
+  it.each(['/mcp/', '/dashboard', '/mcp?target=other'])('rejects non-exact route %s', async (path) => {
+    const { handler, upstreamFetch } = handlerReturning();
+    const response = await handler(request(path), ENV);
+    expect(response.status).toBe(404);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it.each(['HEAD', 'OPTIONS', 'PATCH', 'PUT'])('rejects method %s', async (method) => {
+    const { handler, upstreamFetch } = handlerReturning();
+    const response = await handler(request('/mcp', { method }), ENV);
+    expect(response.status).toBe(405);
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it.each(['DELETE', 'GET', 'POST'])('allows Streamable HTTP method %s', async (method) => {
+    const { handler, upstreamFetch } = handlerReturning();
+    const response = await handler(request('/mcp', { method }), ENV);
+    expect(response.status).toBe(200);
+    expect(upstreamFetch).toHaveBeenCalledOnce();
+  });
+
+  it('uses one fixed HTTPS origin URL and manual redirects', async () => {
+    const { handler, upstreamFetch } = handlerReturning();
+    await handler(new Request('https://attacker.invalid/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer [redacted-api-key]',
+        host: 'other.invalid',
+        'x-forwarded-host': 'other.invalid'
+      }
+    }), ENV);
+
+    expect(upstreamFetch).toHaveBeenCalledWith(
+      'https://harness.zuey.me/mcp-api-key',
+      expect.objectContaining({ redirect: 'manual', cache: 'no-store' })
+    );
+  });
+
+  it('reconstructs request headers and strips mixed-case duplicate forbidden headers', async () => {
+    const headers = new Headers({
+      accept: 'application/json, text/event-stream',
+      authorization: 'Bearer [redacted-api-key]',
+      'content-type': 'application/json',
+      'last-event-id': 'event-1',
+      'mcp-protocol-version': '2025-11-25',
+      'mcp-session-id': 'session-1',
+      cookie: 'sensitive=discarded',
+      forwarded: 'for=192.0.2.1',
+      host: 'spoofed.invalid',
+      'x-real-ip': '192.0.2.2',
+      'x-forwarded-for': '192.0.2.3',
+      connection: 'keep-alive',
+      'cache-control': 'public, max-age=3600',
+      'cf-access-jwt-assertion': 'caller-assertion',
+      'cf-access-client-id': 'caller-id',
+      'cf-access-client-secret': 'caller-secret',
+      'cf-connecting-ip': '192.0.2.4'
+    });
+    headers.append('CF-Access-JWT-Assertion', 'duplicate-caller-assertion');
+    headers.append('X-Forwarded-For', '192.0.2.5');
+    const { handler, upstreamFetch } = handlerReturning();
+
+    await handler(request('/mcp', { headers }), ENV);
+
+    const init = upstreamFetch.mock.calls[0]?.[1];
+    const outgoing = new Headers(init?.headers);
+    expect(Object.fromEntries(outgoing)).toEqual({
+      accept: 'application/json, text/event-stream',
+      authorization: 'Bearer [redacted-api-key]',
+      'cache-control': 'no-store',
+      'cf-access-client-id': ENV.CF_ACCESS_CLIENT_ID,
+      'cf-access-client-secret': ENV.CF_ACCESS_CLIENT_SECRET,
+      'content-type': 'application/json',
+      'last-event-id': 'event-1',
+      'mcp-protocol-version': '2025-11-25',
+      'mcp-session-id': 'session-1'
+    });
+  });
+
+  it.each([
+    undefined,
+    '',
+    'Basic [redacted]',
+    'Bearer first, Bearer second',
+    `Bearer ${'x'.repeat(600)}`
+  ])('rejects missing or ambiguous authorization %s', async (authorization) => {
+    const headers = new Headers();
+    if (authorization !== undefined) headers.set('authorization', authorization);
+    const { handler, upstreamFetch } = handlerReturning();
+    const response = await handler(request('/mcp', { headers }), ENV);
+    expect(response.status).toBe(400);
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate singleton protocol headers', async () => {
+    const headers = new Headers({ authorization: 'Bearer [redacted-api-key]' });
+    headers.append('MCP-Session-Id', 'first');
+    headers.append('mcp-session-id', 'second');
+    const { handler, upstreamFetch } = handlerReturning();
+    const response = await handler(request('/mcp', { headers }), ENV);
+    expect(response.status).toBe(400);
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when Worker secrets are missing without reflecting their values', async () => {
+    const { handler, upstreamFetch } = handlerReturning();
+    const response = await handler(request(), {
+      CF_ACCESS_CLIENT_ID: '',
+      CF_ACCESS_CLIENT_SECRET: '[redacted]',
+      API_KEY_RATE_LIMITER: ENV.API_KEY_RATE_LIMITER
+    });
+    expect(response.status).toBe(503);
+    expect(await response.text()).toBe('{"error":"gateway_unavailable"}');
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects at the edge when the aggregate gateway limit is exhausted', async () => {
+    const { handler, upstreamFetch } = handlerReturning();
+    const response = await handler(request(), {
+      ...ENV,
+      API_KEY_RATE_LIMITER: { limit: async () => ({ success: false }) }
+    });
+    expect(response.status).toBe(429);
+    expect(response.headers.get('retry-after')).toBe('60');
+    expect(await response.text()).toBe('{"error":"rate_limited"}');
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the edge limiter binding is unavailable', async () => {
+    const { handler, upstreamFetch } = handlerReturning();
+    const response = await handler(request(), {
+      ...ENV,
+      API_KEY_RATE_LIMITER: { limit: async () => { throw new Error('[redacted]'); } }
+    });
+    expect(response.status).toBe(503);
+    expect(await response.text()).toBe('{"error":"gateway_unavailable"}');
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it('passes the POST body stream through without reading or replacing it', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('[redacted-body]'));
+        controller.close();
+      }
+    });
+    const { handler, upstreamFetch } = handlerReturning();
+    const incoming = request('/mcp', {
+      method: 'POST',
+      body,
+      duplex: 'half'
+    });
+
+    await handler(incoming, ENV);
+
+    expect(upstreamFetch.mock.calls[0]?.[1]?.body).toBe(incoming.body);
+  });
+
+  it('streams the response body and exposes only safe headers', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: first\\n\\n'));
+        controller.close();
+      }
+    });
+    const upstream = new Response(body, {
+      headers: {
+        'content-type': 'text/event-stream',
+        'mcp-session-id': 'session-1',
+        'set-cookie': 'discarded=true',
+        location: 'https://discarded.invalid',
+        'transfer-encoding': 'chunked',
+        'x-internal-debug': 'discarded'
+      }
+    });
+    const { handler } = handlerReturning(upstream);
+
+    const response = await handler(request(), ENV);
+
+    expect(response.body).toBe(body);
+    expect(Object.fromEntries(response.headers)).toEqual({
+      'cache-control': 'no-store',
+      'content-type': 'text/event-stream',
+      'mcp-session-id': 'session-1'
+    });
+  });
+
+  it('rejects upstream redirects instead of following or reflecting them', async () => {
+    const { handler } = handlerReturning(new Response(null, {
+      status: 302,
+      headers: { location: 'https://attacker.invalid' }
+    }));
+    const response = await handler(request(), ENV);
+    expect(response.status).toBe(502);
+    expect(response.headers.get('location')).toBeNull();
+    expect(await response.text()).toBe('{"error":"bad_gateway"}');
+  });
+
+  it('returns a bounded generic error when upstream fetch fails', async () => {
+    const upstreamFetch = vi.fn<UpstreamFetch>().mockRejectedValue(new Error('[redacted-error]'));
+    const handler = createGatewayHandler(upstreamFetch);
+    const response = await handler(request(), ENV);
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe('{"error":"bad_gateway"}');
+  });
+});

--- a/apps/api-key-gateway/tsconfig.json
+++ b/apps/api-key-gateway/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "composite": true,
+    "lib": ["ES2023", "WebWorker"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/api-key-gateway/wrangler.jsonc
+++ b/apps/api-key-gateway/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "cloud-harness-api-key-gateway",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-18",
+  "workers_dev": false,
+  "preview_urls": false,
+  "send_metrics": false,
+  "observability": {
+    "enabled": false
+  },
+  "ratelimits": [
+    {
+      "name": "API_KEY_RATE_LIMITER",
+      "namespace_id": "2608181610",
+      "simple": {
+        "limit": 600,
+        "period": 60
+      }
+    }
+  ],
+  "routes": [
+    {
+      "pattern": "api.harness.zuey.me",
+      "custom_domain": true
+    }
+  ]
+}

--- a/apps/api/dashboard/dashboard-render.js
+++ b/apps/api/dashboard/dashboard-render.js
@@ -49,6 +49,30 @@ export function renderAuditIndex(events, cursor) {
   return `<div class="page-note"><strong>Retained redacted audit history.</strong> Events exclude secret values, provider credentials, and workspace command output.</div><section aria-labelledby="audit-list-heading"><h2 id="audit-list-heading">Audit events</h2><ul class="audit-list">${items}</ul>${cursor ? `<button id="load-more-audit" type="button" data-cursor="${escape(cursor)}">Load more</button>` : ''}</section>`;
 }
 
+export function renderApiKeyIndex(data) {
+  const keys = Array.isArray(data?.keys) ? data.keys : [];
+  const readiness = data?.readiness ?? { ready: true };
+  const activeCount = keys.filter((key) => key?.state === 'ACTIVE').length;
+  const publicUrl = readiness.ready === true ? publicMcpUrl(readiness.publicUrl ?? data?.publicUrl) : undefined;
+  const readinessNote = readiness.ready === false
+    ? '<p class="warning" role="status">API-key connections are not available yet. An operator must finish the dedicated gateway configuration.</p>'
+    : publicUrl ? `<p class="page-note"><strong>Static client endpoint</strong> <code class="mono wrap">${escape(publicUrl)}</code></p>` : '';
+  const items = keys.length ? keys.map((key) => renderApiKey(key)).join('') : '<li class="empty"><h3>No API keys yet.</h3><p>Create one when a client cannot complete the browser-based OAuth flow.</p></li>';
+  const creationDisabled = readiness.ready === false || activeCount >= 10;
+  const disabled = creationDisabled ? ' disabled' : '';
+  const limitNote = activeCount >= 10 ? '<p class="warning" role="status">The 10-active-key limit is reached. Revoke an active key before creating another.</p>' : '';
+  return `${readinessNote}<section class="panel" aria-labelledby="create-api-key-heading"><h2 id="create-api-key-heading">Create API key</h2><p class="warning"><strong>Full remote execution authority.</strong> This key grants full MCP access as your identity, including arbitrary command execution. It expires, cannot be recovered, and must be revoked if exposed.</p>${limitNote}<form id="create-api-key-form" class="stack-form"><label for="api-key-name">Key name</label><input id="api-key-name" name="name" required maxlength="100" autocomplete="off"${disabled}><label for="api-key-expiry">Expires after (days)</label><input id="api-key-expiry" name="expiryDays" type="number" inputmode="numeric" min="1" max="365" step="1" value="30" required${disabled}><label class="checkbox-label"><input name="authorityAcknowledged" type="checkbox" required${disabled}><span>I understand this key permits full MCP and command-execution access and will be shown only once.</span></label><button id="create-api-key-submit" type="submit"${disabled}>Create API key</button><p class="form-status" aria-live="polite"></p></form></section><section aria-labelledby="api-key-list-heading"><div class="record-heading"><div><h2 id="api-key-list-heading">API keys</h2><p>${escape(activeCount)} active of 10 · ${escape(keys.length)} total</p></div></div><ul class="record-list api-key-list">${items}</ul></section>`;
+}
+
+function renderApiKey(key) {
+  const keyId = key?.id;
+  const generation = Number(key?.generation);
+  const state = ['ACTIVE', 'EXPIRED', 'REVOKED'].includes(key?.state) ? key.state : 'UNKNOWN';
+  const action = state === 'ACTIVE' && typeof keyId === 'string' && Number.isSafeInteger(generation) && generation > 0
+    ? `<button class="danger revoke-api-key" type="button" data-key-id="${escape(keyId)}" data-generation="${escape(generation)}" data-key-name="${escape(key?.name)}">Revoke</button>` : '';
+  return `<li class="panel api-key-card"><div class="record-heading"><div><h3>${escape(key?.name)}</h3><p><code class="mono">${escape(key?.displayPrefix)}</code> <span class="status ${state === 'ACTIVE' ? 'active' : state === 'EXPIRED' ? 'expired' : ''}">${escape(stateLabel(state))}</span></p></div>${action}</div><dl class="facts"><dt>Created</dt><dd>${optionalTime(key?.createdAt)}</dd><dt>Expires</dt><dd>${optionalTime(key?.expiresAt)}</dd><dt>Last used</dt><dd>${optionalTime(key?.lastUsedAt)}</dd><dt>Revoked</dt><dd>${optionalTime(key?.revokedAt)}</dd></dl></li>`;
+}
+
 export function renderGitHub(status, callbackPending = false) {
   const installation = status.installation;
   const installationView = installation ? `<dl class="facts"><dt>Account</dt><dd>${escape(installation.accountLogin ?? installation.accountId)}</dd><dt>Status</dt><dd>${escape(installation.status)}</dd><dt>Installation ID</dt><dd class="mono">${escape(installation.installationId)}</dd><dt>Last checked</dt><dd>${installation.checkedAt ? time(installation.checkedAt) : 'Not yet reconciled'}</dd></dl>` : '<p>No GitHub App installation is bound to this identity.</p>';
@@ -75,3 +99,12 @@ export const repositoryName = (url) => { try { return new URL(url).pathname.repl
 const join = (base, name) => base === '.' ? name : `${base}/${name}`;
 const statusLabelRuntime = (status) => ({ queued: 'Queued', running: 'Running', succeeded: 'Succeeded', failed: 'Failed', cancelled: 'Cancelled', blocked: 'Blocked' })[status] ?? 'Unknown';
 const formatBytes = (value) => Number.isFinite(value) ? `${Number(value).toLocaleString()} bytes` : 'Unknown';
+const stateLabel = (state) => ({ ACTIVE: 'Active', EXPIRED: 'Expired', REVOKED: 'Revoked', UNKNOWN: 'Unknown' })[state];
+const optionalTime = (value) => (typeof value === 'string' && value) || (typeof value === 'number' && Number.isFinite(value)) ? time(value) : 'Never';
+const publicMcpUrl = (value) => {
+  if (typeof value !== 'string') return undefined;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && url.pathname === '/mcp' && !url.username && !url.password && !url.search && !url.hash ? url.toString() : undefined;
+  } catch { return undefined; }
+};

--- a/apps/api/dashboard/dashboard.css
+++ b/apps/api/dashboard/dashboard.css
@@ -44,6 +44,7 @@ th small { display: block; color: var(--ink-muted); font-weight: 400; }
 .mobile-list { display: none; }
 .status { display: inline-flex; gap: var(--space-2); align-items: center; border: 1px solid var(--line-strong); border-radius: 99rem; padding: var(--space-1) var(--space-2); }
 .status.active { background: var(--success-soft); color: var(--success); }.status.reaping { background: var(--warning-soft); color: var(--warning); }.status.failed { background: var(--danger-soft); color: var(--danger); }
+.status.expired { background: var(--warning-soft); color: var(--warning); }
 .detail { min-width: 0; border-inline-start: 1px solid var(--line); background: var(--surface); padding: var(--space-6); }
 .lifecycle { list-style: none; padding: 0; border-inline-start: 2px solid var(--line-strong); margin-inline-start: var(--space-2); }
 .lifecycle li { display: grid; gap: var(--space-1); padding: 0 0 var(--space-6) var(--space-5); position: relative; }
@@ -73,6 +74,12 @@ dialog { max-width: min(32rem, calc(100vw - 2 * var(--space-4))); border: 1px so
 dialog::backdrop { background: oklch(0.20 0.02 255 / .38); }
 .dialog-actions { display: flex; justify-content: flex-end; flex-wrap: wrap; gap: var(--space-3); }
 .status-message { min-height: 1.25rem; }
+.stack-form .checkbox-label { display: flex; align-items: start; gap: var(--space-3); font-weight: 500; }
+.checkbox-label input { flex: 0 0 auto; width: 1.25rem; height: 1.25rem; min-height: auto; padding: 0; margin-block-start: var(--space-1); accent-color: var(--accent); }
+.api-key-list { margin-block: var(--space-4); }
+.api-key-card { display: grid; gap: var(--space-3); }
+.api-key-secret { display: block; width: 100%; margin-block: var(--space-2); }
+#api-key-reveal-dialog { width: min(36rem, calc(100vw - 2 * var(--space-4))); }
 .drawer-close { display: block; margin-inline-start: auto; margin-block-end: var(--space-4); }
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
 .mobile-bar { display: none; }

--- a/apps/api/dashboard/dashboard.js
+++ b/apps/api/dashboard/dashboard.js
@@ -1,6 +1,6 @@
 import { api } from './dashboard-api.js';
 import {
-  renderArtifactIndex, renderAuditIndex, renderFile, renderFileList, renderGitHub, renderProjectDetail,
+  renderApiKeyIndex, renderArtifactIndex, renderAuditIndex, renderFile, renderFileList, renderGitHub, renderProjectDetail,
   renderProjectIndex, renderRuntime, renderWorkspaceDetail, renderWorkspaceIndex, repositoryName
 } from './dashboard-render.js';
 
@@ -76,6 +76,49 @@ export function resetWriteOnlyFields(form) {
   for (const field of form.querySelectorAll('input[data-write-only]')) field.value = '';
 }
 
+export function apiKeyCreateInput(form) {
+  const values = new FormData(form);
+  const name = String(values.get('name') ?? '').trim();
+  const expiresInDays = Number(values.get('expiryDays'));
+  if (!name || name.length > 100 || !Number.isInteger(expiresInDays) || expiresInDays < 1 || expiresInDays > 365) {
+    throw new Error('Enter a key name and an expiry from 1 to 365 whole days.');
+  }
+  return { name, expiresInDays };
+}
+
+export function createApiKeyRevealController({ dialog, secretField, copyButton, acknowledgeButton, status, clipboard, reportError }) {
+  let apiKey; let invoker;
+  function clear() { apiKey = undefined; secretField.value = ''; status.textContent = ''; }
+  function dismiss(restoreFocus = true) {
+    clear();
+    if (dialog.open) dialog.close();
+    if (restoreFocus) invoker?.focus({ preventScroll: true });
+    invoker = undefined;
+  }
+  function open(value, source) {
+    if (typeof value !== 'string' || !/^chm_key_apk_[A-Za-z0-9_-]{24}\.[A-Za-z0-9_-]{43}$/.test(value)) {
+      throw new Error('The new API key was unavailable. Create a replacement key.');
+    }
+    clear(); apiKey = value; invoker = source; secretField.value = value;
+    dialog.showModal(); copyButton.focus({ preventScroll: true });
+  }
+  async function copy() {
+    const value = apiKey;
+    if (!value) return;
+    try {
+      await clipboard.writeText(value);
+      if (apiKey === value && dialog.open) status.textContent = 'API key copied. Save it before closing this window.';
+    } catch {
+      dismiss();
+      reportError(new Error('The API key could not be copied and was cleared. Create a replacement key.'));
+    }
+  }
+  dialog.addEventListener('cancel', (event) => { event.preventDefault(); dismiss(); });
+  copyButton.addEventListener('click', () => void copy());
+  acknowledgeButton.addEventListener('click', () => dismiss());
+  return { open, copy, dismiss, clear: () => dismiss(false) };
+}
+
 export async function submitPatchEdit({ workspaceId, file, oldText, newText, request, onSaved, onConflict, onError }) {
   try {
     await request(`/workspaces/${encodeURIComponent(workspaceId)}/files/content`, {
@@ -118,12 +161,19 @@ export function initializeDashboard() {
   const content = document.querySelector('#content'); const detail = document.querySelector('#detail'); const main = document.querySelector('#main');
   const sidebar = document.querySelector('#product-nav'); const alertBox = document.querySelector('#alert'); const announcer = document.querySelector('#announcer');
   const dialog = document.querySelector('#confirm-dialog'); const menuButton = document.querySelector('#menu-button');
+  const revealDialog = document.querySelector('#api-key-reveal-dialog');
   const pathMatch = location.pathname.match(/^\/dashboard\/workspaces\/(ws_[A-Za-z0-9_-]{20,80})(?:\/(files|runtime))?$/);
   const projectMatch = location.pathname.match(/^\/dashboard\/projects\/(prj_[A-Za-z0-9_-]{20,80})$/);
   if (matchMedia('(max-width: 47.9375rem)').matches) sidebar.hidden = true;
   const confirm = createAsyncDialogController({ dialog, cancelButton: dialog.querySelector('[data-cancel]'), actionButton: document.querySelector('#confirm-action'), status: document.querySelector('#confirm-status'), reportError: showError });
+  const apiKeyReveal = createApiKeyRevealController({
+    dialog: revealDialog, secretField: document.querySelector('#api-key-secret'), copyButton: document.querySelector('#copy-api-key'),
+    acknowledgeButton: document.querySelector('#acknowledge-api-key'), status: document.querySelector('#api-key-copy-status'),
+    clipboard: globalThis.navigator.clipboard, reportError: showError
+  });
   const setBusy = (busy) => content.setAttribute('aria-busy', String(busy));
   const announce = (message) => { announcer.textContent = message; };
+  let apiKeyPageData;
   function showError(error) {
     alertBox.hidden = false;
     alertBox.textContent = error.status === 401 ? 'Your dashboard session ended. Sign in again.'
@@ -150,6 +200,7 @@ export function initializeDashboard() {
       else if (projectMatch) await loadProject(projectMatch[1]);
       else if (location.pathname === '/dashboard/artifacts') await loadArtifacts();
       else if (location.pathname === '/dashboard/audit') await loadAudit();
+      else if (location.pathname === '/dashboard/api-keys') await loadApiKeys();
       else if (location.pathname === '/dashboard/github') await loadGitHub();
       else if (pathMatch?.[2] === 'files') await loadFiles(pathMatch[1]);
       else if (pathMatch?.[2] === 'runtime') await loadRuntime(pathMatch[1]);
@@ -229,6 +280,37 @@ export function initializeDashboard() {
     const parameters = new URLSearchParams(location.search); const cursor = parameters.get('cursor');
     const result = await api(`/audit?limit=50${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`); content.innerHTML = renderAuditIndex(result.data.events, result.cursor);
     document.querySelector('#load-more-audit')?.addEventListener('click', (event) => { location.href = `/dashboard/audit?cursor=${encodeURIComponent(event.currentTarget.dataset.cursor)}`; });
+  }
+  async function loadApiKeys() {
+    selectNavigation('api-keys'); setTitle('API keys', 'Expiring credentials for static MCP clients that cannot complete browser OAuth.');
+    document.querySelector('#command-surface').hidden = true;
+    const result = await api('/api-keys'); apiKeyPageData = result.data; content.innerHTML = renderApiKeyIndex(apiKeyPageData); bindApiKeyControls();
+  }
+  function bindApiKeyControls() {
+    const form = document.querySelector('#create-api-key-form');
+    form.addEventListener('submit', (event) => {
+      event.preventDefault(); const current = event.currentTarget; const invoker = current.querySelector('button[type="submit"]'); let created;
+      void submitForm(current, 'Creating key…', async () => {
+        created = await api('/api-keys', { method: 'POST', body: requestBody(apiKeyCreateInput(current)) });
+        if (typeof created?.data?.apiKey !== 'string') throw new Error('The new API key was unavailable. Create a replacement key.');
+      }, async () => {
+        const apiKey = created.data.apiKey; const metadata = created.data.key;
+        created = undefined;
+        const previousKeys = Array.isArray(apiKeyPageData?.keys) ? apiKeyPageData.keys : [];
+        current.reset(); apiKeyPageData = { ...apiKeyPageData, keys: [metadata, ...previousKeys.filter((key) => key.id !== metadata.id)] };
+        content.innerHTML = renderApiKeyIndex(apiKeyPageData); bindApiKeyControls();
+        apiKeyReveal.open(apiKey, document.querySelector('#create-api-key-submit') ?? invoker);
+        announce('API key created. Copy it now; it will not be shown again.');
+      });
+    });
+    for (const button of document.querySelectorAll('.revoke-api-key')) button.addEventListener('click', (event) => confirmAction({
+      title: 'Revoke API key?', description: 'This key will stop authenticating on the next request. Revocation cannot be undone.',
+      target: button.dataset.keyName, label: 'Revoke API key', pendingLabel: 'Revoking…',
+      action: async () => {
+        await api(`/api-keys/${encodeURIComponent(button.dataset.keyId)}`, { method: 'DELETE', body: requestBody({ expectedGeneration: Number(button.dataset.generation) }) });
+        announce('API key revoked.'); await loadApiKeys();
+      }
+    }, event.currentTarget));
   }
   async function loadGitHub() {
     selectNavigation('github'); setTitle('GitHub', 'GitHub App installation and repository authorization status.'); document.querySelector('#command-surface').hidden = true;
@@ -336,7 +418,9 @@ export function initializeDashboard() {
   document.querySelector('#refresh').addEventListener('click', async () => { announce('Refreshing…'); await load(); announce('Workspace data refreshed.'); });
   const menu = createModalController({ panel: sidebar, backgrounds: [main], trigger: menuButton, initialFocus: () => sidebar.querySelector('a'), onOpen: () => { sidebar.classList.add('open'); menuButton.setAttribute('aria-expanded', 'true'); }, onClose: () => { sidebar.classList.remove('open'); menuButton.setAttribute('aria-expanded', 'false'); } });
   menuButton.addEventListener('click', () => menu.active ? menu.close() : menu.open());
-  document.querySelector('#nav-toggle').addEventListener('click', (event) => { const expanded = event.currentTarget.getAttribute('aria-expanded') === 'true'; event.currentTarget.setAttribute('aria-expanded', String(!expanded)); event.currentTarget.textContent = expanded ? 'Expand navigation' : 'Collapse navigation'; localStorage.setItem('dashboard-navigation-expanded', String(!expanded)); });
+  document.querySelector('#nav-toggle').addEventListener('click', (event) => { const expanded = event.currentTarget.getAttribute('aria-expanded') === 'true'; event.currentTarget.setAttribute('aria-expanded', String(!expanded)); event.currentTarget.textContent = expanded ? 'Expand navigation' : 'Collapse navigation'; });
+  document.addEventListener('click', (event) => { if (event.target.closest?.('a[href]')) apiKeyReveal.clear(); }, { capture: true });
+  addEventListener('pagehide', () => apiKeyReveal.clear());
   addEventListener('popstate', () => location.reload()); void load();
 }
 

--- a/apps/api/dashboard/index.html
+++ b/apps/api/dashboard/index.html
@@ -17,6 +17,7 @@
         <a href="/dashboard/projects" data-section="projects">Projects</a>
         <a href="/dashboard/artifacts" data-section="artifacts">Artifacts</a>
         <a href="/dashboard/audit" data-section="audit">Audit</a>
+        <a href="/dashboard/api-keys" data-section="api-keys">API keys</a>
         <a href="/dashboard/github" data-section="github">GitHub</a>
         <div id="context-nav"></div>
       </nav>
@@ -48,6 +49,14 @@
     <p id="file-conflict-description">This item changed after you opened it. Your unsaved content is still in the editor.</p>
     <p id="file-conflict-status" class="status-message" aria-live="polite"></p>
     <div class="dialog-actions"><button id="cancel-conflict" type="button">Cancel</button><button id="copy-changes" type="button">Copy my changes</button><button id="review-latest" type="button">Review latest</button></div>
+  </dialog>
+  <dialog id="api-key-reveal-dialog" aria-labelledby="api-key-reveal-title" aria-describedby="api-key-reveal-description">
+    <h2 id="api-key-reveal-title">Copy this API key now</h2>
+    <p id="api-key-reveal-description">This is the only time the complete key will be shown. It cannot be recovered later. Anyone with it has full MCP access, including arbitrary command execution as your identity.</p>
+    <label for="api-key-secret">New API key</label>
+    <input id="api-key-secret" class="mono api-key-secret" type="text" readonly autocomplete="off" spellcheck="false">
+    <p id="api-key-copy-status" class="status-message" aria-live="polite"></p>
+    <div class="dialog-actions"><button id="copy-api-key" type="button">Copy API key</button><button id="acknowledge-api-key" type="button">I have saved it</button></div>
   </dialog>
   <script type="module" src="/dashboard/assets/dashboard.js"></script>
 </body>

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,7 +2,7 @@ import express, { type Express, type Request, type Response } from 'express';
 import { createMcpHandler } from '@modelcontextprotocol/server';
 import { toNodeHandler } from '@modelcontextprotocol/node';
 import type { ApiConfig } from '@cloud-harness/contracts';
-import { accessAssertionAuth, bearerAuth } from './auth.js';
+import { accessAssertionAuth, apiKeyGatewayAuth, bearerAuth } from './auth.js';
 import { createDashboardAssetsRouter } from './dashboard-assets.js';
 import { createDashboardRouter } from './dashboard-router.js';
 import { createCloudHarnessServerFactory } from './mcp-server.js';
@@ -31,6 +31,17 @@ export function createApiApp(config: ApiConfig): ApiRuntime {
     }
     await nodeHandler(request, response, request.body);
   });
+  if (config.authMode === 'cloudflare-access' && config.apiKeyAuthEnabled) {
+    app.use('/mcp-api-key', requestSecurity(config), preAuthRequestLimits(), apiKeyGatewayAuth(config, runnerClient), principalRequestLimits());
+    app.use('/mcp-api-key', express.json({ limit: config.maxBodyBytes, strict: true }));
+    app.all('/mcp-api-key', async (request: Request, response: Response) => {
+      if (request.method === 'POST' && !request.is('application/json')) {
+        response.status(415).json({ error: 'unsupported_media_type' });
+        return;
+      }
+      await nodeHandler(request, response, request.body);
+    });
+  }
   if (config.authMode === 'cloudflare-access') {
     app.use('/dashboard', requestSecurity(config), preAuthRequestLimits(), accessAssertionAuth(config), principalRequestLimits());
     app.use('/dashboard', createDashboardRouter(config, runnerClient));

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -4,6 +4,13 @@ import type { AuthInfo } from '@modelcontextprotocol/server';
 import { RunnerPrincipalSelectorSchema, type ApiConfig, type RunnerPrincipalSelector } from '@cloud-harness/contracts';
 import { CloudflareAccessJwtVerifier, type AccessJwtVerifierOptions } from './access-jwt-verifier.js';
 
+type ApiKeyAuthenticator = {
+  authenticateApiKey(apiKey: string): Promise<
+    { ok: true; data: { principal: RunnerPrincipalSelector; keyId: string } }
+    | { ok: false; error: 'authentication_failed' }
+  >;
+};
+
 type AuthenticatedRequest = Request & { auth?: AuthInfo };
 
 function equal(actual: string, expected: string | undefined): boolean {
@@ -14,6 +21,10 @@ function equal(actual: string, expected: string | undefined): boolean {
 }
 
 const scopes = ['workspace:read', 'workspace:write', 'workspace:execute'];
+
+function isApiKeyGatewaySubject(config: ApiConfig, subject: string): boolean {
+  return subject === config.apiKeyGatewayServiceSubject;
+}
 
 function reject(response: Response): void {
   response.setHeader('WWW-Authenticate', 'Bearer realm="cloud-harness-mcp"');
@@ -53,6 +64,10 @@ export function accessAssertionAuth(config: ApiConfig, verifierOptions: Verifier
     activeVerifications += 1;
     try {
       const identity = await verifier.verify(request.header('cf-access-jwt-assertion') ?? '');
+      if (isApiKeyGatewaySubject(config, identity.principal.subject)) {
+        response.status(401).json({ error: 'authentication_failed' });
+        return;
+      }
       const principal: RunnerPrincipalSelector = { kind: 'external', ...identity.principal };
       request.auth = {
         token: 'cloudflare-access',
@@ -86,6 +101,10 @@ export function bearerAuth(config: ApiConfig, verifierOptions: VerifierOverrides
       next();
       return;
     }
+    if (token.startsWith('chm_key_')) {
+      reject(response);
+      return;
+    }
 
     if (activeVerifications >= 32) {
       response.status(429).json({ error: 'too_many_requests' });
@@ -95,6 +114,10 @@ export function bearerAuth(config: ApiConfig, verifierOptions: VerifierOverrides
     try {
       const assertion = request.header('cf-access-jwt-assertion') ?? '';
       const identity = await verifier.verify(assertion);
+      if (isApiKeyGatewaySubject(config, identity.principal.subject)) {
+        reject(response);
+        return;
+      }
       const principal: RunnerPrincipalSelector = { kind: 'external', ...identity.principal };
       request.auth = {
         token: token || 'cloudflare-access',
@@ -102,6 +125,60 @@ export function bearerAuth(config: ApiConfig, verifierOptions: VerifierOverrides
         scopes,
         expiresAt: identity.expiresAt,
         extra: { principal, externalPrincipal: identity.principal }
+      };
+      next();
+    } catch {
+      reject(response);
+    } finally {
+      activeVerifications -= 1;
+    }
+  };
+}
+
+export function apiKeyGatewayAuth(
+  config: ApiConfig,
+  runner: ApiKeyAuthenticator,
+  verifierOptions: VerifierOverrides = {}
+) {
+  const verifier = config.authMode === 'cloudflare-access' && config.apiKeyAuthEnabled
+    ? new CloudflareAccessJwtVerifier({
+        issuer: config.accessIssuer!,
+        audience: config.apiKeyGatewayAccessAudience!,
+        jwksUrl: config.accessJwksUrl!,
+        ...verifierOptions
+      })
+    : undefined;
+  let activeVerifications = 0;
+  return async (request: AuthenticatedRequest, response: Response, next: NextFunction): Promise<void> => {
+    if (!verifier) {
+      response.status(404).json({ error: 'not_found' });
+      return;
+    }
+    if (activeVerifications >= 32) {
+      response.status(429).json({ error: 'too_many_requests' });
+      return;
+    }
+    activeVerifications += 1;
+    try {
+      const identity = await verifier.verify(request.header('cf-access-jwt-assertion') ?? '');
+      if (!isApiKeyGatewaySubject(config, identity.principal.subject)) {
+        reject(response);
+        return;
+      }
+      const authorization = request.header('authorization') ?? '';
+      const apiKey = authorization.startsWith('Bearer ') && authorization.length <= 103
+        ? authorization.slice(7) : '';
+      const authenticated = await runner.authenticateApiKey(apiKey);
+      if (!authenticated.ok || authenticated.data.principal.kind !== 'external') {
+        reject(response);
+        return;
+      }
+      const principal = authenticated.data.principal;
+      request.auth = {
+        token: 'managed-api-key',
+        clientId: `api-key:${authenticated.data.keyId}`,
+        scopes,
+        extra: { principal, apiKeyId: authenticated.data.keyId }
       };
       next();
     } catch {

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -7,6 +7,8 @@ function secret(name: string): string | undefined {
   return process.env[name];
 }
 
+const environment = (name: string): string | undefined => process.env[name];
+
 const csv = (value: string | undefined, fallback = '') => (value ?? fallback).split(',').map((entry) => entry.trim()).filter(Boolean);
 
 export function loadApiConfig(): ApiConfig {
@@ -25,5 +27,9 @@ export function loadApiConfig(): ApiConfig {
     allowedOrigins: csv(process.env.API_ALLOWED_ORIGINS),
     requestTimeoutMs: process.env.REQUEST_TIMEOUT_MS,
     maxBodyBytes: process.env.MAX_BODY_BYTES
+    ,apiKeyAuthEnabled: environment('API_KEY_AUTH_ENABLED'),
+    apiKeyGatewayAccessAudience: environment('API_KEY_GATEWAY_ACCESS_AUDIENCE'),
+    apiKeyGatewayServiceSubject: environment('API_KEY_GATEWAY_SERVICE_SUBJECT'),
+    apiKeyGatewayPublicUrl: environment('API_KEY_GATEWAY_PUBLIC_URL')
   });
 }

--- a/apps/api/src/dashboard-assets.ts
+++ b/apps/api/src/dashboard-assets.ts
@@ -20,6 +20,7 @@ export function createDashboardAssetsRouter(): Router {
     '/artifacts',
     '/audit',
     '/github',
+    '/api-keys',
   ], (_request, response) => response.sendFile('index.html', options));
   return router;
 }

--- a/apps/api/src/dashboard-control-router.ts
+++ b/apps/api/src/dashboard-control-router.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Response, Router } from 'express';
-import type { MetadataRunnerOperation, RunnerPrincipalSelector } from '@cloud-harness/contracts';
+import { ApiKeyManagementResponseSchema, type ApiConfig, type ApiKeyManagementOperation, type MetadataRunnerOperation, type RunnerPrincipalSelector } from '@cloud-harness/contracts';
 import { z } from 'zod';
 import { sendRunnerResponse } from './dashboard-response.js';
 import type { DashboardRequest, DashboardRunnerClient } from './dashboard-types.js';
@@ -11,7 +11,8 @@ const createName = z.object({ name: z.string().trim().min(1).max(100), expectedG
 export function registerDashboardControlRoutes(
   router: Router,
   runner: DashboardRunnerClient,
-  principal: (request: DashboardRequest, response: Response) => RunnerPrincipalSelector | undefined
+  principal: (request: DashboardRequest, response: Response) => RunnerPrincipalSelector | undefined,
+  config?: ApiConfig
 ): void {
   router.get('/api/v1/projects', endpoint('project_list', () => ({})));
   router.post('/api/v1/projects', endpoint('project_create', (request) => createName.parse(request.body)));
@@ -33,6 +34,13 @@ export function registerDashboardControlRoutes(
   router.post('/api/v1/github/setup', endpoint('github_setup_begin', (request) => request.body as Record<string, unknown>));
   router.post('/api/v1/github/complete', endpoint('github_setup_complete', (request) => request.body as Record<string, unknown>));
   router.post('/api/v1/github/reconcile', endpoint('github_reconcile', () => ({})));
+  router.get('/api/v1/api-keys', apiKeyEndpoint('api_key_list', () => ({})));
+  router.post('/api/v1/api-keys', apiKeyEndpoint('api_key_create', (request) => z.object({
+    name: z.string().trim().min(1).max(100), expiresInDays: z.number().int().min(1).max(365)
+  }).strict().parse(request.body)));
+  router.delete('/api/v1/api-keys/:keyId', apiKeyEndpoint('api_key_revoke', (request) => ({
+    keyId: internalId('apk').parse(request.params.keyId), ...generation.parse(request.body)
+  })));
 
   function endpoint(operation: MetadataRunnerOperation, input: (request: DashboardRequest) => Record<string, unknown>) {
     return async (request: DashboardRequest, response: Response, next: NextFunction): Promise<void> => {
@@ -41,6 +49,41 @@ export function registerDashboardControlRoutes(
         if (!selected) return;
         if (!runner.callInternal) throw new Error('dashboard controls are unavailable');
         sendRunnerResponse(response, operation, await runner.callInternal(operation, input(request), selected));
+      } catch (error) { next(error); }
+    };
+  }
+
+  function apiKeyEndpoint(operation: ApiKeyManagementOperation, input: (request: DashboardRequest) => Record<string, unknown>) {
+    return async (request: DashboardRequest, response: Response, next: NextFunction): Promise<void> => {
+      try {
+        const selected = principal(request, response);
+        if (!selected) return;
+        if (!runner.callApiKeys) {
+          response.status(503).json({ error: 'unavailable', message: 'API key authentication is not enabled.' });
+          return;
+        }
+        if (!config?.apiKeyAuthEnabled && operation === 'api_key_create') {
+          response.status(503).json({ error: 'unavailable', message: 'API key authentication is not enabled.' });
+          return;
+        }
+        const result = ApiKeyManagementResponseSchema.parse(await runner.callApiKeys(operation, input(request), selected));
+        if (!result.ok) {
+          const status = result.error.code === 'CONFLICT' ? 409 : result.error.code === 'LIMIT_EXCEEDED' ? 429 : 503;
+          response.status(status).json({ error: result.error.code.toLowerCase(), message: status === 409 ? 'This API key changed after you opened it.' : result.message });
+          return;
+        }
+        if (result.operation === 'api_key_list') {
+          response.json({ data: {
+            keys: result.data.keys,
+            readiness: config?.apiKeyAuthEnabled
+              ? { ready: true, publicUrl: config.apiKeyGatewayPublicUrl }
+              : { ready: false }
+          } });
+        } else if (result.operation === 'api_key_create') {
+          response.json({ data: { key: result.data.key, apiKey: result.data.apiKey } });
+        } else {
+          response.json({ data: { key: result.data.key } });
+        }
       } catch (error) { next(error); }
     };
   }

--- a/apps/api/src/dashboard-router.ts
+++ b/apps/api/src/dashboard-router.ts
@@ -41,7 +41,7 @@ export function createDashboardRouter(config: ApiConfig, runner: DashboardRunner
     if (!['GET', 'HEAD', 'OPTIONS'].includes(request.method)) sessions.verify(request as DashboardRequest, response, next);
     else next();
   });
-  registerDashboardControlRoutes(router, runner, principal);
+  registerDashboardControlRoutes(router, runner, principal, config);
 
   router.get('/api/v1/workspaces', async (request: DashboardRequest, response, next) => {
     await call(runner, request, response, next, 'workspace_list', pageQuery.parse(request.query));

--- a/apps/api/src/dashboard-types.ts
+++ b/apps/api/src/dashboard-types.ts
@@ -1,6 +1,6 @@
 import type { Request } from 'express';
 import type { AuthInfo } from '@modelcontextprotocol/server';
-import type { InternalRunnerOperation, MetadataRunnerOperation, RunnerOperation, RunnerPrincipalSelector, RunnerResponse } from '@cloud-harness/contracts';
+import type { ApiKeyManagementOperation, ApiKeyManagementResponse, InternalRunnerOperation, MetadataRunnerOperation, RunnerOperation, RunnerPrincipalSelector, RunnerResponse } from '@cloud-harness/contracts';
 
 export type DashboardRequest = Request & { auth?: AuthInfo };
 
@@ -23,4 +23,9 @@ export interface DashboardRunnerClient {
     principal: RunnerPrincipalSelector,
     signal?: AbortSignal
   ): Promise<RunnerResponse>;
+  callApiKeys?(
+    operation: ApiKeyManagementOperation,
+    input: Record<string, unknown>,
+    principal: RunnerPrincipalSelector
+  ): Promise<ApiKeyManagementResponse>;
 }

--- a/apps/api/src/runner-client.ts
+++ b/apps/api/src/runner-client.ts
@@ -2,9 +2,16 @@ import {
   InternalRunnerRequestSchema,
   InternalRunnerResponseSchema,
   MetadataRunnerRequestSchema,
+  ApiKeyAuthenticationRequestSchema,
+  ApiKeyAuthenticationResponseSchema,
+  ApiKeyManagementRequestSchema,
+  ApiKeyManagementResponseSchema,
   RunnerRequestSchema,
   RunnerResponseSchema,
   type ApiConfig,
+  type ApiKeyAuthenticationResponse,
+  type ApiKeyManagementOperation,
+  type ApiKeyManagementResponse,
   type InternalRunnerOperation,
   type MetadataRunnerOperation,
   type RunnerOperation,
@@ -31,12 +38,42 @@ export class RunnerClient {
     return await this.callInternal('workspace_close_fenced', { workspaceId, expectedGeneration }, principal, signal);
   }
 
+  async callApiKeys(operation: ApiKeyManagementOperation, input: Record<string, unknown>, principal: RunnerPrincipalSelector): Promise<ApiKeyManagementResponse> {
+    const request = ApiKeyManagementRequestSchema.parse({ version: 1, principal, operation, input });
+    return await this.requestJson('/v1/internal/api-keys', request, ApiKeyManagementResponseSchema, () => ({
+      ok: false, message: 'Runner is unavailable',
+      error: { code: 'UNAVAILABLE', message: 'Runner is unavailable', retryable: true }, truncated: false
+    }));
+  }
+
+  async authenticateApiKey(apiKey: string): Promise<ApiKeyAuthenticationResponse> {
+    const request = ApiKeyAuthenticationRequestSchema.safeParse({ version: 1, apiKey });
+    if (!request.success) return { ok: false, error: 'authentication_failed' };
+    return await this.requestJson('/v1/internal/api-keys', request.data, ApiKeyAuthenticationResponseSchema, () => ({
+      ok: false, error: 'authentication_failed'
+    }));
+  }
+
   private async request(
     path: string,
     body: unknown,
     schema: typeof RunnerResponseSchema,
     signal?: AbortSignal
   ): Promise<RunnerResponse> {
+    return await this.requestJson(path, body, schema, (error) => {
+      const timedOut = error instanceof Error && error.name === 'TimeoutError';
+      const message = timedOut ? 'Runner request timed out' : 'Runner is unavailable';
+      return { ok: false, message, error: { code: timedOut ? 'TIMEOUT' : 'UNAVAILABLE', message, retryable: true }, truncated: false };
+    }, signal);
+  }
+
+  private async requestJson<T>(
+    path: string,
+    body: unknown,
+    schema: { parse(value: unknown): T },
+    fallback: (error: unknown) => T,
+    signal?: AbortSignal
+  ): Promise<T> {
     const timeout = AbortSignal.timeout(this.config.requestTimeoutMs);
     const combined = signal ? AbortSignal.any([signal, timeout]) : timeout;
     try {
@@ -49,8 +86,7 @@ export class RunnerClient {
       const responseBody: unknown = await response.json();
       return schema.parse(responseBody);
     } catch (error) {
-      const message = error instanceof Error && error.name === 'TimeoutError' ? 'Runner request timed out' : 'Runner is unavailable';
-      return { ok: false, message, error: { code: error instanceof Error && error.name === 'TimeoutError' ? 'TIMEOUT' : 'UNAVAILABLE', message, retryable: true }, truncated: false };
+      return fallback(error);
     }
   }
 

--- a/apps/api/test/api-key-gateway-auth.test.ts
+++ b/apps/api/test/api-key-gateway-auth.test.ts
@@ -1,0 +1,125 @@
+import { generateKeyPairSync, sign } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiConfig } from '@cloud-harness/contracts';
+import { apiKeyGatewayAuth, bearerAuth } from '../src/auth.js';
+
+const issuer = 'https://team.cloudflareaccess.com';
+const mainAudience = 'main-app';
+const gatewayAudience = 'gateway-app';
+const jwksUrl = `${issuer}/cdn-cgi/access/certs`;
+const now = 1_800_000_000_000;
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const kid = 'gateway-key';
+const jwk = { ...publicKey.export({ format: 'jwk' }), kid, alg: 'RS256', use: 'sig' };
+const commonName = 'worker-service-client-id';
+const gatewaySubject = `cf-service:${Buffer.from(commonName).toString('base64url')}`;
+
+function jwt(audience: string, service = true): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', kid })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({
+    iss: issuer, aud: [audience], type: 'app', sub: service ? '' : 'human-subject',
+    ...(service ? { common_name: commonName } : { nbf: Math.floor(now / 1_000) - 1 }),
+    exp: Math.floor(now / 1_000) + 60
+  })).toString('base64url');
+  return `${header}.${payload}.${sign('RSA-SHA256', Buffer.from(`${header}.${payload}`), privateKey).toString('base64url')}`;
+}
+
+const config: ApiConfig = {
+  host: '127.0.0.1', port: 3000, authMode: 'cloudflare-access', ownerId: 'owner',
+  accessIssuer: issuer, accessAudience: mainAudience, accessJwksUrl: jwksUrl,
+  apiKeyAuthEnabled: true, apiKeyGatewayAccessAudience: gatewayAudience,
+  apiKeyGatewayServiceSubject: gatewaySubject, apiKeyGatewayPublicUrl: 'https://api.harness.example/mcp',
+  runnerUrl: 'http://runner:3001', runnerToken: 'runner-token-that-is-longer-than-32-characters',
+  publicHosts: ['localhost'], allowedOrigins: [], requestTimeoutMs: 2_000, maxBodyBytes: 65_536
+};
+
+const verifier = {
+  fetcher: vi.fn(async () => new Response(JSON.stringify({ keys: [jwk] }), { status: 200 })),
+  now: () => now
+};
+
+function request(assertion: string, authorization = '') {
+  const headers: Record<string, string> = { 'cf-access-jwt-assertion': assertion, authorization };
+  return { header: (name: string) => headers[name.toLowerCase()] } as any;
+}
+
+function response() {
+  return { setHeader: vi.fn(), status: vi.fn(function (this: unknown) { return this; }), json: vi.fn() } as any;
+}
+
+describe('API-key gateway authentication boundary', () => {
+  it('requires gateway-audience service assertion and a valid managed key', async () => {
+    const runner = { authenticateApiKey: vi.fn(async () => ({
+      ok: true as const,
+      data: { principal: { kind: 'external' as const, issuer, subject: 'human-subject' }, keyId: `apk_${'a'.repeat(24)}` }
+    })) };
+    const middleware = apiKeyGatewayAuth(config, runner, verifier);
+    const current = request(jwt(gatewayAudience), `Bearer chm_key_apk_${'a'.repeat(24)}.${'b'.repeat(43)}`);
+    const reply = response(); const next = vi.fn();
+    await middleware(current, reply, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(current.auth.token).toBe('managed-api-key');
+    expect(current.auth.clientId).toBe(`api-key:apk_${'a'.repeat(24)}`);
+    expect(current.auth.extra.apiKeyId).toBe(`apk_${'a'.repeat(24)}`);
+    expect(JSON.stringify(current.auth)).not.toContain('chm_key_');
+  });
+
+  it('uses immutable credential IDs to isolate two keys owned by the same principal', async () => {
+    const runner = { authenticateApiKey: vi.fn()
+      .mockResolvedValueOnce({
+        ok: true as const,
+        data: { principal: { kind: 'external' as const, issuer, subject: 'human-subject' }, keyId: `apk_${'a'.repeat(24)}` }
+      })
+      .mockResolvedValueOnce({
+        ok: true as const,
+        data: { principal: { kind: 'external' as const, issuer, subject: 'human-subject' }, keyId: `apk_${'c'.repeat(24)}` }
+      }) };
+    const middleware = apiKeyGatewayAuth(config, runner, verifier);
+    const first = request(jwt(gatewayAudience), `Bearer chm_key_apk_${'a'.repeat(24)}.${'b'.repeat(43)}`);
+    const second = request(jwt(gatewayAudience), `Bearer chm_key_apk_${'c'.repeat(24)}.${'d'.repeat(43)}`);
+    await middleware(first, response(), vi.fn());
+    await middleware(second, response(), vi.fn());
+    expect(first.auth.clientId).toBe(`api-key:apk_${'a'.repeat(24)}`);
+    expect(second.auth.clientId).toBe(`api-key:apk_${'c'.repeat(24)}`);
+    expect(first.auth.extra.principal).toEqual(second.auth.extra.principal);
+  });
+
+  it.each([
+    ['human assertion', jwt(gatewayAudience, false)],
+    ['main application audience', jwt(mainAudience)]
+  ])('rejects %s before key verification', async (_name, assertion) => {
+    const runner = { authenticateApiKey: vi.fn() };
+    const middleware = apiKeyGatewayAuth(config, runner as any, verifier);
+    const reply = response(); const next = vi.fn();
+    await middleware(request(assertion, `Bearer chm_key_apk_${'a'.repeat(24)}.${'b'.repeat(43)}`), reply, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(runner.authenticateApiKey).not.toHaveBeenCalled();
+    expect(reply.status).toHaveBeenCalledWith(401);
+  });
+
+  it('rejects a missing key with the generic authentication response', async () => {
+    const runner = { authenticateApiKey: vi.fn(async () => ({ ok: false as const, error: 'authentication_failed' as const })) };
+    const middleware = apiKeyGatewayAuth(config, runner, verifier);
+    const reply = response(); const next = vi.fn();
+    await middleware(request(jwt(gatewayAudience)), reply, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(reply.status).toHaveBeenCalledWith(401);
+    expect(reply.json).toHaveBeenCalledWith({ error: 'authentication_failed' });
+  });
+
+  it('defensively rejects the reserved gateway subject on normal MCP auth', async () => {
+    const middleware = bearerAuth(config, verifier);
+    const reply = response(); const next = vi.fn();
+    await middleware(request(jwt(mainAudience)), reply, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(reply.status).toHaveBeenCalledWith(401);
+  });
+
+  it('rejects a managed key on the normal MCP lane even with a human assertion', async () => {
+    const middleware = bearerAuth(config, verifier);
+    const reply = response(); const next = vi.fn();
+    await middleware(request(jwt(mainAudience, false), `Bearer chm_key_apk_${'a'.repeat(24)}.${'b'.repeat(43)}`), reply, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(reply.status).toHaveBeenCalledWith(401);
+  });
+});

--- a/apps/api/test/dashboard-app-mount.test.ts
+++ b/apps/api/test/dashboard-app-mount.test.ts
@@ -34,7 +34,7 @@ describe('dashboard application mount', () => {
     await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
     const address = server.address();
     if (!address || typeof address === 'string') throw new Error('test server failed');
-    for (const path of ['/projects', '/projects/prj_abcdefghijklmnopqrst', '/artifacts', '/audit', '/github']) {
+    for (const path of ['/projects', '/projects/prj_abcdefghijklmnopqrst', '/artifacts', '/audit', '/github', '/api-keys']) {
       const response = await fetch(`http://127.0.0.1:${address.port}/dashboard${path}`);
       expect(response.status, path).toBe(200);
       expect(await response.text(), path).toContain('<title>Workspaces | Cloud Harness</title>');

--- a/apps/api/test/dashboard-router.test.ts
+++ b/apps/api/test/dashboard-router.test.ts
@@ -12,6 +12,8 @@ const config: ApiConfig = {
   host: '127.0.0.1', port: 3000, authMode: 'cloudflare-access', ownerId: 'owner',
   accessIssuer: 'https://team.cloudflareaccess.com', accessAudience: 'audience',
   accessJwksUrl: 'https://team.cloudflareaccess.com/cdn-cgi/access/certs', runnerUrl: 'http://runner:3001',
+  apiKeyAuthEnabled: true, apiKeyGatewayAccessAudience: 'api-key-audience',
+  apiKeyGatewayServiceSubject: 'cf-service:d29ya2Vy', apiKeyGatewayPublicUrl: 'https://api.example/mcp',
   runnerToken: 'runner-token-that-is-longer-than-32-characters', publicHosts: ['dashboard.example'],
   allowedOrigins: ['https://dashboard.example'], requestTimeoutMs: 2_000, maxBodyBytes: 65_536
 };
@@ -41,6 +43,12 @@ beforeEach(async () => {
         workspaceId, repositoryUrl: 'https://github.com/example/project.git', status: 'ACTIVE', networkMode: 'none', generation: 7,
         createdAt: '2026-08-17T00:00:00.000Z', lastActivityAt: '2026-08-17T00:01:00.000Z', expiresAt: '2026-08-17T00:10:00.000Z'
       } };
+    }),
+    callApiKeys: vi.fn(async (operation) => {
+      const key = { id: `apk_${'k'.repeat(24)}`, name: 'CLI', displayPrefix: 'chm_key_apk_kkkk…', state: 'ACTIVE' as const, generation: 1, createdAt: 1, expiresAt: 2, lastUsedAt: null, revokedAt: null };
+      if (operation === 'api_key_list') return { ok: true as const, operation, data: { keys: [key] }, truncated: false as const };
+      if (operation === 'api_key_create') return { ok: true as const, operation, data: { key, apiKey: `chm_key_apk_${'k'.repeat(24)}.${'s'.repeat(43)}` }, truncated: false as const };
+      return { ok: true as const, operation, data: { key: { ...key, state: 'REVOKED' as const, generation: 2, revokedAt: 2 } }, truncated: false as const };
     })
   };
   const app = express();
@@ -140,5 +148,25 @@ describe('dashboard BFF', () => {
     });
     expect(response.status).toBe(503);
     expect(calls.some((call) => call.operation === 'workspace_close')).toBe(false);
+  });
+
+  it('lists safe key metadata and requires CSRF for one-time create and revoke', async () => {
+    const listed = await send('/api/v1/api-keys');
+    expect(listed.status).toBe(200);
+    expect(listed.json.data.readiness).toEqual({ ready: true, publicUrl: 'https://api.example/mcp' });
+    expect(listed.text).not.toContain('chm_key_apk_kkkkkkkkkkkkkkkkkkkkkkkk.s');
+
+    const session = await send('/api/v1/session');
+    const cookie = String(session.headers['set-cookie']?.[0]).split(';', 1)[0];
+    const headers = { origin: 'https://dashboard.example', cookie, 'content-type': 'application/json', 'x-csrf-token': session.json.csrfToken };
+    const created = await send('/api/v1/api-keys', { method: 'POST', headers, body: JSON.stringify({ name: 'CLI', expiresInDays: 30 }) });
+    expect(created.status).toBe(200);
+    expect(created.json.data.apiKey).toMatch(/^chm_key_/);
+    const revokeBody = JSON.stringify({ expectedGeneration: 1 });
+    const revoked = await send(`/api/v1/api-keys/apk_${'k'.repeat(24)}`, {
+      method: 'DELETE', headers: { ...headers, 'content-length': String(Buffer.byteLength(revokeBody)) }, body: revokeBody
+    });
+    expect(revoked.status).toBe(200);
+    expect(revoked.text).not.toContain('.ssss');
   });
 });

--- a/apps/api/test/dashboard-ui-behavior.test.ts
+++ b/apps/api/test/dashboard-ui-behavior.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-  conflictRecovery, createAsyncDialogController, createModalController, githubCallbackParameters,
+  apiKeyCreateInput, conflictRecovery, createApiKeyRevealController, createAsyncDialogController, createModalController, githubCallbackParameters,
   renderWorkspaceDrawer, resetWriteOnlyFields, submitPatchEdit, submitPatchForm
 } from '../dashboard/dashboard.js';
-import { renderProjectDetail } from '../dashboard/dashboard-render.js';
+import { renderApiKeyIndex, renderProjectDetail } from '../dashboard/dashboard-render.js';
 
 class FakeElement {
   hidden = false;
@@ -11,6 +11,7 @@ class FakeElement {
   disabled = false;
   open = false;
   textContent = '';
+  value = '';
   items: FakeElement[] = [];
   focus = vi.fn();
   private readonly attributes = new Map<string, string>();
@@ -198,5 +199,69 @@ describe('dashboard UI behavior', () => {
     expect(html).toContain('Write-only');
     expect(html).not.toContain('must-not-render');
     expect(html).not.toContain('value="DEPLOY_TOKEN"');
+  });
+
+  it('validates and normalizes API-key creation input without retaining it', () => {
+    class FakeFormData {
+      get(name: string) { return name === 'name' ? '  CI client  ' : '30'; }
+    }
+    vi.stubGlobal('FormData', FakeFormData);
+    try { expect(apiKeyCreateInput({})).toEqual({ name: 'CI client', expiresInDays: 30 }); }
+    finally { vi.unstubAllGlobals(); }
+  });
+
+  it('reveals an API key once, copies it, then clears DOM and JS state on acknowledgement', async () => {
+    const dialog = new FakeElement(); const secretField = new FakeElement(); const copyButton = new FakeElement();
+    const acknowledgeButton = new FakeElement(); const status = new FakeElement(); const invoker = new FakeElement();
+    const clipboard = { writeText: vi.fn().mockResolvedValue(undefined) }; const reportError = vi.fn();
+    const reveal = createApiKeyRevealController({ dialog, secretField, copyButton, acknowledgeButton, status, clipboard, reportError });
+    const key = `chm_key_apk_${'a'.repeat(24)}.${'b'.repeat(43)}`;
+
+    expect(() => reveal.open('not-an-api-key', invoker)).toThrow('unavailable');
+    expect(secretField.value).toBe('');
+    reveal.open(key, invoker); await reveal.copy();
+    expect(secretField.value).toBe(key);
+    expect(clipboard.writeText).toHaveBeenCalledWith(key);
+    expect(status.textContent).toContain('copied');
+    acknowledgeButton.dispatch('click', {});
+    expect(secretField.value).toBe('');
+    expect(dialog.open).toBe(false);
+    expect(invoker.focus).toHaveBeenCalledOnce();
+    await reveal.copy();
+    expect(clipboard.writeText).toHaveBeenCalledOnce();
+    reveal.open(key, invoker); reveal.clear();
+    expect(secretField.value).toBe('');
+    expect(dialog.open).toBe(false);
+  });
+
+  it('clears the only API-key copy after clipboard failure and reports no secret', async () => {
+    const dialog = new FakeElement(); const secretField = new FakeElement(); const copyButton = new FakeElement();
+    const acknowledgeButton = new FakeElement(); const status = new FakeElement(); const invoker = new FakeElement();
+    const clipboard = { writeText: vi.fn().mockRejectedValue(new Error('denied')) }; const reportError = vi.fn();
+    const reveal = createApiKeyRevealController({ dialog, secretField, copyButton, acknowledgeButton, status, clipboard, reportError });
+    const key = `chm_key_apk_${'c'.repeat(24)}.${'d'.repeat(43)}`;
+
+    reveal.open(key, invoker); await reveal.copy();
+    expect(secretField.value).toBe('');
+    expect(dialog.open).toBe(false);
+    expect(reportError).toHaveBeenCalledOnce();
+    expect(reportError.mock.calls[0][0].message).not.toContain(key);
+    await reveal.copy();
+    expect(clipboard.writeText).toHaveBeenCalledOnce();
+  });
+
+  it('renders only safe API-key metadata and a generation-fenced revoke action', () => {
+    const raw = `chm_key_apk_${'e'.repeat(24)}.${'f'.repeat(43)}`;
+    const html = renderApiKeyIndex({ publicUrl: 'https://api.example/mcp', keys: [{
+      id: `apk_${'e'.repeat(24)}`, name: 'Automation', displayPrefix: 'chm_key_apk_eeee…', state: 'ACTIVE', generation: 3,
+      createdAt: 1_786_000_000_000, expiresAt: 1_787_000_000_000, lastUsedAt: null, revokedAt: null,
+      apiKey: raw, secretHash: 'must-not-render'
+    }] });
+    expect(html).toContain('Automation');
+    expect(html).toContain('https://api.example/mcp');
+    expect(html).toContain('chm_key_apk_eeee…');
+    expect(html).toContain('data-generation="3"');
+    expect(html).not.toContain(raw);
+    expect(html).not.toContain('must-not-render');
   });
 });

--- a/apps/api/test/dashboard-ui-contract.test.ts
+++ b/apps/api/test/dashboard-ui-contract.test.ts
@@ -43,7 +43,7 @@ describe('dashboard static UI contract', () => {
   it('exposes accessible metadata navigation and only existing dashboard BFF controls', () => {
     for (const [path, label] of [
       ['/dashboard/projects', 'Projects'], ['/dashboard/artifacts', 'Artifacts'],
-      ['/dashboard/audit', 'Audit'], ['/dashboard/github', 'GitHub']
+      ['/dashboard/audit', 'Audit'], ['/dashboard/api-keys', 'API keys'], ['/dashboard/github', 'GitHub']
     ]) {
       expect(html).toContain(`href="${path}"`);
       expect(html).toContain(`>${label}</a>`);
@@ -56,5 +56,18 @@ describe('dashboard static UI contract', () => {
     expect(script).toContain('retentionSeconds');
     expect(script).toContain('Write-only');
     for (const forbidden of ['sessionStorage', 'document.cookie', 'secret.value', 'secretValue', 'privateKey', 'accessToken']) expect(script).not.toContain(forbidden);
+  });
+
+  it('keeps API keys transient while exposing create, list, and generation-fenced revoke controls', () => {
+    for (const text of [
+      'id="api-key-reveal-dialog"', 'This is the only time the complete key will be shown',
+      'full MCP access', 'arbitrary command execution', 'I have saved it'
+    ]) expect(html).toContain(text);
+    for (const contract of [
+      "api('/api-keys')", "api('/api-keys', { method: 'POST'", '`/api-keys/${',
+      "method: 'DELETE'", 'expiresInDays', 'expectedGeneration', 'apiKeyReveal.clear()'
+    ]) expect(script).toContain(contract);
+    for (const forbidden of ['localStorage', 'sessionStorage', 'document.cookie', 'console.', 'sendBeacon(', 'analytics']) expect(script).not.toContain(forbidden);
+    expect(html).not.toContain('value="chm_key_');
   });
 });

--- a/apps/runner/package.json
+++ b/apps/runner/package.json
@@ -7,6 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "dev": "node --watch --experimental-strip-types src/index.ts",
+    "metadata:down:v1": "node dist/metadata-schema-down.js",
     "secrets:rekey": "node dist/rekey-secrets.js",
     "start": "node dist/index.js",
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/apps/runner/src/api-key-service.ts
+++ b/apps/runner/src/api-key-service.ts
@@ -1,0 +1,52 @@
+import {
+  ApiKeyAuthenticationRequestSchema,
+  ApiKeyManagementRequestSchema,
+  HarnessError,
+  type ApiKeyAuthenticationResponse,
+  type ApiKeyManagementRequest,
+  type ApiKeyManagementResponse
+} from '@cloud-harness/contracts';
+import type { ApiKeyStore } from './api-key-store.js';
+import type { StateStore } from './state-store.js';
+
+export class ApiKeyService {
+  constructor(private readonly principals: StateStore, private readonly keys: ApiKeyStore) {}
+
+  manage(request: unknown): ApiKeyManagementResponse {
+    const parsed = ApiKeyManagementRequestSchema.parse(request);
+    const principalId = this.principals.resolvePrincipal(parsed.principal);
+    try {
+      return this.executeManagement(principalId, parsed);
+    } catch (error) {
+      if (error instanceof HarnessError) throw error;
+      const message = error instanceof Error ? error.message : '';
+      if (message === 'active API key limit reached') {
+        throw new HarnessError('LIMIT_EXCEEDED', 'active API key limit reached', 429, false);
+      }
+      throw error;
+    }
+  }
+
+  authenticate(request: unknown): ApiKeyAuthenticationResponse {
+    const parsed = ApiKeyAuthenticationRequestSchema.safeParse(request);
+    if (!parsed.success) return { ok: false, error: 'authentication_failed' };
+    const verified = this.keys.verify(parsed.data.apiKey);
+    return verified ? { ok: true, data: verified } : { ok: false, error: 'authentication_failed' };
+  }
+
+  private executeManagement(principalId: string, request: ApiKeyManagementRequest): ApiKeyManagementResponse {
+    switch (request.operation) {
+      case 'api_key_list':
+        return { ok: true, operation: request.operation, data: { keys: this.keys.list(principalId) }, truncated: false };
+      case 'api_key_create': {
+        const created = this.keys.create(principalId, request.input.name, request.input.expiresInDays);
+        return { ok: true, operation: request.operation, data: created, truncated: false };
+      }
+      case 'api_key_revoke': {
+        const key = this.keys.revoke(principalId, request.input.keyId, request.input.expectedGeneration);
+        if (!key) throw new HarnessError('CONFLICT', 'resource generation changed or resource is unavailable', 409, false);
+        return { ok: true, operation: request.operation, data: { key }, truncated: false };
+      }
+    }
+  }
+}

--- a/apps/runner/src/api-key-store.ts
+++ b/apps/runner/src/api-key-store.ts
@@ -1,0 +1,147 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import type { DatabaseSync } from 'node:sqlite';
+import { ApiKeyValueSchema, type ApiKeyMetadata, type RunnerPrincipalSelector } from '@cloud-harness/contracts';
+
+type ApiKeyRow = {
+  id: string; principal_id: string; name: string; display_prefix: string; secret_hash: Uint8Array;
+  state: 'ACTIVE' | 'REVOKED'; generation: number; created_at: number; expires_at: number;
+  last_used_at: number | null; revoked_at: number | null;
+};
+
+const DAY_MS = 86_400_000;
+const USAGE_INTERVAL_MS = 300_000;
+const MAX_ACTIVE_KEYS = 10;
+type RandomBytes = (size: number) => Buffer;
+
+const digest = (secret: string): Buffer => createHash('sha256').update(secret, 'utf8').digest();
+
+function transaction<T>(database: DatabaseSync, action: () => T): T {
+  database.exec('BEGIN IMMEDIATE');
+  try {
+    const value = action();
+    database.exec('COMMIT');
+    return value;
+  } catch (error) {
+    database.exec('ROLLBACK');
+    throw error;
+  }
+}
+
+function view(row: ApiKeyRow, now = Date.now()): ApiKeyMetadata {
+  return {
+    id: row.id,
+    name: row.name,
+    displayPrefix: row.display_prefix,
+    state: row.state === 'REVOKED' ? 'REVOKED' : row.expires_at <= now ? 'EXPIRED' : 'ACTIVE',
+    generation: row.generation,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    lastUsedAt: row.last_used_at,
+    revokedAt: row.revoked_at
+  };
+}
+
+export type ApiKeyAudit = (
+  database: DatabaseSync,
+  principalId: string,
+  action: string,
+  key: ApiKeyMetadata
+) => void;
+
+export class ApiKeyStore {
+  constructor(
+    private readonly database: DatabaseSync,
+    private readonly audit: ApiKeyAudit,
+    private readonly now = Date.now,
+    private readonly random: RandomBytes = randomBytes
+  ) {}
+
+  list(principalId: string): ApiKeyMetadata[] {
+    const now = this.now();
+    return (this.database.prepare('SELECT * FROM api_keys WHERE principal_id = ? ORDER BY created_at DESC, id').all(principalId) as ApiKeyRow[])
+      .map((row) => view(row, now));
+  }
+
+  create(principalId: string, name: string, expiresInDays: number): { key: ApiKeyMetadata; apiKey: string } {
+    const normalizedName = name.trim();
+    if (!normalizedName || normalizedName.length > 100 || !Number.isInteger(expiresInDays) || expiresInDays < 1 || expiresInDays > 365) {
+      throw new Error('invalid API key request');
+    }
+    return transaction(this.database, () => {
+      const now = this.now();
+      const active = this.database.prepare("SELECT COUNT(*) AS count FROM api_keys WHERE principal_id = ? AND state = 'ACTIVE' AND expires_at > ?")
+        .get(principalId, now) as { count: number };
+      if (active.count >= MAX_ACTIVE_KEYS) throw new Error('active API key limit reached');
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const id = `apk_${this.random(18).toString('base64url')}`;
+        const secret = this.random(32).toString('base64url');
+        const apiKey = `chm_key_${id}.${secret}`;
+        const expiresAt = now + expiresInDays * DAY_MS;
+        const displayPrefix = `chm_key_${id.slice(0, 12)}…`;
+        try {
+          this.database.prepare(`INSERT INTO api_keys
+            (id, principal_id, name, display_prefix, secret_hash, state, generation, created_at, expires_at, last_used_at, revoked_at)
+            VALUES (?, ?, ?, ?, ?, 'ACTIVE', 1, ?, ?, NULL, NULL)`)
+            .run(id, principalId, normalizedName, displayPrefix, digest(secret), now, expiresAt);
+          const key = this.byOwner(principalId, id, now)!;
+          this.audit(this.database, principalId, 'api_key.created', key);
+          return { key, apiKey };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '';
+          if (!message.includes('UNIQUE constraint failed') || attempt === 4) throw error;
+        }
+      }
+      throw new Error('unable to allocate API key identity');
+    });
+  }
+
+  revoke(principalId: string, keyId: string, expectedGeneration: number): ApiKeyMetadata | undefined {
+    return transaction(this.database, () => {
+      const now = this.now();
+      const result = this.database.prepare(`UPDATE api_keys
+        SET state = 'REVOKED', generation = generation + 1, revoked_at = ?
+        WHERE principal_id = ? AND id = ? AND generation = ? AND state = 'ACTIVE'`)
+        .run(now, principalId, keyId, expectedGeneration);
+      if (result.changes !== 1) return undefined;
+      const key = this.byOwner(principalId, keyId, now)!;
+      this.audit(this.database, principalId, 'api_key.revoked', key);
+      return key;
+    });
+  }
+
+  verify(apiKey: string): { principal: RunnerPrincipalSelector; keyId: string } | undefined {
+    if (!ApiKeyValueSchema.safeParse(apiKey).success) return undefined;
+    const match = /^chm_key_(apk_[A-Za-z0-9_-]{24})\.([A-Za-z0-9_-]{43})$/.exec(apiKey);
+    if (!match) return undefined;
+    const [, keyId, secret] = match;
+    const row = this.database.prepare(`SELECT keys.*, principals.issuer, principals.subject, principals.email, principals.name AS principal_name
+      FROM api_keys keys JOIN principals ON principals.id = keys.principal_id WHERE keys.id = ?`).get(keyId!) as
+      (ApiKeyRow & { issuer: string; subject: string; email: string | null; principal_name: string | null }) | undefined;
+    const now = this.now();
+    if (!row || row.state !== 'ACTIVE' || row.expires_at <= now) return undefined;
+    const actual = digest(secret!);
+    const expected = Buffer.from(row.secret_hash);
+    if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) return undefined;
+    if (row.last_used_at === null || row.last_used_at <= now - USAGE_INTERVAL_MS) {
+      try {
+        this.database.prepare(`UPDATE api_keys SET last_used_at = ?
+          WHERE id = ? AND state = 'ACTIVE' AND expires_at > ? AND (last_used_at IS NULL OR last_used_at <= ?)`)
+          .run(now, row.id, now, now - USAGE_INTERVAL_MS);
+      } catch {
+        // Usage timestamps are non-authoritative telemetry; a write failure must not deny a verified key.
+      }
+    }
+    return {
+      keyId: row.id,
+      principal: {
+        kind: 'external', issuer: row.issuer, subject: row.subject,
+        ...(row.email ? { email: row.email } : {}), ...(row.principal_name ? { name: row.principal_name } : {})
+      }
+    };
+  }
+
+  private byOwner(principalId: string, keyId: string, now: number): ApiKeyMetadata | undefined {
+    const row = this.database.prepare('SELECT * FROM api_keys WHERE principal_id = ? AND id = ?').get(principalId, keyId) as ApiKeyRow | undefined;
+    return row ? view(row, now) : undefined;
+  }
+}

--- a/apps/runner/src/app.ts
+++ b/apps/runner/src/app.ts
@@ -7,10 +7,11 @@ import { executeInternalRunnerOperation } from './internal-runner-operations.js'
 import { runnerRequestPrincipal } from './runner-request-principal.js';
 import type { WorkspaceService } from './workspace-service.js';
 import type { DashboardControlService } from './dashboard-control-service.js';
+import type { ApiKeyService } from './api-key-service.js';
 
 const logger = pino({ level: process.env.LOG_LEVEL ?? 'info', redact: ['req.headers.authorization', 'authorization', '*.token', '*.content', '*.command'] });
 
-export function createRunnerApp(config: RunnerConfig, service: WorkspaceService, controls?: DashboardControlService): Express {
+export function createRunnerApp(config: RunnerConfig, service: WorkspaceService, controls?: DashboardControlService, apiKeys?: ApiKeyService): Express {
   const app = express();
   app.disable('x-powered-by');
   app.use(express.json({ limit: '1mb', strict: true }));
@@ -33,6 +34,23 @@ export function createRunnerApp(config: RunnerConfig, service: WorkspaceService,
     try {
       const result = await executeInternalRunnerOperation(service, request.body, controls);
       response.status(result.ok ? 200 : 400).json(result);
+    } catch (error) {
+      sendRunnerError(response, error);
+    }
+  });
+  app.post('/v1/internal/api-keys', serviceAuth(config.serviceToken), (request: Request, response: Response) => {
+    if (!apiKeys) {
+      response.status(503).json({ ok: false, message: 'API key service unavailable', error: { code: 'UNAVAILABLE', message: 'API key service unavailable', retryable: true }, truncated: false });
+      return;
+    }
+    try {
+      if (request.body && typeof request.body === 'object' && 'apiKey' in request.body) {
+        const result = apiKeys.authenticate(request.body);
+        response.status(result.ok ? 200 : 401).json(result);
+        return;
+      }
+      const result = apiKeys.manage(request.body);
+      response.status(200).json(result);
     } catch (error) {
       sendRunnerError(response, error);
     }

--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -2,6 +2,8 @@ import { createServer } from 'node:http';
 import pino from 'pino';
 import { createRunnerApp } from './app.js';
 import { ArtifactStore } from './artifact-store.js';
+import { ApiKeyService } from './api-key-service.js';
+import { ApiKeyStore } from './api-key-store.js';
 import { loadRunnerConfigWithReadiness } from './config.js';
 import { DashboardControlService } from './dashboard-control-service.js';
 import { GitHubApiInstallationVerifier } from './github-api-installation-verifier.js';
@@ -25,6 +27,12 @@ try {
   logger.error('secret operations disabled because the keyring configuration is invalid');
 }
 const metadata = new MetadataStore(config.stateDb, keyring, secretReadinessError);
+const apiKeyStore = new ApiKeyStore(store.database, (database, principalId, action, key) => {
+  metadata.recordAuditInTransaction(database, principalId, action, 'api_key', key.id, key.generation, {
+    expiresAt: key.expiresAt
+  });
+});
+const apiKeys = new ApiKeyService(store, apiKeyStore);
 const githubInstallations = new SqliteGitHubInstallationStore(store.database);
 const githubBinding = config.githubApp
   ? new GitHubBindingService(new GitHubSetupStateStore(store.database), githubInstallations, new GitHubApiInstallationVerifier(config.githubApp))
@@ -50,7 +58,7 @@ artifactReaper.unref();
 const service = new WorkspaceService(config, store, metadata, githubInstallations);
 const controls = new DashboardControlService(config, store, metadata, artifacts, service, githubInstallations, githubBinding);
 await service.start();
-const server = createServer(createRunnerApp(config, service, controls));
+const server = createServer(createRunnerApp(config, service, controls, apiKeys));
 server.listen(config.port, config.host, () => logger.info({ host: config.host, port: config.port }, 'runner listening'));
 
 async function shutdown(signal: string) {

--- a/apps/runner/src/metadata-schema-down.ts
+++ b/apps/runner/src/metadata-schema-down.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { downgradeMetadataSchemaToV1 } from './metadata-schema.js';
+
+const path = process.argv[2];
+if (!path) throw new Error('usage: metadata-schema-down <state-db-path>');
+const database = new DatabaseSync(resolve(path));
+try {
+  database.exec('PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;');
+  downgradeMetadataSchemaToV1(database);
+  process.stdout.write('metadata-schema-version=1\n');
+} finally {
+  database.close();
+}

--- a/apps/runner/src/metadata-schema.ts
+++ b/apps/runner/src/metadata-schema.ts
@@ -11,12 +11,11 @@ export function migrateMetadataSchema(database: DatabaseSync): void {
   database.exec('BEGIN IMMEDIATE');
   try {
     const row = database.prepare('SELECT version FROM metadata_schema_meta WHERE singleton = 1').get() as { version: number };
-    if (row.version === 1) {
+    if (row.version === 2) {
       database.exec('COMMIT');
       return;
     }
-    if (row.version !== 0) throw new Error(`unsupported metadata schema version ${row.version}`);
-    database.exec(`
+    if (row.version === 0) database.exec(`
       CREATE TABLE projects (
         id TEXT PRIMARY KEY,
         principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE RESTRICT,
@@ -90,6 +89,44 @@ export function migrateMetadataSchema(database: DatabaseSync): void {
         UNIQUE(principal_id, id)
       );
       CREATE INDEX audit_principal_created ON audit_events(principal_id, created_at DESC, id DESC);
+      UPDATE metadata_schema_meta SET version = 1 WHERE singleton = 1;
+    `);
+    const current = (database.prepare('SELECT version FROM metadata_schema_meta WHERE singleton = 1').get() as { version: number }).version;
+    if (current === 1) database.exec(`
+      CREATE TABLE api_keys (
+        id TEXT PRIMARY KEY,
+        principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE RESTRICT,
+        name TEXT NOT NULL,
+        display_prefix TEXT NOT NULL,
+        secret_hash BLOB NOT NULL UNIQUE,
+        state TEXT NOT NULL CHECK (state IN ('ACTIVE', 'REVOKED')),
+        generation INTEGER NOT NULL CHECK (generation > 0),
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL,
+        last_used_at INTEGER,
+        revoked_at INTEGER,
+        UNIQUE(principal_id, id)
+      );
+      CREATE INDEX api_keys_principal_created ON api_keys(principal_id, created_at DESC, id);
+      CREATE INDEX api_keys_active_expiry ON api_keys(principal_id, state, expires_at);
+      UPDATE metadata_schema_meta SET version = 2 WHERE singleton = 1;
+    `);
+    const migrated = (database.prepare('SELECT version FROM metadata_schema_meta WHERE singleton = 1').get() as { version: number }).version;
+    if (migrated !== 2) throw new Error(`unsupported metadata schema version ${migrated}`);
+    database.exec('COMMIT');
+  } catch (error) {
+    database.exec('ROLLBACK');
+    throw error;
+  }
+}
+
+export function downgradeMetadataSchemaToV1(database: DatabaseSync): void {
+  database.exec('BEGIN IMMEDIATE');
+  try {
+    const row = database.prepare('SELECT version FROM metadata_schema_meta WHERE singleton = 1').get() as { version: number } | undefined;
+    if (!row || row.version !== 2) throw new Error('metadata schema must be version 2 before downgrade');
+    database.exec(`
+      DROP TABLE api_keys;
       UPDATE metadata_schema_meta SET version = 1 WHERE singleton = 1;
     `);
     database.exec('COMMIT');

--- a/apps/runner/test/api-key-store.test.ts
+++ b/apps/runner/test/api-key-store.test.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ApiKeyStore } from '../src/api-key-store.js';
+import { MetadataStore } from '../src/metadata-store.js';
+import { downgradeMetadataSchemaToV1, migrateMetadataSchema } from '../src/metadata-schema.js';
+import { StateStore } from '../src/state-store.js';
+
+const directories: string[] = [];
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function fixture(now = 1_800_000_000_000) {
+  const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-api-keys-'));
+  directories.push(directory);
+  const path = join(directory, 'state.db');
+  const state = new StateStore(path);
+  const metadata = new MetadataStore(path);
+  const principal = { kind: 'external' as const, issuer: 'https://team.cloudflareaccess.com', subject: 'human-subject' };
+  const principalId = state.resolvePrincipal(principal);
+  let clock = now;
+  const keys = new ApiKeyStore(state.database, (database, owner, action, key) => {
+    metadata.recordAuditInTransaction(database, owner, action, 'api_key', key.id, key.generation, { expiresAt: key.expiresAt });
+  }, () => clock);
+  return { path, state, metadata, principal, principalId, keys, setNow: (value: number) => { clock = value; } };
+}
+
+describe('ApiKeyStore', () => {
+  it('reveals once, stores only a digest, resolves the durable principal, and revokes immediately', () => {
+    const value = fixture();
+    const created = value.keys.create(value.principalId, 'CLI', 30);
+    expect(created.apiKey).toMatch(/^chm_key_apk_[A-Za-z0-9_-]{24}\.[A-Za-z0-9_-]{43}$/);
+    expect(value.keys.list(value.principalId)).toEqual([created.key]);
+    expect(JSON.stringify(value.keys.list(value.principalId))).not.toContain(created.apiKey);
+    expect(value.keys.verify(created.apiKey)).toEqual({ principal: value.principal, keyId: created.key.id });
+
+    const stored = value.state.database.prepare('SELECT secret_hash, display_prefix FROM api_keys WHERE id = ?').get(created.key.id) as { secret_hash: Uint8Array; display_prefix: string };
+    expect(Buffer.from(stored.secret_hash)).toHaveLength(32);
+    expect(Buffer.from(stored.secret_hash).toString('utf8')).not.toContain(created.apiKey);
+    expect(stored.display_prefix).not.toContain(created.apiKey.split('.')[1]);
+    expect(readFileSync(value.path)).not.toContain(Buffer.from(created.apiKey));
+
+    const revoked = value.keys.revoke(value.principalId, created.key.id, 1);
+    expect(revoked?.state).toBe('REVOKED');
+    expect(value.keys.verify(created.apiKey)).toBeUndefined();
+    expect(value.metadata.listAudit(value.principalId).map((event) => event.action)).toEqual(['api_key.revoked', 'api_key.created']);
+    value.metadata.close(); value.state.close();
+  });
+
+  it('rejects malformed, unknown, altered, expired, and foreign revocation uniformly', () => {
+    const value = fixture();
+    const created = value.keys.create(value.principalId, 'Automation', 1);
+    expect(value.keys.verify('not-a-key')).toBeUndefined();
+    expect(value.keys.verify(`${created.apiKey.slice(0, -1)}A`)).toBeUndefined();
+    expect(value.keys.revoke('prn_foreign', created.key.id, 1)).toBeUndefined();
+    value.setNow(created.key.expiresAt);
+    expect(value.keys.verify(created.apiKey)).toBeUndefined();
+    expect(value.keys.list(value.principalId)[0]?.state).toBe('EXPIRED');
+    value.metadata.close(); value.state.close();
+  });
+
+  it('enforces ten active unexpired keys per principal', () => {
+    const value = fixture();
+    for (let index = 0; index < 10; index += 1) value.keys.create(value.principalId, `Key ${index}`, 30);
+    expect(() => value.keys.create(value.principalId, 'Eleventh', 30)).toThrow('active API key limit reached');
+    expect(value.keys.list(value.principalId)).toHaveLength(10);
+    value.metadata.close(); value.state.close();
+  });
+
+  it('serializes the active-key cap across independent SQLite connections', () => {
+    const value = fixture();
+    for (let index = 0; index < 9; index += 1) value.keys.create(value.principalId, `Key ${index}`, 30);
+    const secondState = new StateStore(value.path);
+    const secondKeys = new ApiKeyStore(secondState.database, () => undefined, () => 1_800_000_000_000);
+    value.keys.create(value.principalId, 'Tenth', 30);
+    expect(() => secondKeys.create(value.principalId, 'Eleventh', 30)).toThrow('active API key limit reached');
+    expect(secondKeys.list(value.principalId)).toHaveLength(10);
+    secondState.close(); value.metadata.close(); value.state.close();
+  });
+
+  it('retries an opaque key-ID collision without exposing the discarded secret', () => {
+    const value = fixture();
+    const sequence = [
+      Buffer.alloc(18, 1), Buffer.alloc(32, 2),
+      Buffer.alloc(18, 1), Buffer.alloc(32, 3),
+      Buffer.alloc(18, 4), Buffer.alloc(32, 5)
+    ];
+    const keys = new ApiKeyStore(value.state.database, () => undefined, () => 1_800_000_000_000, (size) => {
+      const next = sequence.shift();
+      if (!next || next.length !== size) throw new Error('unexpected random allocation');
+      return next;
+    });
+    const first = keys.create(value.principalId, 'First', 30);
+    const second = keys.create(value.principalId, 'Second', 30);
+    expect(second.key.id).not.toBe(first.key.id);
+    expect(keys.verify(second.apiKey)?.keyId).toBe(second.key.id);
+    expect(keys.list(value.principalId)).toHaveLength(2);
+    value.metadata.close(); value.state.close();
+  });
+
+  it('coalesces last-used writes across connections without using them for authorization', () => {
+    const value = fixture();
+    const created = value.keys.create(value.principalId, 'Usage', 30);
+    expect(value.keys.verify(created.apiKey)?.keyId).toBe(created.key.id);
+    const firstUsed = value.keys.list(value.principalId)[0]?.lastUsedAt;
+    value.setNow(1_800_000_299_999);
+    expect(value.keys.verify(created.apiKey)?.keyId).toBe(created.key.id);
+    expect(value.keys.list(value.principalId)[0]?.lastUsedAt).toBe(firstUsed);
+    const secondState = new StateStore(value.path);
+    const secondKeys = new ApiKeyStore(secondState.database, () => undefined, () => 1_800_000_300_000);
+    expect(secondKeys.verify(created.apiKey)?.keyId).toBe(created.key.id);
+    expect(secondKeys.list(value.principalId)[0]?.lastUsedAt).toBe(1_800_000_300_000);
+    secondState.close(); value.metadata.close(); value.state.close();
+  });
+
+  it('authenticates when only the non-authoritative usage write fails', () => {
+    const value = fixture();
+    const created = value.keys.create(value.principalId, 'Telemetry failure', 30);
+    value.state.database.exec(`CREATE TRIGGER reject_api_key_usage_update
+      BEFORE UPDATE OF last_used_at ON api_keys
+      BEGIN SELECT RAISE(ABORT, 'usage telemetry unavailable'); END`);
+    expect(value.keys.verify(created.apiKey)).toEqual({ principal: value.principal, keyId: created.key.id });
+    expect(value.keys.list(value.principalId)[0]?.lastUsedAt).toBeNull();
+    value.metadata.close(); value.state.close();
+  });
+
+  it('keeps key ownership on the durable principal across an exact subject relink', () => {
+    const value = fixture();
+    const created = value.keys.create(value.principalId, 'Relinked', 30);
+    const mapping = {
+      oldIssuer: value.principal.issuer,
+      oldSubject: value.principal.subject,
+      newIssuer: 'https://new-team.cloudflareaccess.com',
+      newSubject: 'new-human-subject'
+    };
+    expect(value.state.applyPrincipalRelinks([mapping])[0]?.principalId).toBe(value.principalId);
+    expect(value.keys.verify(created.apiKey)).toEqual({
+      principal: { kind: 'external', issuer: mapping.newIssuer, subject: mapping.newSubject },
+      keyId: created.key.id
+    });
+    value.metadata.close(); value.state.close();
+  });
+
+  it('downgrades only API-key state and can migrate forward again', () => {
+    const value = fixture();
+    const project = value.metadata.createProject(value.principalId, 'Preserved', 0);
+    value.keys.create(value.principalId, 'Disposable', 30);
+    downgradeMetadataSchemaToV1(value.metadata.database);
+    expect((value.metadata.database.prepare('SELECT version FROM metadata_schema_meta').get() as { version: number }).version).toBe(1);
+    expect(value.metadata.database.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'api_keys'").get()).toBeUndefined();
+    expect(value.metadata.listProjects(value.principalId)[0]?.id).toBe(project?.id);
+    migrateMetadataSchema(value.metadata.database);
+    expect((value.metadata.database.prepare('SELECT version FROM metadata_schema_meta').get() as { version: number }).version).toBe(2);
+    expect(value.metadata.listProjects(value.principalId)[0]?.id).toBe(project?.id);
+    value.metadata.close(); value.state.close();
+  });
+
+  it('fails closed for future, conflicting, and invalid downgrade schema states', () => {
+    const future = fixture();
+    future.metadata.database.prepare('UPDATE metadata_schema_meta SET version = 99 WHERE singleton = 1').run();
+    expect(() => migrateMetadataSchema(future.metadata.database)).toThrow('unsupported metadata schema version 99');
+    expect((future.metadata.database.prepare('SELECT version FROM metadata_schema_meta').get() as { version: number }).version).toBe(99);
+    expect(() => downgradeMetadataSchemaToV1(future.metadata.database)).toThrow('metadata schema must be version 2 before downgrade');
+    future.metadata.close(); future.state.close();
+
+    const conflicting = fixture();
+    downgradeMetadataSchemaToV1(conflicting.metadata.database);
+    conflicting.metadata.database.exec('CREATE TABLE api_keys (unexpected TEXT)');
+    expect(() => migrateMetadataSchema(conflicting.metadata.database)).toThrow();
+    expect((conflicting.metadata.database.prepare('SELECT version FROM metadata_schema_meta').get() as { version: number }).version).toBe(1);
+    expect((conflicting.metadata.database.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'api_keys'").get() as { sql: string }).sql)
+      .toContain('unexpected TEXT');
+    conflicting.metadata.close(); conflicting.state.close();
+  });
+});

--- a/apps/runner/test/metadata-store.test.ts
+++ b/apps/runner/test/metadata-store.test.ts
@@ -33,7 +33,7 @@ describe('MetadataStore', () => {
   it('migrates once, survives restart, and enforces owner-qualified foreign keys', () => {
     const { path, owner, foreign, store, keyring } = fixture();
     const { project, environment } = projectEnvironment(store, owner);
-    expect((store.database.prepare('SELECT version FROM metadata_schema_meta').get() as { version: number }).version).toBe(1);
+    expect((store.database.prepare('SELECT version FROM metadata_schema_meta').get() as { version: number }).version).toBe(2);
     expect(() => store.database.prepare(`INSERT INTO environments
       (id, principal_id, project_id, name, state, generation, created_at, updated_at)
       VALUES (?, ?, ?, 'Foreign', 'ACTIVE', 1, 1, 1)`).run(`env_${'x'.repeat(24)}`, foreign, project.id)).toThrow();

--- a/deploy/nginx/cloud-harness-mcp.conf
+++ b/deploy/nginx/cloud-harness-mcp.conf
@@ -30,6 +30,19 @@ server {
         add_header X-Accel-Buffering no always;
     }
 
+    location = /mcp-api-key {
+        proxy_pass http://127.0.0.1:3100/mcp-api-key;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        add_header X-Accel-Buffering no always;
+    }
+
     location = /dashboard {
         proxy_pass http://127.0.0.1:3100/dashboard;
         proxy_set_header Host $host;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,37 @@ paths are [`apps/api/src/auth.ts`](../apps/api/src/auth.ts) and
 only from API to runner. Secret-valued settings accept their documented
 `_FILE` form and must meet schema length/placeholder checks.
 
+### Dashboard-managed API-key gateway
+
+The static-client lane is an opt-in extension of `cloudflare-access`, not a
+third authentication mode. `API_KEY_AUTH_ENABLED=true` requires all of:
+
+- `API_KEY_GATEWAY_ACCESS_AUDIENCE`, the audience of the separate Access
+  application scoped to exact `/mcp-api-key`;
+- `API_KEY_GATEWAY_SERVICE_SUBJECT`, the normalized `cf-service:` subject
+  observed from the dedicated Worker service token; and
+- `API_KEY_GATEWAY_PUBLIC_URL`, the client-facing Worker URL, currently
+  `https://api.harness.zuey.me/mcp`.
+
+The gateway audience must differ from the main `/mcp` and `/dashboard`
+application audience. Partial configuration and enabling this lane in
+`owner-bearer` mode fail validation. The exact combinations and subject shape
+are owned by
+[`packages/contracts/src/config.ts`](../packages/contracts/src/config.ts).
+
+The Worker stores `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` as
+Cloudflare Worker secrets, never in the runtime environment, Wrangler
+manifest, or repository. They belong only to the Service Auth policy of the
+path-scoped gateway application. Its manifest also owns an aggregate
+Cloudflare Rate Limiting binding for the exact gateway route: 600 requests per
+60 seconds in each Cloudflare location. Limiter exhaustion returns JSON `429`;
+a missing or failed binding returns JSON `503`. This eventual, edge-local cap
+is defense in depth; the origin's per-credential limits remain authoritative.
+The secret-free route and proxy contract are owned by
+[`apps/api-key-gateway/wrangler.jsonc`](../apps/api-key-gateway/wrangler.jsonc)
+and
+[`apps/api-key-gateway/src/gateway.ts`](../apps/api-key-gateway/src/gateway.ts).
+
 Access principals are durable exact `(issuer, subject)` identities. Email and
 display name are never an authorization or account-link key. The first Access
 cutover can bind one legacy owner only through the complete explicit legacy
@@ -114,6 +145,14 @@ keyring, quiescing writes, and using the runner-only re-encryption entry point d
 [operations guide](operations.md#secret-key-rotation). Missing or invalid key
 material disables secret-dependent operations without exposing key details;
 non-secret dashboard reads remain available.
+
+Dashboard-managed MCP API keys use a different write-only contract from
+encrypted environment secrets. The runner stores only a SHA-256 digest and
+safe metadata; the complete random key crosses the authenticated, CSRF-
+protected Dashboard response exactly once. Lifecycle limits and response
+schemas are owned by
+[`packages/contracts/src/api-key-api.ts`](../packages/contracts/src/api-key-api.ts)
+and [`apps/runner/src/api-key-store.ts`](../apps/runner/src/api-key-store.ts).
 
 ## Optional GitHub App repository access
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -167,6 +167,51 @@ If a target client cannot complete Managed OAuth, stop and make the separate
 Managed OAuth versus Workers OAuth Provider decision. Do not add a second
 issuer, hidden bearer path, or unprotected hostname as a compatibility fix.
 
+### API-key gateway rollout
+
+Add the static-client lane only after the existing OAuth and dashboard lane is
+healthy. Create a second Self-hosted Access application scoped exactly to
+`harness.zuey.me/mcp-api-key`, with an audience distinct from the hostname-wide
+application. Its only Allow policy is **Service Auth** for one dedicated Worker
+service token. Do not add users, groups, bypass rules, or that service token to
+the main `/mcp` and `/dashboard` application.
+
+Store the token as `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` Worker
+secrets. Deploy the Worker manifest at
+[`apps/api-key-gateway/wrangler.jsonc`](../apps/api-key-gateway/wrangler.jsonc),
+which binds the custom hostname `api.harness.zuey.me`; do not enable a
+`workers.dev` or preview URL. The same manifest provisions
+`API_KEY_RATE_LIMITER`, an aggregate 600-request/60-second cap per Cloudflare
+location. Confirm the deployed Worker version lists that binding and, in a
+controlled preproduction route, prove exhaustion returns bounded JSON `429`
+with `Retry-After: 60` while a failed/missing binding returns JSON `503` and
+does not reach the origin. Do not weaken the origin's authoritative
+per-credential limiter. Observe the verified service principal at the
+origin, normalize and pin that exact value in
+`API_KEY_GATEWAY_SERVICE_SUBJECT`, and set the separate application audience
+and public URL in `API_KEY_GATEWAY_ACCESS_AUDIENCE` and
+`API_KEY_GATEWAY_PUBLIC_URL`. Enable `API_KEY_AUTH_ENABLED` only after those
+values are complete.
+
+Roll out the schema-capable runner and API with the feature disabled first.
+After the quiesced state backup and v2 migration, prove OAuth, GitHub/Google
+dashboard login, and CSRF behavior before enabling the hidden route and Worker.
+Then create a disposable short-lived key in the dashboard and canary:
+
+1. initialize, list tools, and make one bounded call through
+   `https://api.harness.zuey.me/mcp`;
+2. reject the same key on `https://harness.zuey.me/mcp` and reject direct calls
+   to `/mcp-api-key` without the exact Worker assertion;
+3. revoke the key and prove the next gateway request returns JSON `401`; and
+4. confirm the production Worker version contains the expected rate-limit
+   binding and the sanitized preproduction `429`/fail-closed receipt; and
+5. re-run Managed OAuth discovery/initialize and both IdP dashboard logins.
+
+Record the exact release SHA, Access application identifiers/audiences, Worker
+deployment, hostnames, and sanitized results separately. Never record either
+the key or service-token values. The Worker route can be removed independently;
+the OAuth/dashboard lane remains available.
+
 ## Deploy a release
 
 The deploy command accepts only an exact 40-character commit that is an
@@ -289,3 +334,10 @@ This leaves the project configuration, state, artifact store, backups, and any d
 certificate available for investigation. Remove them only after resolving
 their exact ownership and retention requirements. See
 [operations](operations.md) for backup and cleanup.
+
+For an API-key-gateway rollback, disable the Worker custom route first, set
+`API_KEY_AUTH_ENABLED=false`, confirm the hidden origin route returns 404, and
+revoke the Worker service token. A prior binary that understands only metadata
+schema v1 also requires the quiesced v2→v1 procedure in
+[operations](operations.md#api-key-schema-rollback); that downgrade invalidates
+all managed API keys while preserving unrelated metadata.

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -2,11 +2,16 @@
 
 ## Connection
 
-The Streamable HTTP endpoint is
-`https://harness.zuey.me/mcp` for the current operator deployment. That
-deployment requires the client to complete the Cloudflare Access Managed OAuth
-flow through GitHub or Google; the origin verifies the forwarded Access
-assertion. `owner-bearer` remains the default authentication contract for
+The current operator deployment has two Streamable HTTP endpoints:
+
+- `https://harness.zuey.me/mcp` for Cloudflare Access Managed OAuth through
+  GitHub or Google; and
+- `https://api.harness.zuey.me/mcp` for static-header clients using a
+  dashboard-managed API key as `Authorization: Bearer <key>`.
+
+The lanes are intentionally non-interchangeable. Managed keys are accepted
+only through the fixed Worker gateway; the hidden origin path is not a client
+endpoint. `owner-bearer` remains the default authentication contract for
 separate private deployments. The
 recommended client routes are in the
 [README](../README.md#connect-from-ai-clients). Do not treat implementation or
@@ -20,6 +25,15 @@ Results use the stable envelope defined in
 [`packages/contracts/src/mcp-results.ts`](../packages/contracts/src/mcp-results.ts):
 inspect `structuredContent` for `ok`, `data`, `error`, `truncated`, and
 `cursor`; the text content is a concise human message.
+
+Create, inspect, and revoke managed keys in `/dashboard/api-keys`. The complete
+key is returned once at creation; later list responses contain only safe
+metadata. Keys grant the same full MCP/RCE authority as their creator, expire
+in 1–365 days, and are limited to 10 active keys per principal. There are no
+scopes, recovery, ownership transfer, or rotation endpoint. Rotate by creating
+a replacement, updating the client, verifying it, then revoking the old key.
+The lifecycle contract is owned by
+[`packages/contracts/src/api-key-api.ts`](../packages/contracts/src/api-key-api.ts).
 
 ## Normal workflow
 
@@ -80,6 +94,11 @@ makes a lost response recoverable without duplicating work.
   They are not public MCP tools. Retained artifact snapshots are bounded
   control-plane records, not durable task/session output or a source-control
   replacement.
+- Dashboard API-key lifecycle uses a separate internal contract and is not an
+  MCP tool. A key remains bound to the creator's durable principal across an
+  explicitly applied Access subject relink. Expiry and revocation are checked
+  on every request; `lastUsedAt` is coalesced telemetry and never an
+  authorization input.
 - Executors have no network by default. Dependency installation, arbitrary
   commands, and repository-defined deployments that need network access require
   an explicitly requested/configured `bridge` workspace, which is a weaker

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -44,6 +44,10 @@ close/expiry; they are not a durable source control remote or a backup.
 The same state database also owns the stable random runner-instance identity
 used to scope Docker reconciliation.
 
+Metadata schema v2 adds principal-bound API-key hashes and safe lifecycle
+metadata. A database backup therefore does not recover plaintext keys; clients
+must keep their one-time value in a private credential store.
+
 ## Backup and restore
 
 [`deploy/scripts/deploy-release.sh`](../deploy/scripts/deploy-release.sh)
@@ -124,6 +128,33 @@ df -h /var/lib/cloud-harness
 sudo du -sh /var/lib/cloud-harness/jobs/*
 ```
 
+## Managed API-key lifecycle
+
+Create, list, and revoke keys through the Access-authenticated dashboard. A key
+cannot be recovered after its creation response. For planned replacement,
+create a new key, update and canary the client against
+`https://api.harness.zuey.me/mcp`, then revoke the old key and verify the next
+request is rejected. For suspected disclosure, revoke first and inspect only
+redacted audit/log metadata. Do not copy a key into shell history, URLs,
+tickets, or shared logs.
+
+### API-key schema rollback
+
+Downgrading from metadata schema v2 to a binary that supports only v1 destroys
+all managed API-key records by design. Quiesce dashboard and MCP writes, stop
+the service, and take a coherent recovery backup before running the runner's
+compiled migration command from the exact release checkout:
+
+```bash
+npm run metadata:down:v1 -w @cloud-harness/runner -- /path/to/db
+```
+
+Keep the database offline for the command. It requires version 2, drops only
+the API-key table, and resets the metadata version to 1. Then deploy the prior
+binary, keep `API_KEY_AUTH_ENABLED=false`, and canary readiness, OAuth,
+dashboard, unrelated metadata, and the absence of the hidden route. Restore
+the backup instead of retrying manually if the downgrade does not complete.
+
 ## Release rollback
 
 An automatic deployment failure restores the prior recorded commit, the
@@ -144,6 +175,7 @@ pipeline builds images on the VPS and records local image IDs; it does not pull
 an externally attested image digest.
 
 Always verify loopback readiness, HTTPS, dashboard secret readiness, artifact
-state, and managed-container cleanup after a rollback. Retain at least one
+state, API-key gateway disablement when applicable, and managed-container
+cleanup after a rollback. Retain at least one
 known-good coherent recovery set; backup retention is an operator policy, not
 an automated service feature.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -81,6 +81,34 @@ These controls are implemented in
 [`apps/api/src/app.ts`](../apps/api/src/app.ts). Process-local limits reset on
 API restart and are not a distributed denial-of-service control.
 
+Dashboard-managed API keys add a separate static-client lane without weakening
+the Managed OAuth lane. The public `api.harness.zuey.me/mcp` Worker is a fixed
+streaming proxy to exact `harness.zuey.me/mcp-api-key`: it rebuilds a small
+header allowlist, discards caller-supplied Cloudflare and forwarding identity,
+and injects its own Access service-token headers. The hidden origin path is
+protected by a separate path-scoped Access application and audience. The
+origin requires both a cryptographically verified assertion for the exactly
+pinned gateway service subject and a valid principal-bound API key. Neither
+credential is sufficient alone, and the reserved gateway subject is rejected
+on the normal `/mcp` route. Before forwarding, the Worker enforces the
+manifest-owned aggregate Rate Limiting binding and fails closed if the binding
+cannot answer. That edge-local, eventually consistent cap is defense in depth;
+the origin still enforces authoritative per-credential concurrency and request
+limits. The executable owners are
+[`apps/api-key-gateway/src/gateway.ts`](../apps/api-key-gateway/src/gateway.ts),
+[`apps/api/src/auth.ts`](../apps/api/src/auth.ts), and
+[`apps/runner/src/api-key-store.ts`](../apps/runner/src/api-key-store.ts).
+
+An API key inherits its creator's full MCP authority, including arbitrary
+remote command execution. It is not a fine-grained capability and has no tool
+scopes. The browser can create, list, and revoke keys only through the existing
+Access-authenticated, same-origin CSRF boundary. Plaintext is shown once;
+SQLite retains only the SHA-256 digest and non-secret metadata. Expiry is
+mandatory, revocation takes effect on the next request, and authentication has
+no positive cache. Treat disclosure as full account compromise: revoke the key,
+inspect redacted audit and request metadata, and create a replacement only
+after the leak path is closed.
+
 In owner-bearer mode, rotate `MCP_BEARER_TOKEN` after suspected disclosure and
 restart the API. In Access mode, revoke at Access/IdP and verify the edge no
 longer forwards an accepted assertion. Rotate `RUNNER_TOKEN` independently and
@@ -139,7 +167,8 @@ credentials. Their manifest parsing and execution owner is
 Workspace paths are server-generated and checked beneath the configured jobs
 root. Worker paths reject absolute/traversal paths and symlink escapes. SQLite
 stores workspace/principal, project/environment, encrypted-secret reference,
-GitHub installation, artifact metadata, and redacted audit state. Artifact
+hashed API-key metadata, GitHub installation, artifact metadata, and redacted
+audit state. Artifact
 payloads use a separate runner-confined bounded root. Raw secret values are
 encrypted with a versioned runner-held keyring and are never returned to the
 browser; the keyring and GitHub App private key never cross into API, ingress,

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -10,6 +10,13 @@ MCP client
   -> runner (internal Compose network, service bearer)
   -> rootful Docker socket
   -> ephemeral clone/Git transfer helpers and one executor for the workspace
+
+Static-header MCP client
+  -> api.harness.zuey.me/mcp (fixed Cloudflare Worker)
+  -> path-scoped Cloudflare Access application (Worker Service Auth only)
+  -> harness.zuey.me/mcp-api-key (exact hidden origin route)
+  -> API (verified gateway subject AND principal-bound API key)
+  -> the same runner and execution path above
 ```
 
 Cloudflare Access is an optional public authentication edge in front of nginx;
@@ -62,12 +69,17 @@ Executable owners:
   [`apps/api/src/auth.ts`](../apps/api/src/auth.ts),
   [`apps/api/src/dashboard-router.ts`](../apps/api/src/dashboard-router.ts), and
   [`apps/api/src/dashboard-response.ts`](../apps/api/src/dashboard-response.ts)
+- Static API-key Worker and dual-credential origin boundary:
+  [`apps/api-key-gateway/src/gateway.ts`](../apps/api-key-gateway/src/gateway.ts),
+  [`apps/api/src/auth.ts`](../apps/api/src/auth.ts), and
+  [`apps/runner/src/api-key-store.ts`](../apps/runner/src/api-key-store.ts)
 - Versioned API/runner contract and tool schemas:
   [`packages/contracts/src/runner-api.ts`](../packages/contracts/src/runner-api.ts)
   and
   [`packages/contracts/src/tool-schemas.ts`](../packages/contracts/src/tool-schemas.ts)
-- Versioned dashboard-only runner contract:
+- Versioned dashboard-only runner contracts:
   [`packages/contracts/src/internal-runner-api.ts`](../packages/contracts/src/internal-runner-api.ts)
+  and [`packages/contracts/src/api-key-api.ts`](../packages/contracts/src/api-key-api.ts)
 - Workspace lifecycle and Docker policy:
   [`apps/runner/src/workspace-service.ts`](../apps/runner/src/workspace-service.ts)
 - In-memory shells, named sessions, and dependency-task scheduling:
@@ -113,7 +125,8 @@ handling while the durable workspace identity lives below the transport. A
 lost `workspace_open` response can therefore be recovered by replaying its
 idempotency key or by listing workspaces.
 
-Principal, project/environment, encrypted secret-reference, GitHub binding,
+Principal, project/environment, encrypted secret-reference, API-key digest,
+GitHub binding,
 artifact metadata, and audit state share the runner-owned SQLite database.
 Artifact payloads persist under the artifact root until deletion or bounded
 retention reaping. Dashboard runtime summaries remain volatile. The exact
@@ -130,8 +143,12 @@ cleanup authority.
 Production Compose binds the credential-free ingress proxy to
 `127.0.0.1:3100`; the API and runner have no published host ports. Runner
 egress does not expose an ingress port. Existing
-nginx is the only intended host listener and proxies `/mcp`, `/dashboard`,
+nginx is the only intended origin host listener and proxies `/mcp`,
+`/mcp-api-key`, `/dashboard`,
 `/healthz`, and `/readyz` to loopback. In Access mode the owned public hostname
-is additionally protected by the external Access application. The
+uses one Access application for `/mcp` and `/dashboard`, plus a separate
+application scoped exactly to `/mcp-api-key`. The external Worker owns the
+public static-key hostname and cannot proxy dashboard or arbitrary origin
+traffic. The
 [deployment guide](deployment.md) explains the safe install order and the TLS
 step that is intentionally outside Compose.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,6 +21,10 @@ URLs, or raw command content into tickets or shared logs.
 | TLS hostname/certificate error | Certbot has not issued/installed the dedicated hostname certificate, nginx is serving another site's default certificate, or DNS points elsewhere. Check `certbot certificates`, `nginx -T`, DNS, and the [TLS install step](deployment.md#obtain-https-with-the-existing-nginx). Do not disable certificate verification. |
 | `401` with `WWW-Authenticate: Bearer` in owner-bearer mode | The MCP bearer is missing or differs from `MCP_BEARER_TOKEN`. Check that the client names an exported local variable, then restart it after changing the value. |
 | MCP `401` in Access mode | The public request did not arrive with a valid Access assertion for the configured issuer/audience, or the Access OAuth credential is expired/revoked. Check the Access application, policy, discovery flow, and sanitized edge logs; do not add an origin bearer bypass. |
+| API-key gateway returns JSON `401 authentication_failed` | The Worker reached the origin, but the path-scoped Access assertion did not match the configured audience/subject or the managed key was malformed, unknown, expired, or revoked. Check the distinct Access application, exact pinned service subject, feature configuration, and dashboard metadata without printing the key. All invalid key classes intentionally share this response. |
+| API-key client receives `text/html` or an Access login page | The client is using the OAuth hostname/path, Cloudflare selected an interactive policy for `/mcp-api-key`, or the Worker is not bound to the requested hostname. Static clients must use `https://api.harness.zuey.me/mcp`; the hidden path must have a separate Service Auth-only Access application. Do not add browser cookies, bypass Access, or point the client at the hidden route. |
+| API-key gateway returns JSON `400`, `404`, or `405` | The request has an invalid/missing Bearer header, query string, path, method, or oversized/ambiguous forwarded header. Use exact `/mcp` with Streamable HTTP `GET`, `POST`, or `DELETE`; do not forward Cloudflare or proxy headers from the client. |
+| API-key gateway returns JSON `502` or `503` | `502` means the fixed upstream failed or redirected; `503` means Worker service-token secrets are unavailable. Check the Worker deployment, exact origin route, Access application, and secret bindings without logging their values. OAuth/dashboard availability is independent. |
 | Dashboard login loop or `session_ended` | `/dashboard` did not receive a current Access assertion, or its short-lived CSRF session was lost. Re-authenticate at Access and reload the dashboard; never copy the assertion into browser storage. |
 | `403 forbidden_host` | The request hostname is absent from `API_PUBLIC_HOSTS`, or nginx did not preserve `Host`. Compare the public hostname with the nginx proxy and runtime environment. |
 | `403 forbidden_origin` | A supplied `Origin` is absent from `API_ALLOWED_ORIGINS`. Add only the exact trusted origin; CLI clients normally omit this header. |
@@ -31,7 +35,9 @@ URLs, or raw command content into tickets or shared logs.
 
 The request policy is owned by
 [`apps/api/src/request-security.ts`](../apps/api/src/request-security.ts) and
-[`apps/api/src/auth.ts`](../apps/api/src/auth.ts).
+[`apps/api/src/auth.ts`](../apps/api/src/auth.ts). Worker error and header
+behavior is owned by
+[`apps/api-key-gateway/src/gateway.ts`](../apps/api-key-gateway/src/gateway.ts).
 
 ## Workspace opening
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,10 @@
         "zod": "4.4.3"
       }
     },
+    "apps/api-key-gateway": {
+      "name": "@cloud-harness/api-key-gateway",
+      "version": "0.6.4"
+    },
     "apps/runner": {
       "name": "@cloud-harness/runner",
       "version": "0.6.4",
@@ -134,6 +138,10 @@
     },
     "node_modules/@cloud-harness/api": {
       "resolved": "apps/api",
+      "link": true
+    },
+    "node_modules/@cloud-harness/api-key-gateway": {
+      "resolved": "apps/api-key-gateway",
       "link": true
     },
     "node_modules/@cloud-harness/contracts": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build -w @cloud-harness/contracts && npm run build -w @cloud-harness/api && npm run build -w @cloud-harness/runner",
+    "build": "npm run build -w @cloud-harness/contracts && npm run build -w @cloud-harness/api && npm run build -w @cloud-harness/runner && npm run build -w @cloud-harness/api-key-gateway",
     "clean": "npm run clean --workspaces --if-present",
     "dev:api": "npm run dev -w @cloud-harness/api",
     "dev:runner": "npm run dev -w @cloud-harness/runner",
     "lint": "eslint .",
-    "typecheck": "npm run build -w @cloud-harness/contracts && npm run typecheck -w @cloud-harness/api && npm run typecheck -w @cloud-harness/runner",
+    "typecheck": "npm run build -w @cloud-harness/contracts && npm run typecheck -w @cloud-harness/api && npm run typecheck -w @cloud-harness/runner && npm run typecheck -w @cloud-harness/api-key-gateway",
     "test": "vitest run --exclude '**/*.docker.test.ts' --no-file-parallelism",
     "test:unit": "vitest run packages apps --exclude '**/*.docker.test.ts'",
     "test:integration": "vitest run test/integration --exclude '**/*.docker.test.ts'",

--- a/packages/contracts/src/api-key-api.ts
+++ b/packages/contracts/src/api-key-api.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { RunnerPrincipalSelectorSchema } from './runner-api.js';
+
+export const ApiKeyIdSchema = z.string().regex(/^apk_[A-Za-z0-9_-]{24}$/);
+export const ApiKeyValueSchema = z.string().regex(/^chm_key_apk_[A-Za-z0-9_-]{24}\.[A-Za-z0-9_-]{43}$/).max(96);
+
+const name = z.string().trim().min(1).max(100);
+const generation = z.number().int().positive();
+
+export const ApiKeyManagementOperationSchema = z.enum(['api_key_list', 'api_key_create', 'api_key_revoke']);
+
+const managementBase = {
+  version: z.literal(1),
+  principal: RunnerPrincipalSelectorSchema
+};
+
+export const ApiKeyManagementRequestSchema = z.discriminatedUnion('operation', [
+  z.object({ ...managementBase, operation: z.literal('api_key_list'), input: z.object({}).strict() }).strict(),
+  z.object({
+    ...managementBase,
+    operation: z.literal('api_key_create'),
+    input: z.object({ name, expiresInDays: z.number().int().min(1).max(365) }).strict()
+  }).strict(),
+  z.object({
+    ...managementBase,
+    operation: z.literal('api_key_revoke'),
+    input: z.object({ keyId: ApiKeyIdSchema, expectedGeneration: generation }).strict()
+  }).strict()
+]);
+
+export const ApiKeyMetadataSchema = z.object({
+  id: ApiKeyIdSchema,
+  name,
+  displayPrefix: z.string().min(8).max(40),
+  state: z.enum(['ACTIVE', 'EXPIRED', 'REVOKED']),
+  generation,
+  createdAt: z.number().int().nonnegative(),
+  expiresAt: z.number().int().positive(),
+  lastUsedAt: z.number().int().nonnegative().nullable(),
+  revokedAt: z.number().int().nonnegative().nullable()
+}).strict();
+
+const successBase = { ok: z.literal(true), truncated: z.literal(false) };
+const errorResponse = z.object({
+  ok: z.literal(false),
+  message: z.string(),
+  error: z.object({ code: z.string(), message: z.string(), retryable: z.boolean() }).strict(),
+  truncated: z.literal(false)
+}).strict();
+
+export const ApiKeyManagementResponseSchema = z.union([
+  z.object({ ...successBase, operation: z.literal('api_key_list'), data: z.object({ keys: z.array(ApiKeyMetadataSchema) }).strict() }).strict(),
+  z.object({
+    ...successBase,
+    operation: z.literal('api_key_create'),
+    data: z.object({ key: ApiKeyMetadataSchema, apiKey: ApiKeyValueSchema }).strict()
+  }).strict(),
+  z.object({ ...successBase, operation: z.literal('api_key_revoke'), data: z.object({ key: ApiKeyMetadataSchema }).strict() }).strict(),
+  errorResponse
+]);
+
+export const ApiKeyAuthenticationRequestSchema = z.object({
+  version: z.literal(1),
+  apiKey: ApiKeyValueSchema
+}).strict();
+
+export const ApiKeyAuthenticationResponseSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    data: z.object({ principal: RunnerPrincipalSelectorSchema, keyId: ApiKeyIdSchema }).strict()
+  }).strict(),
+  z.object({ ok: z.literal(false), error: z.literal('authentication_failed') }).strict()
+]);
+
+export type ApiKeyManagementOperation = z.infer<typeof ApiKeyManagementOperationSchema>;
+export type ApiKeyManagementRequest = z.infer<typeof ApiKeyManagementRequestSchema>;
+export type ApiKeyManagementResponse = z.infer<typeof ApiKeyManagementResponseSchema>;
+export type ApiKeyAuthenticationResponse = z.infer<typeof ApiKeyAuthenticationResponseSchema>;
+export type ApiKeyMetadata = z.infer<typeof ApiKeyMetadataSchema>;

--- a/packages/contracts/src/config.ts
+++ b/packages/contracts/src/config.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 const token = z.string().min(32).max(512).refine((value) => !value.startsWith('change-me'), 'placeholder secret is forbidden');
 
 const httpsUrl = z.url().refine((value) => new URL(value).protocol === 'https:', 'HTTPS URL required');
+const enabled = z.preprocess((value) => value === true || value === 'true', z.boolean()).default(false);
 
 const principalRelink = z.object({
   oldIssuer: httpsUrl,
@@ -23,6 +24,10 @@ export const ApiConfigSchema = z.object({
   accessIssuer: httpsUrl.optional(),
   accessAudience: z.string().min(1).max(512).optional(),
   accessJwksUrl: httpsUrl.optional(),
+  apiKeyAuthEnabled: enabled,
+  apiKeyGatewayAccessAudience: z.string().min(1).max(512).optional(),
+  apiKeyGatewayServiceSubject: z.string().regex(/^cf-service:[A-Za-z0-9_-]+$/).max(512).optional(),
+  apiKeyGatewayPublicUrl: httpsUrl.optional(),
   runnerUrl: z.url(),
   runnerToken: token,
   publicHosts: z.array(z.string().min(1)).min(1),
@@ -32,9 +37,11 @@ export const ApiConfigSchema = z.object({
 }).superRefine((config, context) => {
   const mode = config.authMode ?? 'owner-bearer';
   const accessValues = [config.accessIssuer, config.accessAudience, config.accessJwksUrl];
+  const apiKeyValues = [config.apiKeyGatewayAccessAudience, config.apiKeyGatewayServiceSubject, config.apiKeyGatewayPublicUrl];
   if (mode === 'owner-bearer') {
     if (!config.bearerToken) context.addIssue({ code: 'custom', path: ['bearerToken'], message: 'bearer token is required in owner-bearer mode' });
     if (accessValues.some((value) => value !== undefined)) context.addIssue({ code: 'custom', path: ['authMode'], message: 'Cloudflare Access settings are forbidden in owner-bearer mode' });
+    if (config.apiKeyAuthEnabled || apiKeyValues.some((value) => value !== undefined)) context.addIssue({ code: 'custom', path: ['apiKeyAuthEnabled'], message: 'API key gateway is only valid in cloudflare-access mode' });
     return;
   }
   if (config.bearerToken) context.addIssue({ code: 'custom', path: ['bearerToken'], message: 'owner bearer token is forbidden in cloudflare-access mode' });
@@ -44,6 +51,20 @@ export const ApiConfigSchema = z.object({
     ['accessJwksUrl', config.accessJwksUrl]
   ] as const) {
     if (!value) context.addIssue({ code: 'custom', path: [path], message: `${path} is required in cloudflare-access mode` });
+  }
+  if (config.apiKeyAuthEnabled) {
+    for (const [path, value] of [
+      ['apiKeyGatewayAccessAudience', config.apiKeyGatewayAccessAudience],
+      ['apiKeyGatewayServiceSubject', config.apiKeyGatewayServiceSubject],
+      ['apiKeyGatewayPublicUrl', config.apiKeyGatewayPublicUrl]
+    ] as const) {
+      if (!value) context.addIssue({ code: 'custom', path: [path], message: `${path} is required when API key authentication is enabled` });
+    }
+    if (config.apiKeyGatewayAccessAudience === config.accessAudience) {
+      context.addIssue({ code: 'custom', path: ['apiKeyGatewayAccessAudience'], message: 'API key gateway audience must differ from the main Access audience' });
+    }
+  } else if (apiKeyValues.some((value) => value !== undefined)) {
+    context.addIssue({ code: 'custom', path: ['apiKeyAuthEnabled'], message: 'API key gateway settings require API key authentication to be enabled' });
   }
 });
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,4 @@
+export * from './api-key-api.js';
 export * from './config.js';
 export * from './identifiers.js';
 export * from './internal-runner-api.js';

--- a/packages/contracts/test/api-key-api.test.ts
+++ b/packages/contracts/test/api-key-api.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ApiKeyAuthenticationRequestSchema,
+  ApiKeyManagementRequestSchema,
+  ApiKeyManagementResponseSchema,
+  RunnerOperationSchema
+} from '../src/index.js';
+
+const principal = { kind: 'external', issuer: 'https://team.cloudflareaccess.com', subject: 'subject' };
+
+describe('managed API-key contracts', () => {
+  it('keeps lifecycle operations outside the public MCP runner contract', () => {
+    expect(RunnerOperationSchema.safeParse('api_key_create').success).toBe(false);
+  });
+
+  it('validates strict create bounds and a dedicated one-time response', () => {
+    expect(ApiKeyManagementRequestSchema.parse({
+      version: 1, principal, operation: 'api_key_create', input: { name: 'CLI', expiresInDays: 30 }
+    }).operation).toBe('api_key_create');
+    expect(ApiKeyManagementRequestSchema.safeParse({
+      version: 1, principal, operation: 'api_key_create', input: { name: 'CLI', expiresInDays: 366 }
+    }).success).toBe(false);
+    const apiKey = `chm_key_apk_${'a'.repeat(24)}.${'b'.repeat(43)}`;
+    expect(ApiKeyManagementResponseSchema.parse({
+      ok: true, operation: 'api_key_create', truncated: false,
+      data: { apiKey, key: { id: `apk_${'a'.repeat(24)}`, name: 'CLI', displayPrefix: 'chm_key_apk_aaaa…', state: 'ACTIVE', generation: 1, createdAt: 1, expiresAt: 2, lastUsedAt: null, revokedAt: null } }
+    }).data).toHaveProperty('apiKey', apiKey);
+  });
+
+  it('rejects oversized and malformed presented keys before runner work', () => {
+    expect(ApiKeyAuthenticationRequestSchema.safeParse({ version: 1, apiKey: 'x'.repeat(10_000) }).success).toBe(false);
+    expect(ApiKeyAuthenticationRequestSchema.safeParse({ version: 1, apiKey: `chm_key_apk_${'a'.repeat(24)}.${'b'.repeat(43)}` }).success).toBe(true);
+  });
+});

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -42,6 +42,23 @@ describe('contracts', () => {
     expect(() => ApiConfigSchema.parse({ ...access, bearerToken: 'owner-token-that-is-long-enough-123456' })).toThrow();
   });
 
+  it('enables the API-key gateway only with a separate complete Access audience', () => {
+    const access = {
+      ...commonApiConfig, authMode: 'cloudflare-access' as const,
+      accessIssuer: 'https://team.cloudflareaccess.com', accessAudience: 'main-audience',
+      accessJwksUrl: 'https://team.cloudflareaccess.com/cdn-cgi/access/certs'
+    };
+    const gateway = {
+      apiKeyAuthEnabled: true, apiKeyGatewayAccessAudience: 'gateway-audience',
+      apiKeyGatewayServiceSubject: 'cf-service:d29ya2Vy', apiKeyGatewayPublicUrl: 'https://api.example/mcp'
+    };
+    expect(ApiConfigSchema.parse({ ...access, ...gateway }).apiKeyAuthEnabled).toBe(true);
+    expect(() => ApiConfigSchema.parse({ ...access, ...gateway, apiKeyGatewayAccessAudience: 'main-audience' })).toThrow();
+    expect(() => ApiConfigSchema.parse({ ...access, apiKeyAuthEnabled: true })).toThrow();
+    expect(() => ApiConfigSchema.parse({ ...commonApiConfig, bearerToken: 'owner-token-that-is-long-enough-123456', ...gateway })).toThrow();
+    expect(() => ApiConfigSchema.parse({ ...access, apiKeyGatewayPublicUrl: 'https://api.example/mcp' })).toThrow();
+  });
+
   it('accepts only explicit owner or verified external runner principal selectors', () => {
     const base = { version: 2, operation: 'workspace_list', input: {} } as const;
     expect(RunnerRequestSchema.parse({ ...base, principal: { kind: 'owner', ownerId: 'owner' } }).principal.kind).toBe('owner');

--- a/plans/260818-1610-dashboard-managed-api-keys/phase-01-contracts-key-registry-and-migration.md
+++ b/plans/260818-1610-dashboard-managed-api-keys/phase-01-contracts-key-registry-and-migration.md
@@ -1,0 +1,63 @@
+---
+phase: 1
+title: "Contracts, key registry, and reversible migration"
+status: completed
+priority: P1
+effort: "1.5-2d"
+dependencies: []
+---
+
+# Contracts, key registry, and reversible migration
+
+## Context links
+
+- [Plan](./plan.md)
+- [Internal runner contract](../../packages/contracts/src/internal-runner-api.ts)
+- [Metadata schema](../../apps/runner/src/metadata-schema.ts)
+- [Principal store](../../apps/runner/src/principal-store.ts)
+- [Recovery](../../docs/operations.md)
+
+## Overview
+
+Add an internal-only lifecycle contract and principal-owned SQLite registry. Public MCP names and tool inputs remain unchanged.
+
+## Requirements and architecture
+
+- Extend version-2 internal runner operations with `api_key_create`, `api_key_list`, `api_key_revoke`; define a separate service-authenticated verification schema so presented keys never become general runner operations.
+- Generate with `randomBytes(32)` and strict `chm_key_<random-public-id>.<secret>` format. Persist only immutable random ID, `principal_id`, SHA-256 hash, safe display prefix, name, `ACTIVE|REVOKED`, positive generation, and created/expires/last-used/revoked timestamps.
+- Accept a normalized name and integer `expiresInDays` `1..365`; never accept caller principal/hash/expiry timestamp/state/ID/prefix.
+- Enforce 10 active, unexpired keys within the same `BEGIN IMMEDIATE` create transaction; test concurrent creators.
+- Principal-qualify list/revoke; foreign and missing IDs are indistinguishable. Revoke uses expected-generation CAS.
+- Runner owns generation and returns plaintext only through a dedicated typed successful-create response, never generic `ToolResultSchema`. List/revoke/auth verification and every error are safe metadata only. Audit create/revoke without secret/hash.
+- Successful verification conditionally updates `last_used_at` at a fixed coalescing interval after the auth decision.
+
+## Related files
+
+- Modify contracts internal schema/exports and tests.
+- Modify runner metadata schema/store, dashboard control service, internal operation dispatch, and app.
+- Create focused `apps/runner/src/api-key-store.ts` plus narrow verification service if needed.
+
+## Implementation steps
+
+1. Write contract tests for lifecycle inputs, expiry, strict objects, safe responses, and exclusion from public runner operations.
+2. Add metadata schema v2 with `api_keys`, unique hash, and safe-prefix plus principal/state/expiry indexes.
+3. Implement transactional v1→v2 and idempotent v2 restart; reject future versions.
+4. Add a quiesced v2→v1 rollback command that drops only API-key state, resets version to 1, and preserves all unrelated tables/data.
+5. Implement generation-fenced create/list/revoke. Parse the exact public key ID, perform a one-row indexed lookup by ID, then constant-time compare the secret digest; display prefix never participates in lookup/authentication.
+6. Implement state/expiry verification, uniform failure, and post-decision coalesced usage telemetry.
+7. Test migration failure, restart, down migration, backup/restore, concurrency, random-ID collision retry, malformed/oversized keys, and foreign ownership.
+
+## Success criteria
+
+- [x] G4–G10 pass in focused tests.
+- [x] Database/audit contain no plaintext or hash disclosure.
+- [x] v1→v2→restart→v1 preserves unrelated state exactly.
+- [x] Public MCP schemas/tool inventory have zero diff.
+
+## Risks and rollback
+
+Back up quiesced SQLite first. Failed upgrade rolls back transactionally. Application rollback disables gateway/origin route, quiesces key mutation, backs up v2, runs tested down migration (invalidating all API keys), then starts prior binary. Never overwrite newer unrelated data with the pre-cutover snapshot.
+
+## Unresolved questions
+
+None.

--- a/plans/260818-1610-dashboard-managed-api-keys/phase-02-dual-auth-origin-boundary.md
+++ b/plans/260818-1610-dashboard-managed-api-keys/phase-02-dual-auth-origin-boundary.md
@@ -1,0 +1,70 @@
+---
+phase: 2
+title: "Dual-auth origin boundary and runner verification"
+status: completed
+priority: P1
+effort: "1.5-2d"
+dependencies: [1]
+---
+
+# Dual-auth origin boundary and runner verification
+
+## Context links
+
+- [Plan](./plan.md)
+- [Access auth](../../apps/api/src/auth.ts)
+- [JWT verifier](../../apps/api/src/access-jwt-verifier.ts)
+- [API mount](../../apps/api/src/app.ts)
+- [Runner client](../../apps/api/src/runner-client.ts)
+
+## Overview
+
+Mount dormant exact `/mcp-api-key`, requiring two independent credentials: exact verified gateway Access assertion, then a locally verified API key.
+
+## Architecture and requirements
+
+```text
+api.harness.zuey.me/mcp -> Worker service token -> Access assertion
+-> harness.zuey.me/mcp-api-key -> exact gateway verification
+-> private runner key verification -> creator principal -> unchanged MCP handler
+```
+
+- Add `API_KEY_AUTH_ENABLED=false`, `API_KEY_GATEWAY_ACCESS_AUDIENCE`, and exact normalized gateway service-subject pin. Fail config unless complete and `cloudflare-access`; owner-bearer cannot enable it. The gateway audience must differ from the main Access application audience.
+- Use a dedicated verifier configuration for the path-scoped gateway Access application. Reusing its issuer/JWKS is allowed; reusing the main audience is not.
+- Reuse bounded Access JWT verification, then require service identity and exact subject. Reject humans, other services, spoofed headers, opaque OAuth bearer, and missing assertions. Normal `/mcp` explicitly rejects the reserved gateway subject as defense in depth.
+- Verify the bearer only after gateway verification through one strict, bounded, service-authenticated runner RPC that never logs request body/Authorization. Authentication path responses never contain a raw key; the Dashboard create contract is the sole narrow exception.
+- Build request-local MCP `AuthInfo` only from the runner result: creator external selector plus sanitized credential ID for limiting/telemetry.
+- Apply global pre-auth caps and bounded per-credential limits. All invalid-key classes return one 401 shape.
+- Mount exact `/mcp-api-key` only: no aliases, redirect, discovery, dashboard, or fallback. Match `/mcp` JSON/Streamable HTTP bounds.
+- Reverify every request; no positive cache, so revoke/expiry denies the next request.
+
+## Related files
+
+- Modify config contracts/API config, API auth/app/request-security/runner-client, runner app/verification service, and focused tests.
+- Modify `deploy/ingress-proxy.mjs`, exact host nginx route, and boundary tests to carry only `/mcp-api-key` to the API without publishing a service port.
+- Update the environment template with variable names/placeholders only.
+
+## Implementation steps
+
+1. Test dormant default, partial config rejection, Access-only enablement, and exact path.
+2. Add purpose-specific exact-gateway assertion middleware.
+3. Add strict runner verification RPC with secret-free errors.
+4. Add API-key middleware/limiter and a second existing MCP handler mount.
+5. Add exact streaming proxy locations through credential-free ingress and host nginx; retain header pass-through needed for Access assertion and MCP without placing secrets in ingress.
+6. Test both-credential truth table, gateway assertion rejection on `/mcp`, human/main-audience rejection on `/mcp-api-key`, spoofing, concurrency isolation, runner outage, timeout, revoke, expiry, and exact ingress routing.
+7. Regression-test `/mcp`, dashboard, readiness, and owner-bearer.
+
+## Success criteria
+
+- [x] G1, G2, G5, G8, G9, G11 pass.
+- [x] Neither credential alone initializes MCP.
+- [x] Only the pinned gateway subject can present managed keys.
+- [x] Runner exposes no hash; authentication/list/revoke APIs emit no raw key. Only the typed Dashboard create response reveals it once with `no-store`.
+
+## Risks and rollback
+
+Keep separate exact route chains and request-local identity. Rollback disables public route, sets feature false, confirms hidden route absent, then follows Phase 1.
+
+## Unresolved questions
+
+None.

--- a/plans/260818-1610-dashboard-managed-api-keys/phase-03-dashboard-api-key-lifecycle.md
+++ b/plans/260818-1610-dashboard-managed-api-keys/phase-03-dashboard-api-key-lifecycle.md
@@ -1,0 +1,66 @@
+---
+phase: 3
+title: "Dashboard API-key lifecycle and one-time reveal"
+status: completed
+priority: P1
+effort: "1-1.5d"
+dependencies: [1, 2]
+---
+
+# Dashboard API-key lifecycle and one-time reveal
+
+## Context links
+
+- [Plan](./plan.md)
+- [Dashboard router](../../apps/api/src/dashboard-router.ts)
+- [Control routes](../../apps/api/src/dashboard-control-router.ts)
+- [Dashboard API client](../../apps/api/dashboard/dashboard-api.js)
+- [Dashboard renderer](../../apps/api/dashboard/dashboard-render.js)
+
+## Overview
+
+Add create/list/revoke to the Access-authenticated, CSRF-protected dashboard BFF. Reveal plaintext once in transient UI with an explicit full-RCE warning.
+
+## User flow and requirements
+
+1. GitHub/Google user opens **API keys**. List shows name, safe prefix, state, created, expiry, last-used, revoked; never hash/plaintext.
+2. Create requires name and integer expiry `1..365` days. Warn before submission that the key grants full MCP access, including arbitrary command execution as that principal.
+3. Success displays secret once in a keyboard/focus-safe panel with copy and acknowledgement. Keep it only in current JS memory/DOM; clear on dismiss, navigation, page hide, or failed copy.
+4. Revoke requires destructive confirmation and expected generation. No recovery, bulk export, scopes, or rotation action.
+
+## API and security contract
+
+- Add `GET /dashboard/api/v1/api-keys`, `POST /dashboard/api/v1/api-keys`, and generation-fenced `DELETE /dashboard/api/v1/api-keys/:keyId` behind existing Access principal, host/origin, JSON, CSRF, CSP, body-limit, and `no-store` controls.
+- Runner derives `principal_id`; browser/API never chooses it. Foreign and missing resources are indistinguishable.
+- BFF allowlists exactly one `apiKey` field on the typed successful create response. It is `no-store`; every other response and errors/accessibility announcements exclude the raw key.
+- Display only the public Worker URL after readiness says enabled; never show hidden origin path or gateway credentials.
+
+## Related files
+
+- Modify API dashboard control/response/types modules.
+- Modify dashboard API/render/app/style/HTML assets using current patterns.
+- Modify runner dashboard control/internal schemas from Phase 1.
+- Test router, UI contract/behavior, headers, DOM/storage leak, accessibility, and narrow viewport.
+
+## Implementation steps
+
+1. Write BFF tests for scoping, CSRF, validation, one-time create, redacted list, CAS revoke, and disabled state.
+2. Add focused API-client/renderer behavior; modularize only at real current boundaries.
+3. Add accessible create/revoke dialogs, copy feedback, expiry validation, active-count, and loading/empty/error states.
+4. Clear secret on every exit path and never re-fetch/replay it; document the single trusted runner→API→browser response path.
+5. Add static/runtime scans for storage, URL, analytics, console, and forbidden response fields.
+
+## Success criteria
+
+- [x] G4–G7 and G10 pass through BFF/runner/UI tests.
+- [x] Keyboard-only create, copy-once, acknowledgement, and revoke work.
+- [x] Warning states full authority, expiry, and non-recoverability.
+- [x] Reload/list cannot reveal a prior secret.
+
+## Risks and rollback
+
+Lost create responses require a new key; never persist/replay plaintext. Feature readiness may hide this panel while the rest of dashboard stays available.
+
+## Unresolved questions
+
+None.

--- a/plans/260818-1610-dashboard-managed-api-keys/phase-04-cloudflare-worker-gateway.md
+++ b/plans/260818-1610-dashboard-managed-api-keys/phase-04-cloudflare-worker-gateway.md
@@ -1,0 +1,63 @@
+---
+phase: 4
+title: "Cloudflare Worker API-key gateway"
+status: completed
+priority: P1
+effort: "1-1.5d"
+dependencies: [2]
+---
+
+# Cloudflare Worker API-key gateway
+
+## Context links
+
+- [Plan](./plan.md)
+- [Topology](../../docs/system-architecture.md)
+- [Deployment](../../docs/deployment.md)
+- [Compose verifier](../../scripts/verify-compose-boundaries.mjs)
+
+## Overview
+
+Create a minimal Worker workspace for `api.harness.zuey.me/mcp`. It is a fixed streaming proxy, not a key database: accept ordinary Bearer, discard spoofable metadata, inject only its origin Access service token.
+
+## Requirements and architecture
+
+- Add `apps/api-key-gateway/` TypeScript workspace with source, tests, typecheck/build, and secret-free Wrangler manifest.
+- Bind exact public `/mcp` and only MCP-required methods. Reject other paths/methods with bounded non-HTML responses; no dashboard, health, arbitrary proxy, or dynamic upstream.
+- Fixed HTTPS upstream ends at exact `/mcp-api-key`; reject redirects and never derive host/path from caller data.
+- Reconstruct outgoing headers from an allowlist needed for Streamable HTTP: Authorization, content negotiation/type, MCP protocol/session/event IDs, and only justified bounded tracing.
+- Never copy the incoming Headers object. Thus caller `Cf-*`, `Cf-Access-*`, `Forwarded`, `X-Forwarded-*`, `X-Real-IP`, service-token, Host, hop-by-hop, and cache headers are discarded. Inject Worker-owned Access headers afterward.
+- Stream bodies without buffering/transformation. Disable caching, body/auth logging, analytics capture, and exception body dumps. Preserve only safe MCP response headers.
+- Store service-token values as Worker secrets only. Use distinct preview/production credentials and exact Service Auth policy for this Worker token.
+- Protect the hidden origin path with a separate, exact path-scoped Access application and unique audience; never add the Worker token to the main `/mcp`/dashboard application's policies.
+- Add a manifest-owned aggregate Cloudflare Rate Limiting binding (600 requests per 60 seconds per Cloudflare location) that returns bounded `429` on exhaustion and fails closed when unavailable; origin per-credential limits remain authoritative.
+
+## Related files
+
+- Create Worker workspace package, TypeScript config, source, tests, secret-free manifest.
+- Modify root scripts/lockfile/CI to include Worker verification without live credentials.
+- Modify deploy verification for second hostname, host nginx exact hidden route, credential-free ingress exact hidden route, and associated boundary assertions.
+- Do not change Compose networks or publish API/runner ports.
+
+## Implementation steps
+
+1. Test exact route/method, header allowlist, injection, fixed upstream, redirects, streaming/SSE, limiter exhaustion/failure, errors, and cache.
+2. Implement smallest proxy with dependency-injected upstream fetch.
+3. Add secret-name checks and leak scans; fixtures use `[redacted]` only.
+4. Integrate build/typecheck/test into root verification.
+5. Deploy preview and run sanitized key-through-Worker canary.
+
+## Success criteria
+
+- [x] G1, G3, G7, and G11 have automated coverage; G13 has named Phase 6 canaries.
+- [x] Spoofed Cloudflare/forwarding/service headers never reach origin.
+- [x] Worker cannot proxy another origin/path or dashboard traffic.
+- [x] Worker secrets stay out of repository, CI, logs, snapshots.
+
+## Risks and rollback
+
+The Worker is public, so bounded errors and layered limits are mandatory. Remove/disable its route first; hidden origin remains protected by exact service assertion and is disabled independently.
+
+## Unresolved questions
+
+None.

--- a/plans/260818-1610-dashboard-managed-api-keys/phase-05-security-and-regression-verification.md
+++ b/plans/260818-1610-dashboard-managed-api-keys/phase-05-security-and-regression-verification.md
@@ -1,0 +1,62 @@
+---
+phase: 5
+title: "Security, regression, and leak verification"
+status: in_progress
+priority: P1
+effort: "1d"
+dependencies: [1, 2, 3, 4]
+---
+
+# Security, regression, and leak verification
+
+## Context links
+
+- [Acceptance gates](./plan.md#observable-acceptance-gates)
+- [Development verification](../../docs/development.md)
+- [Security model](../../docs/security-model.md)
+- [MCP contract](../../docs/mcp-api.md)
+
+## Overview
+
+Prove G1–G13 across contracts, API, runner, dashboard, Worker, migration, and unchanged OAuth/owner-bearer behavior before rollout.
+
+## Verification matrix
+
+- **Crypto/storage:** entropy/format, hash-only persistence, collision, final constant-time compare, reveal once, no recovery.
+- **Authorization:** gateway+key truth table; gateway subject on `/mcp`; human/main-audience/other assertion on `/mcp-api-key`; malformed/oversized/unknown/foreign/revoked/expired key; cross-principal handle; next-request revoke.
+- **Gateway:** forbidden duplicate/mixed-case headers, hop-by-hop/smuggling, arbitrary target, redirect, method/path, POST/GET/DELETE streaming, SSE/session/event, cache.
+- **Lifecycle:** expiry clock edges, 10-key race, repeat/stale revoke, transaction failure, last-used races.
+- **Browser:** CSRF/origin/type, `no-store`, DOM/storage/URL/console/error/a11y, reload after reveal.
+- **Migration:** empty/existing v1 upgrade, failure, v2 restart, future version, quiesced down migration, prior binary, backup restore.
+- **Regression:** Managed OAuth discovery/login/token, `/mcp` initialize/tools/call, dashboard SSO, owner-bearer, runner service auth, direct-origin denial, public tool snapshot.
+- **Leaks:** source/diff/build assets, SQLite, API/Worker logs, audits, HTTP, snapshots, deploy receipts.
+
+## Related gates
+
+- Add focused tests beside modules and integration coverage under `test/integration/`.
+- Run narrow suites, `npm run verify:compose`, `npm run verify`.
+- When available, build executor/API/runner images and run Docker/e2e suites.
+- Mandatory tester/debugger resolve failures; code-reviewer checks G1–G13, all callers, side effects, and public boundaries.
+
+## Implementation steps
+
+1. Maintain G1–G13-to-test receipt; only Phase 6 live gates may lack local runtime evidence.
+2. Run contract/runner, API/MCP, dashboard, Worker suites in dependency order.
+3. Run sentinel and secret-pattern leak tests on every storage/output surface.
+4. Run full gates without weakening assertions, timeouts, or isolation.
+5. Resolve findings, then independent code review of exact diff.
+
+## Success criteria
+
+- [x] Every G1–G13 row has passing automated evidence or named Phase 6 canary.
+- [x] Compose/full verify pass on the reviewed working tree.
+- [ ] Docker/e2e pass at exact head in hosted CI; local API/runner image builds and Docker/E2E were unavailable due latency/timeouts.
+- [x] Public MCP/OAuth behavior remains compatible in automated regression coverage.
+
+## Risks and rollback
+
+No rollout with untested dual auth, leaks, migration uncertainty, or OAuth regression. Revert/re-plan instead of adding bypasses or weaker assertions.
+
+## Unresolved questions
+
+None.

--- a/plans/260818-1610-dashboard-managed-api-keys/phase-06-deployment-rollback-and-documentation.md
+++ b/plans/260818-1610-dashboard-managed-api-keys/phase-06-deployment-rollback-and-documentation.md
@@ -1,0 +1,64 @@
+---
+phase: 6
+title: "Deployment, rollback, and documentation"
+status: in_progress
+priority: P1
+effort: "1-1.5d"
+dependencies: [1, 2, 3, 4, 5]
+---
+
+# Deployment, rollback, and documentation
+
+## Context links
+
+- [Plan](./plan.md)
+- [Deployment](../../docs/deployment.md)
+- [Operations](../../docs/operations.md)
+- [Configuration](../../docs/configuration.md)
+- [Architecture](../../docs/system-architecture.md)
+- [Client connection](../../README.md#connect-from-ai-clients)
+
+## Overview
+
+Roll out dormant-first in reversible stages, then prove both public lanes and a sanitized create/use/revoke lifecycle at the exact deployed commit.
+
+## Deployment sequence
+
+1. Record branch/SHA, CI, Cloudflare account/zone/application identifiers, DNS target, Access policies, origin config, DB version, and rollback artifact without credentials.
+2. Quiesce, back up SQLite, deploy v2-capable code with feature disabled, migrate/restart/verify OAuth/dashboard, then resume.
+3. Create a separate Access application scoped exactly to `harness.zuey.me/mcp-api-key`, with its own audience and an exact Service Auth policy for the dedicated Worker token. Do not add this token to the existing `/mcp`/dashboard application. Store values only as Worker secrets; pin normalized service subject and gateway audience in origin config.
+4. Deploy preview, prove stripping/fixed upstream/direct-origin denial, then bind `api.harness.zuey.me/mcp` in the owned zone. No unproxied origin record.
+5. Enable hidden route, create disposable short-lived key, initialize/list/call through Worker, revoke, prove next request fails, then destroy test state.
+6. Re-run GitHub/Google dashboard login and Managed OAuth discovery/initialize on `harness.zuey.me/mcp`; prove gateway assertion is denied there, prove Cloudflare selects the path-scoped gateway app/audience only for the hidden path, verify exact head, and inspect logs/DB/audit/browser for key/hash absence.
+
+## Rollback matrix
+
+- **Worker:** disable public route; OAuth/dashboard unchanged.
+- **Origin:** feature false, hidden route absent, then revoke Worker service token.
+- **Application:** quiesce, backup v2, run tested v2→v1 (API keys invalidated, unrelated data retained), deploy prior images/config, canary OAuth/dashboard/readiness.
+- **Corruption:** stop and restore coordinated pre-migration backup; report any unrelated post-cutover write loss.
+- Never expose bearer-only nginx/origin, publish API/runner, relax Access, or retain temporary bypass.
+
+## Documentation owners
+
+- README and MCP usage: separate URLs, full-RCE warning, reveal/expiry/revoke.
+- Security model: Worker/public bearer and exact service assertion boundaries.
+- System architecture: Worker→Access→hidden origin→runner verification.
+- Configuration and environment template: dormant variable/secret names, never values.
+- Deployment, operations, troubleshooting: provision, canary, revoke, backup/down migration, 401/HTML/Worker diagnosis, replacement rotation.
+- Point docs to executable schemas/scripts/manifests rather than copy generated inventories.
+
+## Success criteria
+
+- [ ] G12/G13 receipts record exact SHA, CI, deployments, hosts, revoke, rollback readiness, and secret-free evidence.
+- [ ] OAuth, GitHub/Google dashboard, and static Bearer clients work only on intended lanes.
+- [ ] Direct origin, wrong assertion, and revoked key remain denied.
+- [x] Docs state full authority, no scopes, no recovery, no rotation endpoint.
+
+## Risks and rollback
+
+Cloudflare state and code deployment are separate evidence. Preserve known-good OAuth throughout; stage new hostname last and remove its route first on rollback.
+
+## Unresolved questions
+
+None.

--- a/plans/260818-1610-dashboard-managed-api-keys/plan.md
+++ b/plans/260818-1610-dashboard-managed-api-keys/plan.md
@@ -1,0 +1,61 @@
+---
+title: "Dashboard-managed API keys through a Cloudflare Worker gateway"
+description: "Add principal-bound static API keys without weakening Managed OAuth or origin Access."
+status: in_progress
+priority: P1
+effort: "6-9d"
+branch: codex/feat/dashboard-api-keys
+tags: [api-keys, dashboard, cloudflare-worker, authentication, security]
+created: 2026-08-18
+---
+
+# Dashboard-managed API keys
+
+## Outcome
+
+Dashboard users can create, list, and revoke expiring API keys for static MCP clients. OAuth clients remain on `https://harness.zuey.me/mcp`; API-key clients use `https://api.harness.zuey.me/mcp` through a dedicated Cloudflare Worker. The origin accepts keys only at exact `/mcp-api-key`, protected by a separate path-scoped Access application and audience, and only with the verified, exactly pinned Worker service assertion.
+
+## Constraints and non-goals
+
+- Preserve `cloudflare-access`, GitHub/Google SSO, Managed OAuth discovery, and public MCP tool schemas.
+- Store only SHA-256 hashes of CSPRNG 256-bit secrets; reveal plaintext once, never in logs, audit, SQLite, analytics, or browser persistence.
+- Bind each key to durable `principal_id`; every key grants that principal's full MCP/RCE authority.
+- Mandatory expiry `1..365` days, maximum 10 active keys per principal, immediate next-request revoke.
+- No scopes, ownership edits, recovery, bulk export, or rotation endpoint; rotate by create-new then revoke-old.
+- Gateway and origin route are dormant by default; no direct-origin or spoofed-header fallback.
+
+## Phases
+
+| # | Phase | Dependency | Status |
+|---|---|---|---|
+| 1 | [Contracts, registry, migration](./phase-01-contracts-key-registry-and-migration.md) | — | Complete |
+| 2 | [Dual-auth origin](./phase-02-dual-auth-origin-boundary.md) | 1 | Complete |
+| 3 | [Dashboard lifecycle](./phase-03-dashboard-api-key-lifecycle.md) | 1, 2 | Complete |
+| 4 | [Worker gateway](./phase-04-cloudflare-worker-gateway.md) | 2 | Complete |
+| 5 | [Security verification](./phase-05-security-and-regression-verification.md) | 1–4 | In progress |
+| 6 | [Deploy, rollback, docs](./phase-06-deployment-rollback-and-documentation.md) | 1–5 | In progress |
+
+## Observable acceptance gates
+
+- [x] G1 OAuth stays on `/mcp`; API keys use only the Worker hostname; hidden origin route is not advertised.
+- [x] G2 Origin requires the separate gateway-app audience and exact configured gateway service subject before key verification; `/mcp` explicitly rejects that reserved subject.
+- [x] G3 Worker reconstructs allowlisted requests; caller `Cf-*`, Access, `Forwarded`, and `X-Forwarded-*` cannot pass.
+- [x] G4 Secrets have 256-bit entropy, reveal once, and persist only as SHA-256 plus safe metadata.
+- [x] G5 Key lifecycle and resulting MCP authority remain bound to creator `principal_id`.
+- [x] G6 Expiry `1..365` days and 10-active-key limit hold transactionally under concurrency.
+- [x] G7 Plaintext and hash are absent from logs, audit, errors, browser storage, analytics, fixtures, and receipts.
+- [x] G8 Revoked, expired, unknown, and malformed keys fail uniformly with no positive auth cache.
+- [x] G9 `last_used_at` is coalesced and never participates in authorization.
+- [x] G10 Create/revoke emit redacted principal-scoped audits using immutable key ID/generation.
+- [x] G11 Public runner/tool schemas, `tools/list`, OAuth discovery, and owner-bearer installs stay compatible.
+- [x] G12 v1→v2, restart, v2→v1 rollback, and dormant readiness preserve unrelated state.
+- [ ] G13 live canaries prove path-specific Access app selection, audience separation, both lanes, revoke, direct-origin denial, exact head, and zero secret retention.
+
+## Evidence and decision record
+
+- Scout authority: API auth/app, dashboard control modules, internal runner contract, runner metadata schema/store.
+- Research: `../reports/researcher-260818-1610-api-key-auth-security.md`. Its native service-token recommendation is superseded because static clients need ordinary Bearer keys; Worker plus exact service assertion retains no-bypass origin security.
+- Baseline: `../260817-1321-13-cloudflare-oauth-dashboard/`.
+- Review: six phases swept against G1–G13; public MCP schemas remain untouched; rollback is explicit; unresolved decisions: none.
+
+<!-- slug: dashboard-managed-api-keys -->

--- a/plans/reports/code-reviewer-260818-dashboard-api-keys.md
+++ b/plans/reports/code-reviewer-260818-dashboard-api-keys.md
@@ -1,0 +1,35 @@
+# Dashboard-managed API keys final review
+
+## Verdict
+
+**GO for commit/PR.** No remaining Critical, Important, or real Medium finding. Exact-head hosted CI remains a merge gate; live Cloudflare canaries remain an enablement gate.
+
+## Resolved findings
+
+1. **Usage telemetry is non-authoritative.**
+   - Verified by `apps/runner/src/api-key-store.ts:125-140` and `apps/runner/test/api-key-store.test.ts:118-127`: the coalesced update is best-effort after the digest decision, and a trigger-forced telemetry failure still returns the verified principal/key ID without changing `last_used_at`.
+
+2. **Cloudflare edge rate limiting has executable and operational ownership.**
+   - Verified by `apps/api-key-gateway/wrangler.jsonc:12-20`, `apps/api-key-gateway/src/gateway.ts:94-103`, and `apps/api-key-gateway/test/gateway.test.ts:150-171`: the manifest owns a 600-request/60-second binding, exhaustion returns bounded `429` plus `Retry-After`, binding failure returns `503`, and neither path reaches origin. Configuration, security, and deployment docs own verification and rollback guidance.
+
+## Acceptance trace
+
+- G1-G3: code path separation, dedicated audience/exact service subject, normal `/mcp` rejection, fixed upstream, redirect rejection, header reconstruction, and Worker-owned service-token injection are present and focused-tested.
+- G4-G9: 256-bit secret generation, strict format, SHA-256-only persistence, indexed ID lookup plus constant-time digest compare, principal binding/relink, transactional ten-active cap, revoke/expiry/no-positive-cache behavior, and non-authoritative coalesced usage telemetry are present.
+- G10: create/revoke audit is principal-scoped, redacted, and runs inside the key mutation transaction with immutable key ID/generation.
+- G11-G12: public MCP operation schemas remain separate; config truth table, v1/v2 migration, restart, compiled downgrade, and unrelated-state preservation have automated evidence.
+- G13: intentionally incomplete locally. Exact-head hosted CI and owner-authorized Cloudflare/DNS/Access/Worker/revoke/direct-origin/leak canaries remain mandatory before merge and enablement.
+- Browser: the successful create response is `no-store` through dashboard middleware; plaintext is held only in the current response/local reveal state and cleared on acknowledgement, cancel, navigation, page hide, or copy failure.
+- Runner RPC: service-token authenticated, bounded JSON transport; presented keys are excluded from `AuthInfo`, logs, audit, and non-create response schemas.
+
+## Fresh verification
+
+- Initial focused contracts/API/Worker/runner: 5 files, 54 tests passed.
+- Re-review focused contracts/API/Worker/runner: 4 files, 45 tests passed.
+- API, runner, and Worker typechecks passed; Worker build/Wrangler dry-run passed and listed `API_KEY_RATE_LIMITER (600 requests/60s)`.
+- `git diff --check` passed.
+- Prior exact-tree evidence: full `npm run verify` 258 tests and `verify:compose` passed; local API/runner Docker builds and Docker/E2E were unavailable due latency/timeouts, not passes.
+
+## Unresolved questions
+
+None.

--- a/plans/reports/code-simplifier-260818-1658-api-key-auth.md
+++ b/plans/reports/code-simplifier-260818-1658-api-key-auth.md
@@ -1,0 +1,34 @@
+# API-key implementation simplification
+
+## Scope reviewed
+
+- API authentication middleware and runner client
+- Runner API-key service/store
+- API-key contracts
+- Cloudflare Worker gateway
+
+## Changes
+
+- Centralized the reserved gateway-subject comparison used by normal Access auth and the API-key gateway auth path. This keeps the audience split and exact-subject invariant expressed once.
+- Simplified generic runner JSON fallback handling to one callback shape, removing a union and unsafe function cast while preserving timeout/unavailable behavior.
+- Folded Worker request-header size and singleton rules into one policy map, removing parallel allowlist metadata.
+- Left store, service, and contract implementation unchanged: their current separation is small, explicit, and security-relevant. No file exceeds 200 lines.
+
+## Verification
+
+- `npm run typecheck -w @cloud-harness/api` — pass
+- `npm run typecheck -w @cloud-harness/api-key-gateway` — pass
+- Focused auth/gateway/store/contracts suite — 4 files, 35 tests pass
+- `git diff --check` — pass
+
+## Preserved invariants
+
+- Normal `/mcp` rejects the reserved gateway service subject.
+- API-key route requires the exact gateway service subject and a valid key.
+- Raw keys are not copied into `AuthInfo`.
+- Worker forwards only allowlisted headers and injects its own Access service credentials.
+- No positive key-auth cache introduced.
+
+## Unresolved questions
+
+None.

--- a/plans/reports/pm-260818-dashboard-api-keys.md
+++ b/plans/reports/pm-260818-dashboard-api-keys.md
@@ -1,0 +1,29 @@
+# Dashboard-managed API keys plan sync
+
+## Status
+
+| Phase | Status | Evidence / remaining gate |
+|---|---|---|
+| 1. Contracts, registry, migration | Complete | Focused coverage; compiled rollback leaves schema version 1 with `api_keys` absent. |
+| 2. Dual-auth origin | Complete | Exact subject/audience and two-credential boundary focused-tested. |
+| 3. Dashboard lifecycle | Complete | One-time reveal, no-store, revoke, UI safety, and regression coverage pass. |
+| 4. Worker gateway | Complete | Fixed route/header policy tested; dry-run lists `API_KEY_RATE_LIMITER` at 600 requests/60s. |
+| 5. Security verification | In progress | Corrections: 45 tests pass. Full verify: lint/typecheck/build plus 46 files/264 tests pass. Compose gate passes. Hosted exact-head Docker/E2E CI pending. |
+| 6. Deploy, rollback, docs | In progress | Code/docs/rollback procedure complete. PR/CI, Cloudflare Access app, Worker/domain/rate limit, canaries, and production enablement pending. |
+
+## Review decision
+
+- Final reviewer: GO for commit/PR; no Critical, Important, or Medium findings.
+- G1–G12 supported by implementation and automated evidence. G13 remains open for exact-head hosted CI and owner-authorized live canaries.
+- Local API/runner image build and Docker/E2E unavailable due latency/timeouts; not claimed as passing.
+- No production deployment or customer enablement claimed.
+
+## Next actions
+
+1. Open PR and require exact-head hosted CI, including Docker/E2E.
+2. Provision separate path-scoped Cloudflare Access app/policy and Worker secrets/rate-limit binding.
+3. Deploy preview, then run sanitized dual-lane, revoke, direct-origin, audience-selection, and leak canaries before production enablement.
+
+## Unresolved questions
+
+None.

--- a/plans/reports/researcher-260818-1610-api-key-auth-security.md
+++ b/plans/reports/researcher-260818-1610-api-key-auth-security.md
@@ -1,0 +1,150 @@
+---
+title: Dashboard-managed API key authentication security research
+date: 2026-08-18T16:10:00+07:00
+status: complete
+scope: Cloudflare Access-protected MCP and static-key clients
+---
+
+# Dashboard-managed API key authentication security research
+
+## Summary
+
+Recommend provisioning **Cloudflare Access service tokens**, not origin-verified
+opaque bearer keys. Access can accept a service token in one configured header;
+Cloudflare creates a client ID/secret pair, shows the secret once, verifies every
+request at the edge, and forwards a signed application JWT. This preserves the
+existing no-bypass invariant while supporting clients able to set one exact
+header value. [Cloudflare service tokens](https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/)
+
+Critical compatibility gate: the one-header value is JSON containing both
+Cloudflare fields, not `Bearer <opaque-key>`. Confirm Dewee can send this exact
+`Authorization` value. If it forces Bearer syntax, do not open an unprotected
+hostname/path or accept that bearer at origin; retain Managed OAuth or make the
+separate Workers OAuth-provider decision already required by
+[`docs/deployment.md`](../../docs/deployment.md).
+
+## Recommended trust flow
+
+```text
+human Access identity -> dashboard -> runner-only Cloudflare broker -> service token
+static client -> Access edge -> signed JWT -> origin mapping -> principal operation
+```
+
+Use a dedicated Service Auth policy. Configure
+`read_service_tokens_from_header: Authorization`; the client sends the exact
+Cloudflare JSON value. Keep the hostname-wide Access application protecting
+both `/mcp` and `/dashboard`. Direct-to-origin traffic still fails because the
+origin requires a valid issuer/audience/signature/expiry Access assertion.
+
+Cloudflare service JWTs have empty `sub`; `common_name` is the service token
+client ID. The current verifier already normalizes this shape, but automatic
+creation of a new external principal is unsafe for dashboard keys. Require an
+active local mapping from verified `common_name` to the creating human's durable
+principal. Unknown service IDs fail closed. [Application-token claims](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/)
+
+## Key lifecycle and storage
+
+- Generate through a runner-only broker. Give its API credential only
+  account-scoped `Access: Service Tokens Write`; never expose it elsewhere.
+- Return client ID + secret only in the successful `no-store` create response.
+  Use transient DOM state; no storage, analytics, replay, or later recovery.
+- Do **not** persist or hash the Cloudflare client secret locally: origin never
+  verifies it. Store `credential_id`, Cloudflare token ID, client ID,
+  `principal_id`, label, state/generation, created/expires/revoked timestamps,
+  and coalesced last-used metadata. Client ID is an identifier, not a secret.
+- If a future edge verifier issues native high-entropy `Bearer chm_...` keys,
+  store only a versioned keyed hash (HMAC with a separately held pepper), use a
+  public lookup prefix plus constant-time verification, and show plaintext once.
+  Password KDFs address low-entropy memorized secrets; a CSPRNG-generated token
+  should instead have enough entropy to resist guessing. This alternative is
+  out of scope until the edge can authenticate it without bypass.
+- Expiry is mandatory and bounded; no `forever` default. Rotation creates a new
+  credential, allows an explicit overlap window, then revokes the old one.
+  Bearer credentials are replayable, so TLS, audience restriction, scoping and
+  short lifetime reduce exposure. [RFC 6750](https://www.rfc-editor.org/rfc/rfc6750.html)
+
+## Ownership and consistency
+
+- Create/list/rotate/revoke queries always include the authenticated human
+  principal. Never select by email/name and never permit cross-principal IDs.
+- Prefer a preconfigured `any valid service token` Service Auth policy plus the
+  origin mapping gate. This avoids granting runtime policy-write authority and
+  policy-update races. Its safety depends on unknown client IDs being denied,
+  not auto-enrolled.
+- Create: record intent/idempotency key; call Cloudflare; transactionally store
+  mapping; return plaintext once. If the response is lost, never replay/store
+  the secret: revoke and recreate. Reconcile reserved-name Cloudflare tokens
+  with no local mapping as denied orphans and delete them.
+- Revoke: transactionally mark local state `REVOKING` first so origin denies
+  immediately, then delete at Cloudflare, then mark `REVOKED`. Retry/reconcile
+  failed or uncertain deletes by Cloudflare token ID. Cloudflare says deletion
+  prevents future service-token access.
+- Configure Service Auth so the credential is presented every request. Access
+  notes that reusable JWT sessions are available when an Allow policy exists;
+  the local active-record check must still reject a revoked mapping.
+- Avoid positive authorization caches initially. The runner's single SQLite
+  record can be checked per operation. If later measured necessary, use
+  generation-tagged entries, explicit invalidation, very short TTL, and
+  fail-closed behavior on registry failure. Never let `last_used_at` writes
+  become the authorization transaction; coalesce them asynchronously.
+
+## Rate limits and audit
+
+- Keep pre-auth global/concurrency limits, then rate-limit by credential ID,
+  separately from the resource principal. One owner with several keys needs
+  independent abuse attribution. Add stricter create/rotate/revoke limits.
+- Add an edge IP/host/path rate rule as defense in depth. Cloudflare counters
+  are per data center, not global; origin limits remain required. Avoid using
+  the raw Authorization value as a logged/counting identifier.
+  [Cloudflare rate calculation](https://developers.cloudflare.com/waf/rate-limiting-rules/request-rate/)
+- Audit create, reveal completion, rotate, revoke request/result, expiry,
+  reconciliation, successful use (coalesced), rejected revoked/expired use,
+  and authorization failures. Record human principal, credential ID, action,
+  timestamps, result, and sanitized Cloudflare/Ray correlation IDs—never
+  secret/header/JWT values.
+- Correlate local events with Cloudflare Access authentication logs, which
+  record successful and failed user/service authentication. Per-request log
+  availability depends on plan. [Access authentication logs](https://developers.cloudflare.com/cloudflare-one/insights/logs/dashboard-logs/access-authentication-logs/)
+
+## MCP standards impact
+
+The current MCP HTTP authorization specification uses OAuth 2.1 bearer access
+tokens, Protected Resource Metadata, authorization-server discovery, and
+`WWW-Authenticate`; tokens must target the MCP resource and must not be
+accepted for other resources. Keep Cloudflare Managed OAuth as the standards
+lane. [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+
+The service-token JSON header is a manual non-OAuth compatibility lane. Do not
+describe it as MCP OAuth or mint an origin bearer that collides with OAuth.
+Continue serving discovery for capable clients and test both lanes at the same
+public edge.
+
+## Deployment and test implications
+
+- Add migration-backed credential mapping/lifecycle/audit tables and internal
+  runner operations; preserve rollback with the existing state snapshot.
+- Add a runner-only Cloudflare API-token file and bounded outbound client
+  (fixed account/API host, redirect rejection, time/body bounds).
+- Change principal resolution so `cf-service:*` cannot auto-provision. Preserve
+  separate `auth actor credential` and `resource owner principal` identities.
+- Cloudflare rollout: one-header application setting, Service Auth policy,
+  restricted broker API token, expiry alerts, then exact-head deploy/canary.
+- Tests: unknown/cross-owner/revoked/expired IDs; forged origin headers; lost
+  responses/orphans; leak scans; concurrency; limits; last-used coalescing;
+  Dewee live probe; Managed OAuth regression; rollback migration.
+- Production proof must separately show edge acceptance, origin mapping,
+  immediate local revoke, Cloudflare deletion, direct-origin rejection, and no
+  browser/log/DB secret retention.
+
+## Unresolved questions
+
+1. Can Dewee send the exact single-header JSON value, or only `Bearer <token>`?
+2. What maximum expiry and rotation overlap does the owner accept?
+3. Does the Cloudflare plan provide needed per-request logs/rate characteristics?
+
+## Primary sources
+- [Cloudflare service tokens and lifecycle](https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/)
+- [Cloudflare service-token API](https://developers.cloudflare.com/api/resources/zero_trust/subresources/access/subresources/service_tokens/)
+- [Cloudflare Access JWT validation and claims](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/)
+- [MCP HTTP authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [OAuth bearer-token security](https://www.rfc-editor.org/rfc/rfc6750.html)

--- a/plans/reports/tester-260818-1705-dashboard-api-key-verification.md
+++ b/plans/reports/tester-260818-1705-dashboard-api-key-verification.md
@@ -1,0 +1,56 @@
+---
+title: Dashboard-managed API-key verification
+date: 2026-08-18
+status: done-with-concerns
+branch: codex/feat/dashboard-api-keys
+base_head: 87958e9
+---
+
+# Summary
+
+Final working-tree implementation passes focused tests, Compose boundary verification, and the full non-Docker repository gate. Testing found one real UI contract mismatch: the BFF returned `publicUrl` at a different shape than the renderer consumed. A regression assertion was added, the implementation was fixed, and the focused/full gates passed afterward.
+
+Docker-backed verification is not a pass. The executor image rebuilt successfully from this working tree, but API and runner image builds stalled during `npm ci`; the local Docker integration and E2E suites subsequently hit their existing fixed timeouts. No assertion showed an API-key feature defect, but exact-head hosted Docker evidence is still required before claiming the complete ship gate.
+
+# Verification results
+
+| Gate | Result | Evidence |
+|---|---|---|
+| Focused contracts/runner/API/dashboard/Worker | PASS | 10 files, 90 tests |
+| `npm run verify:compose` | PASS | `compose-boundaries=pass` |
+| `npm run verify` | PASS | lint, typecheck, 46 files / 258 tests, builds, Wrangler dry-run |
+| Executor image build | PASS | rebuilt `cloud-harness-executor:local` from current working tree |
+| API/runner image build | UNAVAILABLE | both stalled at `RUN npm ci`; stopped cleanly after more than 10 minutes |
+| `npm run test:docker` | UNAVAILABLE | 2 files failed on timeouts: 10s setup and 120s test; 1 failed, 3 skipped |
+| `npm run test:e2e` | UNAVAILABLE | coding workflow reached fixed 120s timeout; 1 failed |
+| Live production canaries | NOT RUN | deployment/owner-credential gate, outside local test scope |
+
+# Acceptance coverage
+
+- G1-G3: route separation, dedicated audience/subject validation, Worker host/header enforcement covered by contracts, API gateway-auth, and Worker tests.
+- G4-G6: key format, hash-only persistence, durable principal mapping, expiry bounds, and transactional active-key limit covered by contracts and runner store/service tests.
+- G7-G10: safe response metadata, uniform invalid-key behavior, coalesced usage tracking, and audit events covered by focused API/runner tests. Safe synthetic sentinels only; no real secrets used.
+- G11: public `TOOL_SPECS`, OAuth flow, and owner bearer behavior remained covered by the full 258-test repository suite.
+- G12: migration up/down and restart behavior covered by metadata/store tests; Docker restart evidence remains unavailable because the suite timed out.
+- G13: live valid/revoked/expired/wrong-host/OAuth canaries were not executed locally.
+
+# Regression added
+
+`apps/api/test/dashboard-ui-behavior.test.ts` now asserts that the configured API-key MCP endpoint is rendered, while raw keys and internal hashes are absent. Existing UI tests also verify one-time reveal, clipboard-failure clearing, acknowledgement clearing, and removal of the JS-held secret.
+
+# Docker diagnosis and cleanup
+
+- `test:docker` and `test:e2e` import current working-tree TypeScript sources and use the freshly rebuilt executor image; they were not stale-image-only runs.
+- API/runner image builds emitted Node engine warnings for release-only dependencies, then stopped producing output during `npm ci`.
+- Timeouts were not increased and assertions were not weakened.
+- The owned build was interrupted cleanly. Final inspection found no Cloud Harness managed containers, matching test volumes, Vitest/E2E process, or orphaned Compose/build process.
+
+# Concerns
+
+- Do not label the API/runner image build, Docker integration suite, or E2E suite as passing.
+- Require exact-head hosted CI or a successful local rerun for those gates before merge/release claims.
+- No coverage percentage was collected because the repository defines no coverage threshold command; the repository-owned `verify` gate is green.
+
+# Unresolved questions
+
+None.

--- a/scripts/verify-compose-boundaries.mjs
+++ b/scripts/verify-compose-boundaries.mjs
@@ -51,9 +51,12 @@ const locationBlock = (pattern) => nginx.match(pattern)?.[0] ?? '';
 const dashboardEntry = locationBlock(/location = \/dashboard \{[^}]+\}/s);
 const dashboardPrefix = locationBlock(/location \^~ \/dashboard\/ \{[^}]+\}/s);
 const mcp = locationBlock(/location = \/mcp \{[^}]+\}/s);
+const apiKeyMcp = locationBlock(/location = \/mcp-api-key \{[^}]+\}/s);
 requireBoundary(dashboardEntry.includes('proxy_pass http://127.0.0.1:3100/dashboard;'), 'nginx dashboard entry point must preserve its upstream path');
 requireBoundary(dashboardPrefix.includes('proxy_pass http://127.0.0.1:3100/dashboard/;'), 'nginx dashboard prefix must preserve asset and BFF paths');
 for (const directive of ['proxy_http_version 1.1;', 'proxy_buffering off;', 'proxy_request_buffering off;', 'proxy_read_timeout 3600s;']) {
   requireBoundary(mcp.includes(directive), `nginx MCP streaming directive is missing: ${directive}`);
+  requireBoundary(apiKeyMcp.includes(directive), `nginx API-key MCP streaming directive is missing: ${directive}`);
 }
+requireBoundary(apiKeyMcp.includes('proxy_pass http://127.0.0.1:3100/mcp-api-key;'), 'nginx API-key MCP route must preserve its hidden upstream path');
 console.log('compose-boundaries=pass');


### PR DESCRIPTION
## Summary
- Add a dashboard-managed MCP API key lifecycle across typed contracts, the runner metadata store, dashboard controls, and API dual-auth routing.
- Add a separate Cloudflare Worker gateway that validates API keys at the origin, forwards the Access service assertion, and applies bounded request controls without exposing key material.
- Preserve security boundaries with hashed key storage, one-time plaintext display, revocation, explicit origin-only headers, rollback artifacts, and updated operator/security guidance.

## Verification
- [x] npm run verify:compose — PASS
- [x] npm run verify — PASS: lint, typecheck, build, and 46 files / 267 tests
- [x] Pages link check — PASS: 8 links
- [x] Worker dry-run — PASS: bindings validated at 600 requests / 60 seconds
- [x] Compiled rollback receipt — PASS
- [x] Final reviewer — GO
- [x] Exact-head hosted CI run 32131415733 — quality PASS (1m2s); docker-integration PASS (2m20s), including all image builds, non-root check, test:docker, test:e2e, and cleanup.

## Rollout boundary
Live Cloudflare Access app setup, Worker secrets, domain routing, rate-limit state, canaries, and production enablement remain pending rollout; they are not code-complete evidence and are not performed by this PR.

No exact related GitHub issue was found. Issues #13 and #18 are unrelated and are not closed by this PR.