### PR TITLE
feat(dashboard): adaptive light/dark console, Overview home, executor prune fix

### DIFF
--- a/apps/api/dashboard/dashboard-render.js
+++ b/apps/api/dashboard/dashboard-render.js
@@ -116,3 +116,21 @@ const publicMcpUrl = (value) => {
     return url.protocol === 'https:' && url.pathname === '/mcp' && !url.username && !url.password && !url.search && !url.hash ? url.toString() : undefined;
   } catch { return undefined; }
 };
+
+export function renderOverviewSkeleton() {
+  const tile = '<li class="skeleton tile" aria-hidden="true"></li>';
+  const block = '<div class="skeleton tile" aria-hidden="true"></div>';
+  return `<div class="overview"><ul class="metric-grid">${tile.repeat(4)}</ul><div class="overview-columns">${block}${block}</div></div>`;
+}
+
+export function renderOverview(summary) {
+  const metrics = summary.metrics.map((metric) => `<li class="metric"><span class="metric-label">${escape(metric.label)}</span><span class="metric-value${metric.small ? ' small' : ''}">${escape(metric.value)}</span>${metric.note ? `<span class="metric-note">${escape(metric.note)}</span>` : ''}</li>`).join('');
+  const activity = summary.activity.length
+    ? `<ul class="activity-list">${summary.activity.map((event) => `<li><strong>${escape(event.action)}</strong>${time(event.createdAt)}<span class="subject">${escape(event.subjectType)} <span class="mono wrap">${escape(event.subjectId)}</span></span></li>`).join('')}</ul>`
+    : '<p>No retained audit events yet.</p>';
+  const access = summary.access;
+  const endpoint = access.endpoint
+    ? `<dt>Static endpoint</dt><dd class="wrap"><span class="mono wrap">${escape(access.endpoint)}</span> <button type="button" class="copy" data-copy="${escape(access.endpoint)}">Copy</button></dd>`
+    : '';
+  return `<div class="overview"><ul class="metric-grid">${metrics}</ul><div class="overview-columns"><section class="panel" aria-labelledby="overview-activity-heading"><h2 id="overview-activity-heading">Recent activity</h2>${activity}</section><section class="panel" aria-labelledby="overview-access-heading"><h2 id="overview-access-heading">Access</h2><dl class="facts"><dt>Signed in as</dt><dd class="wrap">${escape(access.name)}</dd><dt>Email</dt><dd class="wrap">${escape(access.email)}</dd><dt>Session expires</dt><dd>${optionalTime(access.sessionExpiresAt)}</dd>${endpoint}</dl></section></div></div>`;
+}

--- a/apps/api/dashboard/dashboard.css
+++ b/apps/api/dashboard/dashboard.css
@@ -1,17 +1,17 @@
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
 
   /* Neutrals — cool blue-graphite ramp, single hue held, lightness varied. */
   --canvas: oklch(0.967 0.006 264);
   --surface: oklch(0.994 0.002 264);
   --surface-raised: oklch(0.978 0.004 264);
-  --surface-muted: oklch(0.940 0.008 264);
+  --surface-muted: oklch(0.930 0.009 264);
   --ink: oklch(0.255 0.020 265);
   --ink-muted: oklch(0.500 0.022 265);
   --line: oklch(0.905 0.008 264);
   --line-strong: oklch(0.820 0.013 264);
 
-  /* Accent — one confident indigo, used only for primary action, selection, focus, and state. */
+  /* Accent — one confident indigo: primary action, active nav, selection, focus, state. */
   --accent: oklch(0.535 0.176 264);
   --accent-hover: oklch(0.470 0.176 264);
   --accent-strong: oklch(0.440 0.170 264);
@@ -25,21 +25,50 @@
   --warning: oklch(0.520 0.115 78); --warning-soft: oklch(0.958 0.052 82); --warning-line: oklch(0.815 0.100 82);
   --danger: oklch(0.515 0.190 27); --danger-hover: oklch(0.450 0.185 27); --danger-soft: oklch(0.956 0.036 27); --danger-line: oklch(0.800 0.115 27);
 
-  /* Code surface — dark graphite, brand-tinted. */
   --code-bg: oklch(0.255 0.018 264); --code-ink: oklch(0.930 0.010 264);
+  --shadow-hue: 264;
+  --shadow-overlay: 0 .25rem .75rem oklch(0.28 0.04 264 / .12), 0 1rem 2.5rem oklch(0.24 0.05 264 / .18);
+  --shadow-raise: 0 .0625rem .1875rem oklch(0.30 0.04 264 / .10);
 
   --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-display: var(--font-sans);
   --font-mono: ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 
