### PR TITLE
fix(deploy): install API key nginx route

### DIFF
--- a/apps/runner/test/api-key-store.test.ts
+++ b/apps/runner/test/api-key-store.test.ts
@@ -52,8 +52,9 @@ describe('ApiKeyStore', () => {
   it('rejects malformed, unknown, altered, expired, and foreign revocation uniformly', () => {
     const value = fixture();
     const created = value.keys.create(value.principalId, 'Automation', 1);
+    const replacement = created.apiKey.endsWith('A') ? 'B' : 'A';
     expect(value.keys.verify('not-a-key')).toBeUndefined();
-    expect(value.keys.verify(`${created.apiKey.slice(0, -1)}A`)).toBeUndefined();
+    expect(value.keys.verify(`${created.apiKey.slice(0, -1)}${replacement}`)).toBeUndefined();
     expect(value.keys.revoke('prn_foreign', created.key.id, 1)).toBeUndefined();
     value.setNow(created.key.expiresAt);
     expect(value.keys.verify(created.apiKey)).toBeUndefined();

--- a/deploy/scripts/upgrade-nginx-dashboard.sh
+++ b/deploy/scripts/upgrade-nginx-dashboard.sh
@@ -2,18 +2,33 @@
 set -euo pipefail
 umask 077
 
-if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+test_root=${CLOUD_HARNESS_NGINX_TEST_ROOT:-}
+if [[ -n $test_root ]]; then
+  [[ ${EUID:-$(id -u)} -ne 0 && -f $test_root/.cloud-harness-nginx-test-root ]] || {
+    echo "invalid Cloud Harness nginx test root" >&2
+    exit 1
+  }
+  site=$test_root/etc/nginx/sites-available/cloud-harness-mcp.conf
+  enabled=$test_root/etc/nginx/sites-enabled/cloud-harness-mcp.conf
+  runtime_config=$test_root/etc/cloud-harness-mcp/runtime."env"
+  backup_root=$test_root/etc/cloud-harness-mcp/nginx-backups
+  nginx_command=$test_root/bin/nginx
+  systemctl_command=$test_root/bin/systemctl
+elif [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   echo "upgrade-nginx-dashboard.sh must run as root" >&2
   exit 1
+else
+  site=/etc/nginx/sites-available/cloud-harness-mcp.conf
+  enabled=/etc/nginx/sites-enabled/cloud-harness-mcp.conf
+  runtime_config=/etc/cloud-harness-mcp/runtime."env"
+  backup_root=/etc/cloud-harness-mcp/nginx-backups
+  nginx_command=/usr/sbin/nginx
+  systemctl_command=/usr/bin/systemctl
 fi
 
-site=/etc/nginx/sites-available/cloud-harness-mcp.conf
-enabled=/etc/nginx/sites-enabled/cloud-harness-mcp.conf
-runtime_config=/etc/cloud-harness-mcp/runtime."env"
-backup_root=/etc/cloud-harness-mcp/nginx-backups
-
 [[ -f $site && -f $runtime_config ]] || { echo "Cloud Harness nginx site or runtime configuration is missing" >&2; exit 2; }
-[[ -L $enabled && $(readlink -f "$enabled") == "$site" ]] || { echo "enabled Cloud Harness nginx site is not the managed target" >&2; exit 3; }
+[[ -L $enabled && $(readlink "$enabled") == "$site" ]] || { echo "enabled Cloud Harness nginx site is not the managed target" >&2; exit 3; }
+[[ -x $nginx_command && -x $systemctl_command ]] || { echo "required nginx management command is missing" >&2; exit 2; }
 
 public_hosts=$(awk -F= '$1 == "API_PUBLIC_HOSTS" { print substr($0, index($0, "=") + 1); found++ } END { if (found != 1) exit 1 }' "$runtime_config") || {
   echo "API_PUBLIC_HOSTS must appear exactly once" >&2
@@ -28,7 +43,8 @@ for host in "${configured_hosts[@]}"; do
   }
 done
 
-mapfile -t blocks < <(awk -v configured="$public_hosts" '
+blocks=()
+while IFS= read -r block; do blocks+=("$block"); done < <(awk -v configured="$public_hosts" '
   function brace_count(value, needle, count, pos) {
     count = 0
     while ((pos = index(value, needle)) > 0) {
@@ -87,31 +103,78 @@ sed -n "${start_line},${end_line}p" "$site" > "$block_file"
 
 dashboard_entry_count=$(grep -Fxc '    location = /dashboard {' "$block_file" || true)
 dashboard_prefix_count=$(grep -Fxc '    location ^~ /dashboard/ {' "$block_file" || true)
-if [[ $dashboard_entry_count -eq 1 && $dashboard_prefix_count -eq 1 ]] &&
-   grep -Fq 'proxy_pass http://127.0.0.1:3100/dashboard;' "$block_file" &&
-   grep -Fq 'proxy_pass http://127.0.0.1:3100/dashboard/;' "$block_file"; then
-  nginx -t
-  echo "Cloud Harness dashboard nginx routes are already installed"
+api_key_count=$(grep -Fxc '    location = /mcp-api-key {' "$block_file" || true)
+dashboard_entry_block=$(sed -n '/^    location = \/dashboard {$/,/^    }$/p' "$block_file")
+dashboard_prefix_block=$(sed -n '/^    location \^~ \/dashboard\/ {$/,/^    }$/p' "$block_file")
+api_key_block=$(sed -n '/^    location = \/mcp-api-key {$/,/^    }$/p' "$block_file")
+normalize_block() {
+  sed -E \
+    -e 's/[[:space:]]*#.*$//' \
+    -e 's/^[[:space:]]+//' \
+    -e 's/[[:space:]]+$//' \
+    -e '/^$/d'
+}
+expected_dashboard_entry=$'location = /dashboard {\nproxy_pass http://127.0.0.1:3100/dashboard;\nproxy_set_header Host $host;\nproxy_set_header X-Forwarded-Proto $scheme;\n}'
+expected_dashboard_prefix=$'location ^~ /dashboard/ {\nproxy_pass http://127.0.0.1:3100/dashboard/;\nproxy_set_header Host $host;\nproxy_set_header X-Forwarded-Proto $scheme;\n}'
+expected_api_key=$'location = /mcp-api-key {\nproxy_pass http://127.0.0.1:3100/mcp-api-key;\nproxy_http_version 1.1;\nproxy_set_header Host $host;\nproxy_set_header X-Forwarded-Proto $scheme;\nproxy_set_header Connection "";\nproxy_buffering off;\nproxy_request_buffering off;\nproxy_cache off;\nproxy_read_timeout 3600s;\nadd_header X-Accel-Buffering no always;\n}'
+
+dashboard_installed=0
+if [[ $dashboard_entry_count -eq 1 && $dashboard_prefix_count -eq 1 &&
+      $(normalize_block <<< "$dashboard_entry_block") == "$expected_dashboard_entry" &&
+      $(normalize_block <<< "$dashboard_prefix_block") == "$expected_dashboard_prefix" ]]; then
+  dashboard_installed=1
+fi
+api_key_installed=0
+if [[ $api_key_count -eq 1 && $(normalize_block <<< "$api_key_block") == "$expected_api_key" ]]; then
+  api_key_installed=1
+fi
+
+if [[ $dashboard_installed -eq 1 && $api_key_installed -eq 1 ]]; then
+  "$nginx_command" -t
+  echo "Cloud Harness dashboard and API-key nginx routes are already installed"
   exit 0
 fi
-if [[ $dashboard_entry_count -ne 0 || $dashboard_prefix_count -ne 0 ]] || grep -Fq '127.0.0.1:3100/dashboard' "$block_file"; then
+if [[ $dashboard_installed -eq 0 ]] &&
+   { [[ $dashboard_entry_count -ne 0 || $dashboard_prefix_count -ne 0 ]] || grep -Fq '127.0.0.1:3100/dashboard' "$block_file"; }; then
   echo "existing dashboard nginx routing is not the managed shape; refusing to overwrite it" >&2
   exit 6
 fi
+if [[ $api_key_installed -eq 0 ]] &&
+   { [[ $api_key_count -ne 0 ]] || grep -Fq '127.0.0.1:3100/mcp-api-key' "$block_file"; }; then
+  echo "existing API-key nginx routing is not the managed shape; refusing to overwrite it" >&2
+  exit 7
+fi
 
-awk -v closing="$end_line" '
+awk -v closing="$end_line" -v add_dashboard="$((1 - dashboard_installed))" -v add_api_key="$((1 - api_key_installed))" '
   NR == closing {
-    print "    location = /dashboard {"
-    print "        proxy_pass http://127.0.0.1:3100/dashboard;"
-    print "        proxy_set_header Host $host;"
-    print "        proxy_set_header X-Forwarded-Proto $scheme;"
-    print "    }"
-    print ""
-    print "    location ^~ /dashboard/ {"
-    print "        proxy_pass http://127.0.0.1:3100/dashboard/;"
-    print "        proxy_set_header Host $host;"
-    print "        proxy_set_header X-Forwarded-Proto $scheme;"
-    print "    }"
+    if (add_api_key) {
+      print "    location = /mcp-api-key {"
+      print "        proxy_pass http://127.0.0.1:3100/mcp-api-key;"
+      print "        proxy_http_version 1.1;"
+      print "        proxy_set_header Host $host;"
+      print "        proxy_set_header X-Forwarded-Proto $scheme;"
+      print "        proxy_set_header Connection \"\";"
+      print "        proxy_buffering off;"
+      print "        proxy_request_buffering off;"
+      print "        proxy_cache off;"
+      print "        proxy_read_timeout 3600s;"
+      print "        add_header X-Accel-Buffering no always;"
+      print "    }"
+      print ""
+    }
+    if (add_dashboard) {
+      print "    location = /dashboard {"
+      print "        proxy_pass http://127.0.0.1:3100/dashboard;"
+      print "        proxy_set_header Host $host;"
+      print "        proxy_set_header X-Forwarded-Proto $scheme;"
+      print "    }"
+      print ""
+      print "    location ^~ /dashboard/ {"
+      print "        proxy_pass http://127.0.0.1:3100/dashboard/;"
+      print "        proxy_set_header Host $host;"
+      print "        proxy_set_header X-Forwarded-Proto $scheme;"
+      print "    }"
+    }
   }
   { print }
 ' "$site" > "$rendered"
@@ -121,14 +184,19 @@ backup="$backup_root/cloud-harness-mcp.conf.$(date -u +%Y%m%dT%H%M%SZ)"
 cp -a "$site" "$backup"
 restore() {
   cp -a "$backup" "$site"
-  nginx -t && systemctl reload nginx || true
+  "$nginx_command" -t && "$systemctl_command" reload nginx || true
 }
 trap 'status=$?; if [[ $status -ne 0 ]]; then restore; fi; rm -f -- "$block_file" "$rendered"; exit "$status"' EXIT
 
-chmod --reference="$site" "$rendered"
-chown --reference="$site" "$rendered"
-cp --preserve=mode,ownership "$rendered" "$site"
-nginx -t
-systemctl reload nginx
+if [[ -n $test_root ]]; then
+  chmod 0644 "$rendered"
+  cp "$rendered" "$site"
+else
+  chmod --reference="$site" "$rendered"
+  chown --reference="$site" "$rendered"
+  cp --preserve=mode,ownership "$rendered" "$site"
+fi
+"$nginx_command" -t
+"$systemctl_command" reload nginx
 trap 'rm -f -- "$block_file" "$rendered"' EXIT
-echo "installed Cloud Harness dashboard nginx routes; backup: $backup"
+echo "installed Cloud Harness dashboard and API-key nginx routes; backup: $backup"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,7 +55,7 @@ Certbot edits in that file. Back up and deliberately reapply TLS configuration
 before any rerun.
 
 For an existing TLS-enabled installation, the Access-mode release deploy runs
-the dedicated dashboard-route upgrade before its public canary. It can also be
+the dedicated application-route upgrade before its public canary. It can also be
 run idempotently after deploying a release that contains it:
 
 ```bash
@@ -64,11 +64,14 @@ sudo /usr/local/sbin/cloud-harness-upgrade-nginx
 
 This command reads the configured `API_PUBLIC_HOSTS` allowlist without sourcing
 the runtime file, selects the unique matching TLS server block, and refuses
-ambiguous or pre-existing nonstandard dashboard routing. It backs up the live
-site under `/etc/cloud-harness-mcp/nginx-backups/`, changes only the two
-`/dashboard` locations, validates with `nginx -t`, and reloads nginx. A failed
-validation or reload restores the exact backup and attempts to reload it. The
-operation is idempotent. Do not use bootstrap for this upgrade.
+ambiguous or pre-existing nonstandard application routing. It backs up the live
+site under `/etc/cloud-harness-mcp/nginx-backups/`, installs the two
+`/dashboard` locations and the exact streaming `/mcp-api-key` location when
+they are missing, validates with `nginx -t`, and reloads nginx. Existing routes
+must match the managed blocks exactly after comments and blank lines are
+removed; otherwise the command fails closed without changing the site. A
+failed validation or reload restores the exact backup and attempts to reload
+it. The operation is idempotent. Do not use bootstrap for this upgrade.
 
 Review `/etc/cloud-harness-mcp/runtime.env` as root. Do not print or transfer
 its tokens through logs or shell history. Configure the optional GitHub App

--- a/scripts/verify-compose-boundaries.mjs
+++ b/scripts/verify-compose-boundaries.mjs
@@ -59,4 +59,16 @@ for (const directive of ['proxy_http_version 1.1;', 'proxy_buffering off;', 'pro
   requireBoundary(apiKeyMcp.includes(directive), `nginx API-key MCP streaming directive is missing: ${directive}`);
 }
 requireBoundary(apiKeyMcp.includes('proxy_pass http://127.0.0.1:3100/mcp-api-key;'), 'nginx API-key MCP route must preserve its hidden upstream path');
+
+const nginxUpgrade = readFileSync('deploy/scripts/upgrade-nginx-dashboard.sh', 'utf8');
+requireBoundary(
+  nginxUpgrade.includes('dashboard_installed -eq 1 && $api_key_installed -eq 1'),
+  'nginx upgrade must not return early until dashboard and API-key routes are installed'
+);
+requireBoundary(
+  nginxUpgrade.includes('location = /mcp-api-key {') &&
+    nginxUpgrade.includes('proxy_pass http://127.0.0.1:3100/mcp-api-key;') &&
+    nginxUpgrade.includes('add_api_key="$((1 - api_key_installed))"'),
+  'nginx upgrade must install the hidden API-key route when it is absent'
+);
 console.log('compose-boundaries=pass');

--- a/test/upgrade-nginx-routes.test.ts
+++ b/test/upgrade-nginx-routes.test.ts
@@ -1,0 +1,114 @@
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+const upgradeScript = join(process.cwd(), 'deploy/scripts/upgrade-nginx-dashboard.sh');
+const dashboardRoutes = `
+    location = /dashboard {
+        proxy_pass http://127.0.0.1:3100/dashboard;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ^~ /dashboard/ {
+        proxy_pass http://127.0.0.1:3100/dashboard/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }`;
+const apiKeyRoute = `
+    location = /mcp-api-key {
+        proxy_pass http://127.0.0.1:3100/mcp-api-key;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        add_header X-Accel-Buffering no always;
+    }`;
+
+function createFixture(extraRoutes = dashboardRoutes) {
+  const root = mkdtempSync(join(tmpdir(), 'cloud-harness-nginx-'));
+  const site = join(root, 'etc/nginx/sites-available/cloud-harness-mcp.conf');
+  const enabled = join(root, 'etc/nginx/sites-enabled/cloud-harness-mcp.conf');
+  const runtime = join(root, 'etc/cloud-harness-mcp/runtime.env');
+  const bin = join(root, 'bin');
+  for (const path of [dirname(site), dirname(enabled), dirname(runtime), bin]) mkdirSync(path, { recursive: true });
+  writeFileSync(join(root, '.cloud-harness-nginx-test-root'), 'fixture\n');
+  writeFileSync(runtime, 'API_PUBLIC_HOSTS=harness.zuey.me\n');
+  const source = `server {
+    listen 443 ssl;
+    server_name harness.zuey.me;
+${extraRoutes}
+}
+`;
+  writeFileSync(site, source);
+  symlinkSync(site, enabled);
+  writeFileSync(join(bin, 'nginx'), '#!/usr/bin/env bash\necho nginx >> "$CLOUD_HARNESS_NGINX_TEST_ROOT/nginx.calls"\n');
+  writeFileSync(join(bin, 'systemctl'), `#!/usr/bin/env bash
+calls="$CLOUD_HARNESS_NGINX_TEST_ROOT/systemctl.calls"
+count=0; [[ -f $calls ]] && count=$(wc -l < "$calls")
+echo systemctl >> "$calls"
+if [[ -f $CLOUD_HARNESS_NGINX_TEST_ROOT/fail-systemctl-once && $count -eq 0 ]]; then exit 1; fi
+`);
+  chmodSync(join(bin, 'nginx'), 0o755);
+  chmodSync(join(bin, 'systemctl'), 0o755);
+  return { root, site, source };
+}
+
+function runUpgrade(root: string) {
+  return spawnSync('bash', [upgradeScript], {
+    encoding: 'utf8',
+    env: { ...process.env, CLOUD_HARNESS_NGINX_TEST_ROOT: root }
+  });
+}
+
+function backups(root: string) {
+  const directory = join(root, 'etc/cloud-harness-mcp/nginx-backups');
+  try { return readdirSync(directory); } catch { return []; }
+}
+
+describe('nginx route upgrade', () => {
+  it('adds the API-key route to a dashboard-only install and is idempotent', () => {
+    const fixture = createFixture();
+    const first = runUpgrade(fixture.root);
+    expect(first.status, first.stderr).toBe(0);
+    expect(readFileSync(fixture.site, 'utf8')).toContain(apiKeyRoute);
+    expect(backups(fixture.root)).toHaveLength(1);
+
+    const second = runUpgrade(fixture.root);
+    expect(second.status).toBe(0);
+    expect(second.stdout).toContain('already installed');
+    expect(backups(fixture.root)).toHaveLength(1);
+    expect(readFileSync(join(fixture.root, 'systemctl.calls'), 'utf8').trim().split('\n')).toHaveLength(1);
+  });
+
+  it('rejects a commented canonical route with an active wrong upstream', () => {
+    const malformed = `${dashboardRoutes}
+    location = /mcp-api-key {
+        # proxy_pass http://127.0.0.1:3100/mcp-api-key;
+        # proxy_http_version 1.1;
+        proxy_pass http://127.0.0.1:9999/mcp-api-key;
+    }`;
+    const fixture = createFixture(malformed);
+    const result = runUpgrade(fixture.root);
+    expect(result.status, result.stderr).toBe(7);
+    expect(result.stderr).toContain('not the managed shape');
+    expect(readFileSync(fixture.site, 'utf8')).toBe(fixture.source);
+    expect(backups(fixture.root)).toHaveLength(0);
+  });
+
+  it('restores the original site when nginx reload fails', () => {
+    const fixture = createFixture();
+    writeFileSync(join(fixture.root, 'fail-systemctl-once'), 'fail\n');
+    const result = runUpgrade(fixture.root);
+    expect(result.status, result.stderr).not.toBe(0);
+    expect(readFileSync(fixture.site, 'utf8')).toBe(fixture.source);
+    expect(backups(fixture.root)).toHaveLength(1);
+    expect(readFileSync(join(fixture.root, 'systemctl.calls'), 'utf8').trim().split('\n')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- install the exact streaming `/mcp-api-key` nginx location on existing dashboard-only deployments
- fail closed on commented, partial, duplicate, or noncanonical managed route blocks
- add behavioral fixtures for upgrade, idempotency, malformed-route rejection, and rollback
- update the deployment runbook mutation boundary

## Root cause
The Access-mode upgrade returned early when the two dashboard locations already existed, so the new hidden API-key origin route was never mounted on upgraded hosts.

## Verification
- `bash -n deploy/scripts/upgrade-nginx-dashboard.sh`
- `npm run verify:compose`
- `npx vitest run test/upgrade-nginx-routes.test.ts --no-file-parallelism` (3/3)
- scoped ESLint
- `git diff --check origin/main...HEAD`
- independent code review: approved, no Critical/Important findings

## Rollout
Keep the origin behind the exact path-scoped Cloudflare Access Service Auth application. After merge and exact-head CI, deploy the merge SHA, verify the nginx route and both auth lanes, then complete create/use/revoke API-key canaries.