### PR TITLE
docs(plan): record API key rollout

### DIFF
--- a/plans/260818-1610-dashboard-managed-api-keys/phase-05-security-and-regression-verification.md
+++ b/plans/260818-1610-dashboard-managed-api-keys/phase-05-security-and-regression-verification.md
@@ -1,7 +1,7 @@
 ---
 phase: 5
 title: "Security, regression, and leak verification"
-status: in_progress
+status: complete
 priority: P1
 effort: "1d"
 dependencies: [1, 2, 3, 4]
@@ -50,7 +50,7 @@ Prove G1–G13 across contracts, API, runner, dashboard, Worker, migration, and 
 
 - [x] Every G1–G13 row has passing automated evidence or named Phase 6 canary.
 - [x] Compose/full verify pass on the reviewed working tree.
-- [ ] Docker/e2e pass at exact head in hosted CI; local API/runner image builds and Docker/E2E were unavailable due latency/timeouts.
+- [x] Docker/e2e pass at exact PR head and post-merge head in hosted CI; post-merge run `32147300865` completed both jobs successfully.
 - [x] Public MCP/OAuth behavior remains compatible in automated regression coverage.
 
 ## Risks and rollback

--- a/plans/260818-1610-dashboard-managed-api-keys/phase-06-deployment-rollback-and-documentation.md
+++ b/plans/260818-1610-dashboard-managed-api-keys/phase-06-deployment-rollback-and-documentation.md
@@ -1,7 +1,7 @@
 ---
 phase: 6
 title: "Deployment, rollback, and documentation"
-status: in_progress
+status: complete
 priority: P1
 effort: "1-1.5d"
 dependencies: [1, 2, 3, 4, 5]
@@ -50,10 +50,18 @@ Roll out dormant-first in reversible stages, then prove both public lanes and a 
 
 ## Success criteria
 
-- [ ] G12/G13 receipts record exact SHA, CI, deployments, hosts, revoke, rollback readiness, and secret-free evidence.
-- [ ] OAuth, GitHub/Google dashboard, and static Bearer clients work only on intended lanes.
-- [ ] Direct origin, wrong assertion, and revoked key remain denied.
+- [x] G12/G13 receipts record exact SHA, CI, deployments, hosts, revoke, rollback readiness, and secret-free evidence.
+- [x] OAuth, GitHub/Google dashboard, and static Bearer clients work only on intended lanes.
+- [x] Direct origin, wrong assertion, and revoked key remain denied.
 - [x] Docs state full authority, no scopes, no recovery, no rotation endpoint.
+
+## Live rollout receipt
+
+- Release `v0.7.1` deployed commit `c193dd09a8c8fcf1597ea620251dbcd61f51426e` after post-merge CI run `32147300865`; production run `32147597077` succeeded.
+- `harness.zuey.me/mcp-api-key` is protected by the separate path-scoped Access application and exact Service Auth policy. Without the Worker assertion it returned 403; with the assertion and no key it reached the origin and returned JSON 401.
+- `api.harness.zuey.me/mcp` returned bounded JSON failures for missing and malformed bearer values. A disposable one-day key initialized and listed 52 tools only through this Worker URL.
+- The same key was rejected on the OAuth URL, then rejected by the Worker on the first request after dashboard revocation. The dashboard recorded last use and revocation, the database contained no plaintext match, and the clipboard was cleared.
+- Production service readiness passed, nginx exposed the exact streaming route only to loopback origin, and `/etc/cloud-harness-mcp/runtime.env` remained root-owned mode 0600.
 
 ## Risks and rollback
 

--- a/plans/260818-1610-dashboard-managed-api-keys/plan.md
+++ b/plans/260818-1610-dashboard-managed-api-keys/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Dashboard-managed API keys through a Cloudflare Worker gateway"
 description: "Add principal-bound static API keys without weakening Managed OAuth or origin Access."
-status: in_progress
+status: complete
 priority: P1
 effort: "6-9d"
 branch: codex/feat/dashboard-api-keys
@@ -32,8 +32,8 @@ Dashboard users can create, list, and revoke expiring API keys for static MCP cl
 | 2 | [Dual-auth origin](./phase-02-dual-auth-origin-boundary.md) | 1 | Complete |
 | 3 | [Dashboard lifecycle](./phase-03-dashboard-api-key-lifecycle.md) | 1, 2 | Complete |
 | 4 | [Worker gateway](./phase-04-cloudflare-worker-gateway.md) | 2 | Complete |
-| 5 | [Security verification](./phase-05-security-and-regression-verification.md) | 1–4 | In progress |
-| 6 | [Deploy, rollback, docs](./phase-06-deployment-rollback-and-documentation.md) | 1–5 | In progress |
+| 5 | [Security verification](./phase-05-security-and-regression-verification.md) | 1–4 | Complete |
+| 6 | [Deploy, rollback, docs](./phase-06-deployment-rollback-and-documentation.md) | 1–5 | Complete |
 
 ## Observable acceptance gates
 
@@ -49,7 +49,7 @@ Dashboard users can create, list, and revoke expiring API keys for static MCP cl
 - [x] G10 Create/revoke emit redacted principal-scoped audits using immutable key ID/generation.
 - [x] G11 Public runner/tool schemas, `tools/list`, OAuth discovery, and owner-bearer installs stay compatible.
 - [x] G12 v1→v2, restart, v2→v1 rollback, and dormant readiness preserve unrelated state.
-- [ ] G13 live canaries prove path-specific Access app selection, audience separation, both lanes, revoke, direct-origin denial, exact head, and zero secret retention.
+- [x] G13 live canaries prove path-specific Access app selection, audience separation, both lanes, revoke, direct-origin denial, exact head, and zero secret retention.
 
 ## Evidence and decision record
 
@@ -57,5 +57,7 @@ Dashboard users can create, list, and revoke expiring API keys for static MCP cl
 - Research: `../reports/researcher-260818-1610-api-key-auth-security.md`. Its native service-token recommendation is superseded because static clients need ordinary Bearer keys; Worker plus exact service assertion retains no-bypass origin security.
 - Baseline: `../260817-1321-13-cloudflare-oauth-dashboard/`.
 - Review: six phases swept against G1–G13; public MCP schemas remain untouched; rollback is explicit; unresolved decisions: none.
+- Release receipt: PR #42 merged as `c193dd09a8c8fcf1597ea620251dbcd61f51426e`; post-merge CI run `32147300865`, release `v0.7.1`, and production deploy run `32147597077` completed successfully.
+- Live receipt: exact `/mcp-api-key` Access selection returned 403 without a service assertion and JSON 401 with the pinned assertion but no API key. A one-day disposable key initialized through `https://api.harness.zuey.me/mcp`, listed 52 tools, was rejected on `https://harness.zuey.me/mcp`, and failed on the next request after revocation. The plaintext was absent from SQLite and the transient clipboard was cleared.
 
 <!-- slug: dashboard-managed-api-keys -->


### PR DESCRIPTION
## Summary
- mark the dashboard API-key rollout plan complete
- record exact merge, CI, release, production deploy, and redacted live canary evidence
- close hosted Docker/e2e and G13 receipts

## Verification
- `npm run pages:links`
- `git diff --check`

No credential values or plaintext API keys are included.