-  --text-11: .6875rem; --text-12: .75rem; --text-13: .8125rem; --text-14: .875rem; --text-16: 1rem; --text-20: 1.25rem; --text-24: 1.5rem; --text-28: 1.75rem;
+  --text-11: .6875rem; --text-12: .75rem; --text-13: .8125rem; --text-14: .875rem; --text-16: 1rem; --text-20: 1.25rem; --text-24: 1.5rem; --text-28: 1.75rem; --text-36: 2.25rem;
   --space-1: .25rem; --space-2: .5rem; --space-3: .75rem; --space-4: 1rem; --space-5: 1.25rem; --space-6: 1.5rem; --space-8: 2rem;
   --radius-sm: .375rem; --radius-md: .625rem; --radius-lg: .875rem; --radius-pill: 99rem;
 
-  --shadow-overlay: 0 .25rem .75rem oklch(0.28 0.04 264 / .12), 0 1rem 2.5rem oklch(0.24 0.05 264 / .18);
-  --shadow-raise: 0 .0625rem .1875rem oklch(0.30 0.04 264 / .10);
-
   --motion-fast: 150ms; --motion-state: 220ms; --ease-out: cubic-bezier(.16, 1, .3, 1);
+}
+
+/* Adaptive dark theme — tinted graphite, elevate by lightening, accent brightened. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --canvas: oklch(0.180 0.012 264);
+    --surface: oklch(0.215 0.014 264);
+    --surface-raised: oklch(0.258 0.016 264);
+    --surface-muted: oklch(0.300 0.017 264);
+    --ink: oklch(0.948 0.010 264);
+    --ink-muted: oklch(0.722 0.020 264);
+    --line: oklch(0.320 0.016 264);
+    --line-strong: oklch(0.430 0.020 264);
+
+    --accent: oklch(0.680 0.150 264);
+    --accent-hover: oklch(0.745 0.150 264);
+    --accent-strong: oklch(0.800 0.130 264);
+    --accent-soft: oklch(0.315 0.070 264);
+    --accent-line: oklch(0.500 0.120 264);
+    --on-accent: oklch(0.170 0.020 264);
+    --focus: oklch(0.740 0.150 264);
+
+    --success: oklch(0.760 0.130 155); --success-soft: oklch(0.320 0.055 155); --success-line: oklch(0.470 0.085 155);
+    --warning: oklch(0.810 0.120 82); --warning-soft: oklch(0.330 0.050 82); --warning-line: oklch(0.500 0.080 82);
+    --danger: oklch(0.720 0.160 27); --danger-hover: oklch(0.660 0.175 27); --danger-soft: oklch(0.330 0.075 27); --danger-line: oklch(0.500 0.120 27);
+
+    --code-bg: oklch(0.150 0.012 264); --code-ink: oklch(0.905 0.012 264);
+    --shadow-overlay: 0 .25rem .75rem oklch(0.05 0.02 264 / .55), 0 1rem 2.5rem oklch(0.03 0.02 264 / .65);
+    --shadow-raise: 0 .0625rem .1875rem oklch(0.05 0.02 264 / .5);
+  }
 }
 
 * { box-sizing: border-box; }
@@ -64,7 +93,6 @@ button, input, select, textarea {
 }
 input, select, textarea { box-shadow: var(--shadow-raise) inset; }
 input::placeholder { color: var(--ink-muted); }
-input:hover:not(:disabled), select:hover:not(:disabled), textarea:hover:not(:disabled) { border-color: var(--line-strong); }
 input:focus, select:focus, textarea:focus { border-color: var(--accent); }
 input[type="number"] { font-variant-numeric: tabular-nums; }
 
@@ -80,24 +108,25 @@ button[type="submit"]:not(.danger):active:not(:disabled) { background: var(--acc
 
 :focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; border-radius: var(--radius-sm); }
 
-.skip-link { position: fixed; z-index: 40; inset-block-start: var(--space-2); inset-inline-start: var(--space-2); transform: translateY(-200%); background: var(--ink); color: var(--surface); padding: var(--space-3); border-radius: var(--radius-sm); text-decoration: none; }
+.skip-link { position: fixed; z-index: 40; inset-block-start: var(--space-2); inset-inline-start: var(--space-2); transform: translateY(-200%); background: var(--ink); color: var(--canvas); padding: var(--space-3); border-radius: var(--radius-sm); text-decoration: none; }
 .skip-link:focus { transform: none; }
 
 /* Shell */
 .app-shell { display: grid; grid-template-columns: 15rem minmax(0, 1fr); min-height: 100dvh; }
 .app-shell.has-detail { grid-template-columns: 15rem minmax(0, 1fr) minmax(25rem, 28rem); }
 
-.sidebar { background: var(--surface); border-inline-end: 1px solid var(--line); padding: var(--space-6) var(--space-4); display: flex; flex-direction: column; gap: var(--space-6); }
+.sidebar { background: var(--surface); border-inline-end: 1px solid var(--line); padding: var(--space-6) var(--space-4); display: flex; flex-direction: column; gap: var(--space-5); }
 .brand { display: flex; align-items: center; gap: var(--space-3); font-family: var(--font-display); font-size: var(--text-20); font-weight: 700; letter-spacing: -.02em; }
 .brand::before { content: ""; flex: 0 0 auto; width: 1rem; height: 1rem; border-radius: var(--radius-sm); background: var(--accent); box-shadow: inset 0 0 0 .1875rem var(--accent-soft); }
 h1, h2, h3 { font-family: var(--font-display); text-wrap: balance; }
 
-.sidebar nav { display: grid; gap: var(--space-1); }
+.sidebar nav { display: grid; gap: var(--space-1); align-content: start; }
+.nav-group { margin: var(--space-4) 0 var(--space-1); padding-inline: var(--space-3); font-size: var(--text-11); font-weight: 700; letter-spacing: .09em; text-transform: uppercase; color: var(--ink-muted); }
 .sidebar nav a { position: relative; min-height: 2.75rem; display: flex; align-items: center; padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); color: var(--ink-muted); text-decoration: none; font-weight: 600; letter-spacing: -.005em; transition: background-color var(--motion-fast) var(--ease-out), color var(--motion-fast) var(--ease-out); }
 .sidebar nav a:hover { background: var(--surface-raised); color: var(--ink); }
 .sidebar nav a[aria-current] { background: var(--accent-soft); color: var(--accent-strong); }
 .sidebar nav a[aria-current]::before { content: ""; position: absolute; inset-block: 22%; inset-inline-start: 0; width: .1875rem; border-radius: var(--radius-pill); background: var(--accent); }
-#context-nav { display: grid; gap: var(--space-1); margin-block-start: var(--space-2); padding-block-start: var(--space-2); border-block-start: 1px solid var(--line); }
+#context-nav { display: grid; gap: var(--space-1); margin-block-start: var(--space-3); padding-block-start: var(--space-3); border-block-start: 1px solid var(--line); }
 #context-nav:empty { display: none; }
 #context-nav a { min-height: 2.5rem; display: flex; align-items: center; padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); color: var(--ink-muted); text-decoration: none; font-weight: 600; }
 #context-nav a:hover { background: var(--surface-raised); color: var(--ink); }
@@ -119,13 +148,29 @@ label { display: block; font-weight: 600; color: var(--ink); }
 section { min-width: 0; }
 #content > h2:first-child { margin-block: 0 var(--space-4); font-size: var(--text-20); letter-spacing: -.015em; }
 
+/* Overview */
+.overview { display: grid; gap: var(--space-6); }
+.metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 13rem), 1fr)); gap: var(--space-4); list-style: none; padding: 0; margin: 0; }
+.metric { min-width: 0; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); padding: var(--space-5); display: grid; gap: var(--space-2); align-content: start; }
+.metric-label { font-size: var(--text-11); font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--ink-muted); }
+.metric-value { font-size: var(--text-36); font-weight: 700; letter-spacing: -.03em; line-height: 1; font-variant-numeric: tabular-nums; }
+.metric-value.small { font-size: var(--text-24); letter-spacing: -.02em; }
+.metric-note { font-size: var(--text-13); color: var(--ink-muted); }
+.metric-note .status { margin-block-start: var(--space-1); }
+.overview-columns { display: grid; grid-template-columns: minmax(0, 3fr) minmax(0, 2fr); gap: var(--space-6); align-items: start; }
+.activity-list { list-style: none; padding: 0; margin: 0; display: grid; }
+.activity-list li { display: grid; grid-template-columns: minmax(0, 1fr) max-content; gap: var(--space-2) var(--space-4); align-items: baseline; padding: var(--space-3) 0; border-block-start: 1px solid var(--line); }
+.activity-list li:first-child { border-block-start: none; }
+.activity-list strong { font-weight: 600; }
+.activity-list .subject { grid-column: 1 / -1; color: var(--ink-muted); font-size: var(--text-13); }
+.activity-list time { color: var(--ink-muted); font-size: var(--text-13); font-variant-numeric: tabular-nums; white-space: nowrap; }
+
 /* Tables */
 .desktop-table { border: 1px solid var(--line); border-radius: var(--radius-md); overflow: hidden; background: var(--surface); }
 table { width: 100%; border-collapse: separate; border-spacing: 0; background: var(--surface); font-variant-numeric: tabular-nums; }
 caption { text-align: start; padding: var(--space-3) var(--space-4); color: var(--ink-muted); font-size: var(--text-13); font-weight: 600; border-block-end: 1px solid var(--line); }
-thead th { background: var(--surface-raised); color: var(--ink-muted); font-size: var(--text-11); font-weight: 700; letter-spacing: .06em; text-transform: uppercase; border-block-end: 1px solid var(--line-strong); }
+thead th { background: var(--surface-raised); color: var(--ink-muted); font-size: var(--text-11); font-weight: 700; letter-spacing: .06em; text-transform: uppercase; border-block-end: 1px solid var(--line-strong); border-block-start: none; }
 th, td { border-block-start: 1px solid var(--line); padding: var(--space-3) var(--space-4); text-align: start; height: 2.75rem; vertical-align: middle; }
-thead th { border-block-start: none; }
 tbody tr:first-child td, tbody tr:first-child th { border-block-start: none; }
 tbody tr { transition: background-color var(--motion-fast) var(--ease-out); }
 tbody tr:hover td, tbody tr:hover th { background: var(--surface-raised); }
@@ -141,6 +186,11 @@ td time, th time { white-space: nowrap; }
 .status.reaping { background: var(--warning-soft); color: var(--warning); border-color: var(--warning-line); }
 .status.expired { background: var(--warning-soft); color: var(--warning); border-color: var(--warning-line); }
 .status.failed { background: var(--danger-soft); color: var(--danger); border-color: var(--danger-line); }
+
+/* Copy-to-clipboard affordance */
+.copy { position: relative; min-height: 2rem; padding: var(--space-1) var(--space-2); font-size: var(--text-12); font-weight: 600; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface); color: var(--ink-muted); }
+.copy::before { content: ""; position: absolute; inset: -.625rem; }
+.copy:hover:not(:disabled) { color: var(--accent-strong); border-color: var(--accent); background: var(--accent-soft); }
 
 /* Detail drawer */
 .detail { min-width: 0; border-inline-start: 1px solid var(--line); background: var(--surface); padding: var(--space-6); }
@@ -175,6 +225,7 @@ td time, th time { white-space: nowrap; }
 
 /* Panels & records */
 .panel { min-width: 0; border: 1px solid var(--line); background: var(--surface); padding: var(--space-5); border-radius: var(--radius-md); }
+.panel > h2:first-child, .panel > h3:first-child { margin-block: 0 var(--space-4); }
 .card-grid, .environment-list, .audit-list, .record-list { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--space-4); }
 .card-grid { grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); }
 .card-grid li.panel { transition: border-color var(--motion-fast) var(--ease-out), transform var(--motion-fast) var(--ease-out), box-shadow var(--motion-fast) var(--ease-out); }
@@ -217,10 +268,24 @@ textarea { display: block; width: 100%; min-height: 12rem; font-family: var(--fo
 nav[aria-label="Breadcrumb"] { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); margin-block-end: var(--space-4); color: var(--ink-muted); font-size: var(--text-13); }
 nav[aria-label="Breadcrumb"] span { color: var(--ink); }
 
+/* Skeleton loading */
+.skeleton-grid { display: grid; gap: var(--space-4); }
+.skeleton { background: var(--surface-muted); border: 1px solid var(--line); border-radius: var(--radius-md); animation: skeleton-pulse 1.4s var(--ease-out) infinite; }
+.skeleton.tile { height: 6.5rem; }
+.skeleton.row { height: 3.25rem; border-radius: var(--radius-sm); }
+@keyframes skeleton-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .5; } }
+
+/* Toasts */
+.toasts { position: fixed; z-index: 50; inset-block-end: var(--space-5); inset-inline-end: var(--space-5); display: grid; gap: var(--space-3); max-width: min(24rem, calc(100vw - 2 * var(--space-5))); pointer-events: none; }
+.toast { pointer-events: auto; border: 1px solid var(--line-strong); border-inline-start-width: .1875rem; background: var(--surface-raised); color: var(--ink); border-radius: var(--radius-md); padding: var(--space-3) var(--space-4); box-shadow: var(--shadow-overlay); font-weight: 500; animation: toast-in var(--motion-state) var(--ease-out); }
+.toast.success { border-inline-start-color: var(--success); }
+.toast.error { border-inline-start-color: var(--danger); }
+@keyframes toast-in { from { opacity: 0; transform: translateY(.5rem); } to { opacity: 1; transform: none; } }
+
 /* Dialogs */
 dialog { max-width: min(32rem, calc(100vw - 2 * var(--space-4))); border: 1px solid var(--line-strong); border-radius: var(--radius-lg); box-shadow: var(--shadow-overlay); padding: var(--space-6); color: var(--ink); background: var(--surface); }
 dialog h2 { margin-block: 0 var(--space-3); }
-dialog::backdrop { background: oklch(0.22 0.03 264 / .42); }
+dialog::backdrop { background: oklch(0.15 0.02 264 / .5); }
 .dialog-actions { display: flex; justify-content: flex-end; flex-wrap: wrap; gap: var(--space-3); margin-block-start: var(--space-5); }
 .status-message { min-height: 1.25rem; color: var(--ink-muted); }
 .stack-form .checkbox-label { display: flex; align-items: start; gap: var(--space-3); font-weight: 500; }
@@ -239,8 +304,9 @@ dialog::backdrop { background: oklch(0.22 0.03 264 / .42); }
   .app-shell, .app-shell.has-detail { grid-template-columns: 4rem minmax(0, 1fr); }
   .app-shell.has-detail .detail { position: fixed; z-index: 20; inset: 0 0 0 auto; width: min(26.25rem, 92vw); box-shadow: var(--shadow-overlay); overflow: auto; }
   .sidebar { padding-inline: var(--space-2); }
-  .brand, #nav-toggle { overflow: hidden; }
+  .brand, #nav-toggle, .nav-group { overflow: hidden; }
   .sidebar nav a { overflow: hidden; }
+  .overview-columns { grid-template-columns: minmax(0, 1fr); }
 }
 
 /* Mobile: drawer sidebar, block layout, stacked cards. */
@@ -249,12 +315,14 @@ dialog::backdrop { background: oklch(0.22 0.03 264 / .42); }
   .mobile-bar { display: flex; height: 3.5rem; align-items: center; gap: var(--space-4); padding-inline: var(--space-3); background: var(--surface); border-block-end: 1px solid var(--line); }
   .mobile-bar strong { letter-spacing: -.01em; }
   .app-shell, .app-shell.has-detail { display: block; min-height: calc(100dvh - 3.5rem); grid-template-columns: none; }
-  .sidebar { position: fixed; z-index: 30; inset: 3.5rem auto 0 0; width: min(18rem, 88vw); padding-inline: var(--space-4); transform: translateX(-110%); transition: transform var(--motion-state) var(--ease-out); box-shadow: var(--shadow-overlay); }
+  .sidebar { position: fixed; z-index: 30; inset: 3.5rem auto 0 0; width: min(18rem, 88vw); padding-inline: var(--space-4); transform: translateX(-110%); transition: transform var(--motion-state) var(--ease-out); box-shadow: var(--shadow-overlay); overflow: auto; }
   .sidebar.open { transform: none; }
+  .brand, #nav-toggle, .nav-group { overflow: visible; }
   main { padding: var(--space-4); }
   .detail { display: none; }
   .command-surface, form { align-items: stretch; }
   .command-surface form { display: grid; width: 100%; }
+  .overview-columns { grid-template-columns: minmax(0, 1fr); }
   .desktop-table { display: none; }
   .mobile-list { display: grid; list-style: none; padding: 0; margin: 0; gap: var(--space-3); }
   .mobile-list li { border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); padding: var(--space-4); }
@@ -264,6 +332,7 @@ dialog::backdrop { background: oklch(0.22 0.03 264 / .42); }
   .mobile-list dd { margin: 0; }
   .secret-reference { grid-template-columns: 1fr; }
   .record-heading > .danger { width: 100%; }
+  .toasts { inset-inline: var(--space-4); max-width: none; }
   .sticky-actions { padding-bottom: env(safe-area-inset-bottom); }
 }
 

--- a/apps/api/dashboard/dashboard.js
+++ b/apps/api/dashboard/dashboard.js
@@ -1,7 +1,7 @@
 import { api } from './dashboard-api.js';
 import {
-  renderApiKeyIndex, renderArtifactIndex, renderAuditIndex, renderFile, renderFileList, renderGitHub, renderProjectDetail,
-  renderProfile, renderProjectIndex, renderRuntime, renderWorkspaceDetail, renderWorkspaceIndex, repositoryName
+  renderApiKeyIndex, renderArtifactIndex, renderAuditIndex, renderFile, renderFileList, renderGitHub, renderOverview, renderOverviewSkeleton,
+  renderProjectDetail, renderProfile, renderProjectIndex, renderRuntime, renderWorkspaceDetail, renderWorkspaceIndex, repositoryName
 } from './dashboard-render.js';
 
 const focusableSelector = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -172,7 +172,16 @@ export function initializeDashboard() {
     clipboard: globalThis.navigator.clipboard, reportError: showError
   });
   const setBusy = (busy) => content.setAttribute('aria-busy', String(busy));
-  const announce = (message) => { announcer.textContent = message; };
+  const announce = (message) => { announcer.textContent = message; toast(message); };
+  function toast(message, kind = '') {
+    const region = document.querySelector('#toasts');
+    if (!region) return;
+    const node = document.createElement('div');
+    node.className = kind ? `toast ${kind}` : 'toast';
+    node.textContent = message;
+    region.appendChild(node);
+    globalThis.setTimeout(() => node.remove(), 4200);
+  }
   let apiKeyPageData;
   function showError(error) {
     alertBox.hidden = false;
@@ -196,6 +205,7 @@ export function initializeDashboard() {
     alertBox.hidden = true; setBusy(true);
     try {
       if (location.pathname === '/dashboard' || location.pathname === '/dashboard/') await loadIndex();
+      else if (location.pathname === '/dashboard/overview') await loadOverview();
       else if (location.pathname === '/dashboard/projects') await loadProjects();
       else if (projectMatch) await loadProject(projectMatch[1]);
       else if (location.pathname === '/dashboard/artifacts') await loadArtifacts();
@@ -209,6 +219,39 @@ export function initializeDashboard() {
       else throw Object.assign(new Error('Dashboard page not found.'), { status: 404 });
       setBusy(false); main.focus({ preventScroll: true });
     } catch (error) { showError(error); }
+  }
+  async function loadOverview() {
+    selectNavigation('overview');
+    setTitle('Overview', 'A live summary of your workspaces, credentials, and recent activity.');
+    document.querySelector('#command-surface').hidden = true;
+    content.innerHTML = renderOverviewSkeleton();
+    const [ws, keys, auditResult, github, profile] = await Promise.allSettled([
+      api('/workspaces'), api('/api-keys'), api('/audit?limit=50'), api('/github'), api('/profile')
+    ]);
+    const data = (result) => result.status === 'fulfilled' ? result.value.data : undefined;
+    const workspaces = data(ws)?.workspaces ?? [];
+    const keyData = data(keys);
+    const apiKeys = Array.isArray(keyData?.keys) ? keyData.keys : [];
+    const events = data(auditResult)?.events ?? [];
+    const installation = data(github)?.installation;
+    const identity = data(profile)?.identity ?? {};
+    const endpoint = keyData?.readiness?.ready === true ? (keyData.readiness.publicUrl ?? keyData.publicUrl) : undefined;
+    const account = installation?.accountLogin ?? installation?.accountId;
+    content.innerHTML = renderOverview({
+      metrics: [
+        { label: 'Active workspaces', value: workspaces.filter((item) => item.status === 'ACTIVE').length, note: `${workspaces.length} total` },
+        { label: 'API keys', value: `${apiKeys.filter((item) => item.state === 'ACTIVE').length}/10`, note: 'Active of limit' },
+        { label: 'GitHub', value: installation ? 'Connected' : 'Not connected', small: true, note: installation ? (account ?? 'Installation bound') : 'No installation bound' },
+        { label: 'Recent events', value: events.length, note: 'Retained audit records' }
+      ],
+      activity: events.slice(0, 6).map((event) => ({ action: event.action, subjectType: event.subjectType, subjectId: event.subjectId, createdAt: event.createdAt })),
+      access: {
+        name: identity.name ?? 'Not provided',
+        email: identity.email ?? 'Not provided',
+        sessionExpiresAt: data(profile)?.sessionExpiresAt,
+        endpoint: typeof endpoint === 'string' && /^https:\/\//.test(endpoint) ? endpoint : undefined
+      }
+    });
   }
   async function loadIndex() {
     selectNavigation('workspaces');
@@ -425,6 +468,11 @@ export function initializeDashboard() {
   menuButton.addEventListener('click', () => menu.active ? menu.close() : menu.open());
   document.querySelector('#nav-toggle').addEventListener('click', (event) => { const expanded = event.currentTarget.getAttribute('aria-expanded') === 'true'; event.currentTarget.setAttribute('aria-expanded', String(!expanded)); event.currentTarget.textContent = expanded ? 'Expand navigation' : 'Collapse navigation'; });
   document.addEventListener('click', (event) => { if (event.target.closest?.('a[href]')) apiKeyReveal.clear(); }, { capture: true });
+  document.addEventListener('click', (event) => {
+    const trigger = event.target.closest?.('[data-copy]');
+    if (!trigger) return;
+    void globalThis.navigator.clipboard.writeText(trigger.dataset.copy).then(() => announce('Copied to clipboard.')).catch(() => announce('Copy failed. Select and copy the value manually.'));
+  });
   addEventListener('pagehide', () => apiKeyReveal.clear());
   addEventListener('popstate', () => location.reload()); void load();
 }

--- a/apps/api/dashboard/index.html
+++ b/apps/api/dashboard/index.html
@@ -13,12 +13,17 @@
     <aside id="product-nav" class="sidebar" aria-label="Product navigation">
       <div class="brand">Cloud Harness</div>
       <nav aria-label="Primary">
+        <a href="/dashboard/overview" data-section="overview">Overview</a>
+        <p class="nav-group">Runtime</p>
         <a href="/dashboard" data-section="workspaces">Workspaces</a>
+        <p class="nav-group">Configuration</p>
         <a href="/dashboard/projects" data-section="projects">Projects</a>
-        <a href="/dashboard/artifacts" data-section="artifacts">Artifacts</a>
-        <a href="/dashboard/audit" data-section="audit">Audit</a>
         <a href="/dashboard/api-keys" data-section="api-keys">API keys</a>
         <a href="/dashboard/github" data-section="github">GitHub</a>
+        <p class="nav-group">Observability</p>
+        <a href="/dashboard/artifacts" data-section="artifacts">Artifacts</a>
+        <a href="/dashboard/audit" data-section="audit">Audit</a>
+        <p class="nav-group">Account</p>
         <a href="/dashboard/profile" data-section="profile">Profile</a>
         <div id="context-nav"></div>
       </nav>
@@ -40,6 +45,7 @@
     <aside id="detail" class="detail" aria-labelledby="workspace-detail-title" hidden></aside>
   </div>
   <div id="announcer" class="sr-only" aria-live="polite"></div>
+  <div id="toasts" class="toasts" aria-hidden="true"></div>
   <dialog id="confirm-dialog" aria-labelledby="confirm-title" aria-describedby="confirm-description">
     <h2 id="confirm-title">Confirm action</h2><p id="confirm-description"></p><p id="confirm-target" class="mono"></p>
     <p id="confirm-status" class="status-message" aria-live="polite"></p>

--- a/apps/api/src/dashboard-assets.ts
+++ b/apps/api/src/dashboard-assets.ts
@@ -12,6 +12,7 @@ export function createDashboardAssetsRouter(): Router {
   router.get('/assets/dashboard.js', (_request, response) => response.sendFile('dashboard.js', options));
   router.get([
     '/',
+    '/overview',
     '/workspaces/:workspaceId',
     '/workspaces/:workspaceId/files',
     '/workspaces/:workspaceId/runtime',

--- a/apps/api/test/dashboard-app-mount.test.ts
+++ b/apps/api/test/dashboard-app-mount.test.ts
@@ -34,7 +34,7 @@ describe('dashboard application mount', () => {
     await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
     const address = server.address();
     if (!address || typeof address === 'string') throw new Error('test server failed');
-    for (const path of ['/projects', '/projects/prj_abcdefghijklmnopqrst', '/artifacts', '/audit', '/github', '/api-keys', '/profile']) {
+    for (const path of ['/overview', '/projects', '/projects/prj_abcdefghijklmnopqrst', '/artifacts', '/audit', '/github', '/api-keys', '/profile']) {
       const response = await fetch(`http://127.0.0.1:${address.port}/dashboard${path}`);
       expect(response.status, path).toBe(200);
       expect(await response.text(), path).toContain('<title>Workspaces | Cloud Harness</title>');

--- a/apps/api/test/dashboard-ui-behavior.test.ts
+++ b/apps/api/test/dashboard-ui-behavior.test.ts
@@ -3,7 +3,7 @@ import {
   apiKeyCreateInput, conflictRecovery, createApiKeyRevealController, createAsyncDialogController, createModalController, githubCallbackParameters,
   renderWorkspaceDrawer, resetWriteOnlyFields, submitPatchEdit, submitPatchForm
 } from '../dashboard/dashboard.js';
-import { renderApiKeyIndex, renderProfile, renderProjectDetail } from '../dashboard/dashboard-render.js';
+import { renderApiKeyIndex, renderOverview, renderProfile, renderProjectDetail } from '../dashboard/dashboard-render.js';
 
 class FakeElement {
   hidden = false;
@@ -282,6 +282,19 @@ describe('dashboard UI behavior', () => {
     const html = renderProfile({ identity: { issuer: 'https://team.cloudflareaccess.com', subject: 'operator' }, scopes: [], sessionExpiresAt: null });
     expect(html).toContain('Not provided');
     expect(html).toContain('No scopes reported.');
+    expect(html).toContain('Never');
+  });
+
+  it('escapes attacker-influenceable overview fields and renders a copy affordance', () => {
+    const html = renderOverview({
+      metrics: [{ label: 'GitHub', value: '<img src=x onerror=alert(1)>', small: true, note: '<b>x</b>' }],
+      activity: [{ action: '<script>a</script>', subjectType: 'workspace', subjectId: '<script>b</script>', createdAt: '2026-01-01T00:00:00.000Z' }],
+      access: { name: '<script>n</script>', email: 'op@example.com', sessionExpiresAt: undefined, endpoint: 'https://api.example.com/mcp"><script>' }
+    });
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('data-copy="https://api.example.com/mcp&quot;&gt;&lt;script&gt;"');
     expect(html).toContain('Never');
   });
 });

--- a/apps/api/test/dashboard-ui-contract.test.ts
+++ b/apps/api/test/dashboard-ui-contract.test.ts
@@ -42,7 +42,7 @@ describe('dashboard static UI contract', () => {
 
   it('exposes accessible metadata navigation and only existing dashboard BFF controls', () => {
     for (const [path, label] of [
-      ['/dashboard/projects', 'Projects'], ['/dashboard/artifacts', 'Artifacts'],
+      ['/dashboard/overview', 'Overview'], ['/dashboard/projects', 'Projects'], ['/dashboard/artifacts', 'Artifacts'],
       ['/dashboard/audit', 'Audit'], ['/dashboard/api-keys', 'API keys'], ['/dashboard/github', 'GitHub'],
       ['/dashboard/profile', 'Profile']
     ]) {

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -26,3 +26,28 @@ services:
         limits: { cpus: "1.00", memory: 1G, pids: 256 }
     volumes:
       - /etc/cloud-harness-mcp:/run/cloud-harness-secrets:ro
+
+  # Keep the locally-built executor image referenced by a running container so a
+  # host `docker image prune -a` / `docker system prune -a` cannot delete it
+  # between workspace operations. The executor image only ever runs as
+  # short-lived per-workspace containers, so without a standing reference it is
+  # "unused" and a prune removes it, breaking workspace_open until the next
+  # deploy. This idle holder is strictly less privileged than a real executor:
+  # no network, no mounts, no secrets, all capabilities dropped, read-only,
+  # non-root.
+  executor-image-keepalive:
+    image: cloud-harness-executor:local
+    command: ["sleep", "infinity"]
+    read_only: true
+    network_mode: none
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    user: "10001:10001"
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options: { max-size: 1m, max-file: "1" }
+    deploy:
+      resources:
+        limits: { cpus: "0.01", memory: 32M, pids: 8 }


### PR DESCRIPTION
## Summary
A professional dashboard redesign plus the production reliability fix behind the earlier failed deploy. Client assets + one compose change only; DOM/render contracts and security invariants preserved.

## UI redesign (out-classes the light-only prior version)
- **Adaptive dual theme** — full light + dark OKLCH token sets via `prefers-color-scheme`. WCAG AA verified in **both** themes (dark muted 7.1:1, light muted 5.9:1; primary button 6.6/5.2, links 9.1/7.9, status pills >=4.75).
- **Overview home** (`/dashboard/overview`, first nav item) — live metric tiles (active workspaces, API keys x/10, GitHub status, recent events), a recent-activity feed, and an Access card with a copy-to-clipboard static endpoint. Aggregated **client-side from existing allowlisted endpoints** — no new BFF route, no new data surface.
- **Logical grouped navigation** (Runtime / Configuration / Observability / Account) with an accent active-rail; **skeleton loading**; **transient toasts**; **copy-to-clipboard**; refined tables, status pills, drawer, and dialogs.

## Reliability fix (root cause of the failed deploy)
- `compose.production.yaml`: a hardened, inert **executor-image-keepalive** holder (no network, no mounts, all caps dropped, read-only, non-root) keeps the locally-built, ephemerally-run `cloud-harness-executor:local` referenced by a running container, so a host `docker prune -a` cannot delete it between workspace ops. That deletion caused the prior deploy canary failure `No such image: cloud-harness-executor:local`.

## Constraints honored
- CSP `default-src 'none'`: native fonts, no inline styles, no external assets, no storage/telemetry.
- OKLCH-only, no hex, no gradients (enforced by the UI contract test).
- Security: no control-plane fields rendered; executor holder strictly less privileged than a real executor.

## Verification
- `npx vitest run apps/api/test/dashboard-*.test.ts` -> 35 pass (added Overview route, nav entry, and renderOverview escaping/copy test).
- `npm run verify` (plugin:check + lint + typecheck + tests + build) and `npm run verify:compose` both pass; `docker compose config` renders; runner mounts intact.
- Real-browser visual check in **light + dark + 375px**: Overview, Workspaces (+detail drawer), API keys; metric tiles stack, table -> cards, no horizontal scroll.