### PR TITLE
feat(dashboard): top header, working icon collapse, Overview server status

### DIFF
--- a/apps/api/dashboard/dashboard-render.js
+++ b/apps/api/dashboard/dashboard-render.js
@@ -123,6 +123,19 @@ export function renderOverviewSkeleton() {
   return `<div class="overview"><ul class="metric-grid">${tile.repeat(4)}</ul><div class="overview-columns">${block}${block}</div></div>`;
 }
 
+function renderServerPanel(server) {
+  if (!server) return '';
+  const oauth = server.managedOAuthUrl
+    ? `<dd class="wrap"><span class="mono wrap">${escape(server.managedOAuthUrl)}</span> <button type="button" class="copy" data-copy="${escape(server.managedOAuthUrl)}">Copy</button></dd>`
+    : '<dd>Not published</dd>';
+  const gateway = server.apiKeyGateway?.enabled
+    ? `<dd class="wrap">Enabled${server.apiKeyGateway.endpoint ? ` <span class="mono wrap">${escape(server.apiKeyGateway.endpoint)}</span> <button type="button" class="copy" data-copy="${escape(server.apiKeyGateway.endpoint)}">Copy</button>` : ''}</dd>`
+    : '<dd>Disabled</dd>';
+  const maxBytes = Number.isFinite(server.limits?.maxRequestBytes) ? formatBytes(server.limits.maxRequestBytes) : 'Unknown';
+  const timeout = Number.isFinite(server.limits?.requestTimeoutMs) ? `${Math.round(server.limits.requestTimeoutMs / 1_000)}s` : 'Unknown';
+  return `<section class="panel" aria-labelledby="overview-server-heading"><div class="record-heading"><h2 id="overview-server-heading">Server</h2><span class="status active">Online</span></div><dl class="facts"><dt>Auth mode</dt><dd class="mono">${escape(server.authMode ?? 'Unknown')}</dd><dt>Version</dt><dd class="mono">${escape(server.version ?? 'Unknown')}</dd><dt>Managed OAuth</dt>${oauth}<dt>API-key gateway</dt>${gateway}<dt>Max request</dt><dd>${escape(maxBytes)}</dd><dt>Request timeout</dt><dd>${escape(timeout)}</dd><dt>Session expires</dt><dd>${optionalTime(server.session?.expiresAt)}</dd><dt>Checked</dt><dd>${optionalTime(server.checkedAt)}</dd></dl></section>`;
+}
+
 export function renderOverview(summary) {
   const metrics = summary.metrics.map((metric) => `<li class="metric"><span class="metric-label">${escape(metric.label)}</span><span class="metric-value${metric.small ? ' small' : ''}">${escape(metric.value)}</span>${metric.note ? `<span class="metric-note">${escape(metric.note)}</span>` : ''}</li>`).join('');
   const activity = summary.activity.length
@@ -132,5 +145,5 @@ export function renderOverview(summary) {
   const endpoint = access.endpoint
     ? `<dt>Static endpoint</dt><dd class="wrap"><span class="mono wrap">${escape(access.endpoint)}</span> <button type="button" class="copy" data-copy="${escape(access.endpoint)}">Copy</button></dd>`
     : '';
-  return `<div class="overview"><ul class="metric-grid">${metrics}</ul><div class="overview-columns"><section class="panel" aria-labelledby="overview-activity-heading"><h2 id="overview-activity-heading">Recent activity</h2>${activity}</section><section class="panel" aria-labelledby="overview-access-heading"><h2 id="overview-access-heading">Access</h2><dl class="facts"><dt>Signed in as</dt><dd class="wrap">${escape(access.name)}</dd><dt>Email</dt><dd class="wrap">${escape(access.email)}</dd><dt>Session expires</dt><dd>${optionalTime(access.sessionExpiresAt)}</dd>${endpoint}</dl></section></div></div>`;
+  return `<div class="overview"><ul class="metric-grid">${metrics}</ul><div class="overview-columns"><section class="panel" aria-labelledby="overview-activity-heading"><h2 id="overview-activity-heading">Recent activity</h2>${activity}</section><section class="panel" aria-labelledby="overview-access-heading"><h2 id="overview-access-heading">Access</h2><dl class="facts"><dt>Signed in as</dt><dd class="wrap">${escape(access.name)}</dd><dt>Email</dt><dd class="wrap">${escape(access.email)}</dd><dt>Session expires</dt><dd>${optionalTime(access.sessionExpiresAt)}</dd>${endpoint}</dl></section></div>${renderServerPanel(summary.server)}</div>`;
 }

--- a/apps/api/dashboard/dashboard.css
+++ b/apps/api/dashboard/dashboard.css
@@ -42,7 +42,7 @@
 
 /* Adaptive dark theme - tinted graphite, brightened amber, elevate by lightening. */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --canvas: oklch(0.188 0.010 255);
     --surface: oklch(0.226 0.012 255);
     --surface-raised: oklch(0.270 0.014 255);
@@ -68,6 +68,31 @@
     --shadow-overlay: 0 .25rem .75rem oklch(0.05 0.02 255 / .55), 0 1rem 2.5rem oklch(0.03 0.02 255 / .65);
     --shadow-raise: 0 .0625rem .1875rem oklch(0.05 0.02 255 / .5);
   }
+}
+
+/* Forced theme (explicit user choice, persisted via server cookie -> html[data-theme]). */
+:root[data-theme="dark"] {
+  --canvas: oklch(0.188 0.010 255);
+  --surface: oklch(0.226 0.012 255);
+  --surface-raised: oklch(0.270 0.014 255);
+  --surface-muted: oklch(0.315 0.015 255);
+  --ink: oklch(0.930 0.008 250);
+  --ink-muted: oklch(0.705 0.016 250);
+  --line: oklch(0.330 0.014 255);
+  --line-strong: oklch(0.440 0.018 255);
+  --accent: oklch(0.780 0.150 68);
+  --accent-hover: oklch(0.830 0.140 70);
+  --accent-strong: oklch(0.815 0.135 70);
+  --accent-soft: oklch(0.320 0.075 62);
+  --accent-line: oklch(0.605 0.130 66);
+  --on-accent: oklch(0.175 0.022 58);
+  --focus: oklch(0.795 0.140 68);
+  --success: oklch(0.770 0.130 155); --success-soft: oklch(0.320 0.055 155); --success-line: oklch(0.470 0.085 155);
+  --warning: oklch(0.830 0.120 100); --warning-soft: oklch(0.330 0.050 100); --warning-line: oklch(0.500 0.080 100);
+  --danger: oklch(0.720 0.160 27); --danger-hover: oklch(0.660 0.175 27); --danger-soft: oklch(0.330 0.075 27); --danger-line: oklch(0.500 0.120 27);
+  --code-bg: oklch(0.150 0.010 255); --code-ink: oklch(0.905 0.012 250);
+  --shadow-overlay: 0 .25rem .75rem oklch(0.05 0.02 255 / .55), 0 1rem 2.5rem oklch(0.03 0.02 255 / .65);
+  --shadow-raise: 0 .0625rem .1875rem oklch(0.05 0.02 255 / .5);
 }
 
 * { box-sizing: border-box; }
@@ -111,13 +136,18 @@ button[type="submit"]:not(.danger):active:not(:disabled) { background: var(--acc
 .skip-link:focus { transform: none; }
 
 /* Shell */
-.app-shell { display: grid; grid-template-columns: 15rem minmax(0, 1fr); min-height: 100dvh; }
+.app-shell { display: grid; grid-template-columns: 15rem minmax(0, 1fr); min-height: calc(100dvh - 3.5rem); }
 .app-shell.has-detail { grid-template-columns: 15rem minmax(0, 1fr) minmax(25rem, 28rem); }
+.app-shell.nav-collapsed { grid-template-columns: 3.5rem minmax(0, 1fr); }
+.app-shell.nav-collapsed.has-detail { grid-template-columns: 3.5rem minmax(0, 1fr) minmax(25rem, 28rem); }
+.app-shell.nav-collapsed .sidebar { padding-inline: var(--space-2); }
+.app-shell.nav-collapsed .sidebar nav a, .app-shell.nav-collapsed .nav-group, .app-shell.nav-collapsed #context-nav a { overflow: hidden; white-space: nowrap; }
+.app-shell.nav-collapsed .nav-group { color: transparent; }
 
 .sidebar { background: var(--surface); border-inline-end: 1px solid var(--line); padding: var(--space-6) var(--space-4); display: flex; flex-direction: column; gap: var(--space-2); }
 .brand { display: flex; align-items: center; gap: var(--space-3); font-family: var(--font-display); font-size: var(--text-16); font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
 .brand::before { content: ""; flex: 0 0 auto; width: 1rem; height: 1rem; border-radius: var(--radius-sm); background: var(--accent); box-shadow: inset 0 0 0 .1875rem var(--accent-soft); }
-.env-tag { margin: var(--space-1) 0 var(--space-5); padding-inline-start: calc(1rem + var(--space-3)); font-family: var(--font-mono); font-size: var(--text-11); font-weight: 600; letter-spacing: .12em; text-transform: uppercase; color: var(--accent-strong); }
+.env-tag { margin: 0; font-family: var(--font-mono); font-size: var(--text-11); font-weight: 600; letter-spacing: .12em; text-transform: uppercase; color: var(--accent-strong); }
 h1, h2, h3 { font-family: var(--font-display); text-wrap: balance; }
 
 .sidebar nav { display: grid; gap: var(--space-1); align-content: start; }
@@ -133,8 +163,26 @@ h1, h2, h3 { font-family: var(--font-display); text-wrap: balance; }
 #context-nav a { min-height: 2.5rem; display: flex; align-items: center; padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); color: var(--ink-muted); text-decoration: none; font-weight: 600; }
 #context-nav a:hover { background: var(--surface-raised); color: var(--ink); }
 #context-nav a[aria-current] { color: var(--accent-strong); }
-#nav-toggle { margin-block-start: auto; background: transparent; border-color: transparent; color: var(--ink-muted); font-weight: 600; justify-content: flex-start; }
-#nav-toggle:hover:not(:disabled) { background: var(--surface-raised); border-color: var(--line-strong); color: var(--ink); }
+/* Top header */
+.topbar { position: sticky; inset-block-start: 0; z-index: 35; display: flex; align-items: center; justify-content: space-between; gap: var(--space-4); height: 3.5rem; padding-inline: var(--space-4); background: var(--surface); border-block-end: 1px solid var(--line); }
+.topbar-left, .topbar-right { display: flex; align-items: center; gap: var(--space-3); min-width: 0; }
+.icon-btn { min-height: 2.75rem; min-width: 2.75rem; display: inline-flex; align-items: center; justify-content: center; padding: 0; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--ink-muted); cursor: pointer; transition: background-color var(--motion-fast) var(--ease-out), border-color var(--motion-fast) var(--ease-out), color var(--motion-fast) var(--ease-out); }
+.icon-btn svg { width: 1.25rem; height: 1.25rem; }
+.icon-btn:hover:not(:disabled) { background: var(--surface-raised); border-color: var(--line-strong); color: var(--ink); }
+.topbar-collapse svg { transition: transform var(--motion-state) var(--ease-out); }
+.topbar-collapse[aria-expanded="false"] svg { transform: rotate(180deg); }
+.theme-control { display: inline-flex; border: 1px solid var(--line-strong); border-radius: var(--radius-sm); overflow: hidden; }
+.theme-opt { min-height: 2.75rem; border: 0; border-radius: 0; background: var(--surface); color: var(--ink-muted); font-family: var(--font-mono); font-size: var(--text-11); letter-spacing: .06em; padding: var(--space-1) var(--space-3); }
+.theme-opt + .theme-opt { border-inline-start: 1px solid var(--line); }
+.theme-opt:hover:not(:disabled) { background: var(--surface-raised); color: var(--ink); }
+.theme-opt[aria-pressed="true"] { background: var(--accent-soft); color: var(--ink); }
+.profile-chip { display: flex; align-items: center; gap: var(--space-3); margin: 0; min-width: 0; }
+.avatar { flex: 0 0 auto; width: 2rem; height: 2rem; display: grid; place-items: center; border-radius: var(--radius-pill); background: var(--accent-soft); color: var(--accent-strong); font-family: var(--font-mono); font-size: var(--text-12); font-weight: 700; text-transform: uppercase; }
+.profile-meta { display: grid; min-width: 0; line-height: 1.2; }
+.profile-meta strong { font-size: var(--text-13); font-weight: 700; }
+.profile-meta span { font-size: var(--text-12); color: var(--ink-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 14rem; }
+.signout { min-height: 2.75rem; display: inline-flex; align-items: center; padding: var(--space-1) var(--space-3); border: 1px solid var(--line-strong); border-radius: var(--radius-sm); color: var(--ink); text-decoration: none; font-size: var(--text-12); font-weight: 600; letter-spacing: .02em; text-transform: uppercase; transition: background-color var(--motion-fast) var(--ease-out), border-color var(--motion-fast) var(--ease-out), color var(--motion-fast) var(--ease-out); }
+.signout:hover { background: var(--accent-soft); border-color: var(--accent); color: var(--accent-strong); }
 
 main { min-width: 0; padding: var(--space-8); }
 .page-header { display: grid; gap: var(--space-2); margin-block-end: var(--space-6); }
@@ -305,15 +353,14 @@ dialog::backdrop { background: oklch(0.14 0.02 255 / .55); }
 
 .drawer-close { display: block; margin-inline-start: auto; margin-block-end: var(--space-4); }
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
-.mobile-bar { display: none; }
+.topbar-menu { display: none; }
 
 /* Tablet: collapse detail drawer to overlay, sidebar to icon rail. */
 @media (max-width: 73.6875rem) {
   .app-shell, .app-shell.has-detail { grid-template-columns: 4rem minmax(0, 1fr); }
   .app-shell.has-detail .detail { position: fixed; z-index: 20; inset: 0 0 0 auto; width: min(26.25rem, 92vw); box-shadow: var(--shadow-overlay); overflow: auto; }
   .sidebar { padding-inline: var(--space-2); }
-  .brand, #nav-toggle, .nav-group, .env-tag { overflow: hidden; }
-  .env-tag { padding-inline-start: 0; }
+  .nav-group { overflow: hidden; }
   .sidebar nav a { overflow: hidden; }
   .overview-columns { grid-template-columns: minmax(0, 1fr); }
 }
@@ -321,13 +368,16 @@ dialog::backdrop { background: oklch(0.14 0.02 255 / .55); }
 /* Mobile: drawer sidebar, block layout, stacked cards. */
 @media (max-width: 47.9375rem) {
   html { font-size: var(--text-16); }
-  .mobile-bar { display: flex; height: 3.5rem; align-items: center; gap: var(--space-4); padding-inline: var(--space-3); background: var(--surface); border-block-end: 1px solid var(--line); }
-  .mobile-bar strong { letter-spacing: .04em; text-transform: uppercase; }
+  .topbar { gap: var(--space-2); padding-inline: var(--space-3); }
+  .topbar-menu { display: inline-flex; }
+  .topbar-collapse { display: none; }
+  .env-tag { display: none; }
+  .brand { font-size: 0; }
+  .profile-chip { display: none; }
+  .theme-opt { padding-inline: var(--space-2); }
   .app-shell, .app-shell.has-detail { display: block; min-height: calc(100dvh - 3.5rem); grid-template-columns: none; }
   .sidebar { position: fixed; z-index: 30; inset: 3.5rem auto 0 0; width: min(18rem, 88vw); padding-inline: var(--space-4); transform: translateX(-110%); transition: transform var(--motion-state) var(--ease-out); box-shadow: var(--shadow-overlay); overflow: auto; }
   .sidebar.open { transform: none; }
-  .brand, #nav-toggle, .nav-group, .env-tag { overflow: visible; }
-  .env-tag { padding-inline-start: calc(1rem + var(--space-3)); }
   main { padding: var(--space-4); }
   .detail { display: none; }
   .command-surface, form { align-items: stretch; }

--- a/apps/api/dashboard/dashboard.js
+++ b/apps/api/dashboard/dashboard.js
@@ -225,8 +225,8 @@ export function initializeDashboard() {
     setTitle('Overview', 'A live summary of your workspaces, credentials, and recent activity.');
     document.querySelector('#command-surface').hidden = true;
     content.innerHTML = renderOverviewSkeleton();
-    const [ws, keys, auditResult, github, profile] = await Promise.allSettled([
-      api('/workspaces'), api('/api-keys'), api('/audit?limit=50'), api('/github'), api('/profile')
+    const [ws, keys, auditResult, github, profile, server] = await Promise.allSettled([
+      api('/workspaces'), api('/api-keys'), api('/audit?limit=50'), api('/github'), api('/profile'), api('/server')
     ]);
     const data = (result) => result.status === 'fulfilled' ? result.value.data : undefined;
     const workspaces = data(ws)?.workspaces ?? [];
@@ -250,7 +250,8 @@ export function initializeDashboard() {
         email: identity.email ?? 'Not provided',
         sessionExpiresAt: data(profile)?.sessionExpiresAt,
         endpoint: typeof endpoint === 'string' && /^https:\/\//.test(endpoint) ? endpoint : undefined
-      }
+      },
+      server: data(server)
     });
   }
   async function loadIndex() {
@@ -466,7 +467,30 @@ export function initializeDashboard() {
   document.querySelector('#refresh').addEventListener('click', async () => { announce('Refreshing…'); await load(); announce('Workspace data refreshed.'); });
   const menu = createModalController({ panel: sidebar, backgrounds: [main], trigger: menuButton, initialFocus: () => sidebar.querySelector('a'), onOpen: () => { sidebar.classList.add('open'); menuButton.setAttribute('aria-expanded', 'true'); }, onClose: () => { sidebar.classList.remove('open'); menuButton.setAttribute('aria-expanded', 'false'); } });
   menuButton.addEventListener('click', () => menu.active ? menu.close() : menu.open());
-  document.querySelector('#nav-toggle').addEventListener('click', (event) => { const expanded = event.currentTarget.getAttribute('aria-expanded') === 'true'; event.currentTarget.setAttribute('aria-expanded', String(!expanded)); event.currentTarget.textContent = expanded ? 'Expand navigation' : 'Collapse navigation'; });
+  document.querySelector('#nav-toggle').addEventListener('click', (event) => {
+    const collapsed = document.querySelector('.app-shell').classList.toggle('nav-collapsed');
+    event.currentTarget.setAttribute('aria-expanded', String(!collapsed));
+    event.currentTarget.setAttribute('aria-label', collapsed ? 'Expand navigation' : 'Collapse navigation');
+  });
+  const themeControl = document.querySelector('.theme-control');
+  for (const option of themeControl.querySelectorAll('.theme-opt')) {
+    option.setAttribute('aria-pressed', String(option.dataset.themeValue === (document.documentElement.dataset.theme ?? 'system')));
+    option.addEventListener('click', (event) => {
+      const value = event.currentTarget.dataset.themeValue;
+      if (value === 'system') delete document.documentElement.dataset.theme;
+      else document.documentElement.dataset.theme = value;
+      for (const other of themeControl.querySelectorAll('.theme-opt')) other.setAttribute('aria-pressed', String(other === event.currentTarget));
+      void api('/preferences', { method: 'PUT', body: requestBody({ theme: value }) }).catch(() => announce('Theme preference was not saved.'));
+      announce(`Theme set to ${value}.`);
+    });
+  }
+  void api('/profile').then((result) => {
+    const identity = result.data?.identity ?? {};
+    document.querySelector('#profile-name').textContent = identity.name ?? identity.email ?? 'Signed in';
+    document.querySelector('#profile-email').textContent = identity.email ?? '';
+    const parts = String(identity.name ?? identity.email ?? '?').trim().split(/[\s@._-]+/).filter(Boolean).slice(0, 2);
+    document.querySelector('#profile-avatar').textContent = (parts.map((part) => part[0]).join('') || '?').toUpperCase();
+  }).catch(() => undefined);
   document.addEventListener('click', (event) => { if (event.target.closest?.('a[href]')) apiKeyReveal.clear(); }, { capture: true });
   document.addEventListener('click', (event) => {
     const trigger = event.target.closest?.('[data-copy]');

--- a/apps/api/dashboard/index.html
+++ b/apps/api/dashboard/index.html
@@ -8,11 +8,25 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to main content</a>
-  <div class="mobile-bar"><button id="menu-button" type="button" aria-controls="product-nav" aria-expanded="false">Menu</button><strong>Cloud Harness</strong></div>
+  <header class="topbar">
+    <div class="topbar-left">
+      <button id="menu-button" class="icon-btn topbar-menu" type="button" aria-controls="product-nav" aria-expanded="false" aria-label="Open navigation"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16"/></svg></button>
+      <button id="nav-toggle" class="icon-btn topbar-collapse" type="button" aria-expanded="true" aria-label="Collapse navigation"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 5 8 12l7 7"/></svg></button>
+      <span class="brand">Cloud Harness</span>
+      <span class="env-tag">MCP Control Plane</span>
+    </div>
+    <div class="topbar-right">
+      <div class="theme-control" role="group" aria-label="Theme">
+        <button type="button" class="theme-opt" data-theme-value="system" aria-pressed="true">System</button>
+        <button type="button" class="theme-opt" data-theme-value="light" aria-pressed="false">Light</button>
+        <button type="button" class="theme-opt" data-theme-value="dark" aria-pressed="false">Dark</button>
+      </div>
+      <p class="profile-chip" id="profile-chip"><span class="avatar" id="profile-avatar" aria-hidden="true"></span><span class="profile-meta"><strong id="profile-name">Signed in</strong><span id="profile-email" class="wrap"></span></span></p>
+      <a class="signout" href="/cdn-cgi/access/logout">Sign out</a>
+    </div>
+  </header>
   <div class="app-shell">
     <aside id="product-nav" class="sidebar" aria-label="Product navigation">
-      <div class="brand">Cloud Harness</div>
-      <p class="env-tag">MCP Control Plane</p>
       <nav aria-label="Primary">
         <a href="/dashboard/overview" data-section="overview"><svg class="nav-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>Overview</a>
         <p class="nav-group">Runtime</p>
@@ -28,7 +42,6 @@
         <a href="/dashboard/profile" data-section="profile"><svg class="nav-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="3.5"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/></svg>Profile</a>
         <div id="context-nav"></div>
       </nav>
-      <button id="nav-toggle" type="button" aria-expanded="true">Collapse navigation</button>
     </aside>
     <main id="main" tabindex="-1">
       <header class="page-header"><p class="eyebrow">CONTROL PLANE</p><h1 id="page-title">Workspaces</h1><p id="page-help">TTL-limited coding environments available to your signed-in identity.</p></header>

--- a/apps/api/src/dashboard-assets.ts
+++ b/apps/api/src/dashboard-assets.ts
@@ -1,7 +1,22 @@
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { Router } from 'express';
+import { Router, type Request } from 'express';
 
 const directory = fileURLToPath(new URL('../dashboard/', import.meta.url));
+const shellHtml = readFileSync(new URL('../dashboard/index.html', import.meta.url), 'utf8');
+
+function forcedTheme(request: Request): 'light' | 'dark' | undefined {
+  const header = request.headers.cookie;
+  if (!header) return undefined;
+  for (const part of header.split(';')) {
+    const index = part.indexOf('=');
+    if (index === -1) continue;
+    if (part.slice(0, index).trim() !== 'ch-dashboard-theme') continue;
+    const value = part.slice(index + 1).trim();
+    return value === 'light' || value === 'dark' ? value : undefined;
+  }
+  return undefined;
+}
 
 export function createDashboardAssetsRouter(): Router {
   const router = Router();
@@ -23,6 +38,11 @@ export function createDashboardAssetsRouter(): Router {
     '/github',
     '/api-keys',
     '/profile',
-  ], (_request, response) => response.sendFile('index.html', options));
+  ], (request, response) => {
+    const theme = forcedTheme(request);
+    const html = theme ? shellHtml.replace('<html lang="en">', `<html lang="en" data-theme="${theme}">`) : shellHtml;
+    response.setHeader('Cache-Control', 'no-store');
+    response.type('html').send(html);
+  });
   return router;
 }

--- a/apps/api/src/dashboard-router.ts
+++ b/apps/api/src/dashboard-router.ts
@@ -7,6 +7,17 @@ import { dashboardSecurity, requireJson } from './dashboard-security.js';
 import { createDashboardSessions } from './dashboard-session.js';
 import type { DashboardRequest, DashboardRunnerClient } from './dashboard-types.js';
 import { registerDashboardControlRoutes } from './dashboard-control-router.js';
+import { createRequire } from 'node:module';
+
+const THEME_COOKIE = 'ch-dashboard-theme';
+let apiVersion = 'unknown';
+try {
+  // Local build-time package manifest; shape is known and trusted, not external input.
+  const manifest = createRequire(import.meta.url)('../package.json') as { version?: string };
+  apiVersion = manifest.version ?? 'unknown';
+} catch {
+  apiVersion = 'unknown';
+}
 
 const workspaceId = z.string().regex(/^ws_[A-Za-z0-9_-]{20,80}$/);
 const pageQuery = z.object({ cursor: z.string().max(256).optional(), limit: z.coerce.number().int().min(1).max(100).default(100) });
@@ -58,6 +69,41 @@ export function createDashboardRouter(config: ApiConfig, runner: DashboardRunner
         sessionExpiresAt: typeof request.auth?.expiresAt === 'number' ? new Date(request.auth.expiresAt * 1_000).toISOString() : null
       }
     });
+  });
+
+  router.get('/api/v1/server', (request: DashboardRequest, response) => {
+    const selected = principal(request, response);
+    if (!selected || selected.kind !== 'external') return;
+    const host = config.publicHosts[0];
+    response.json({
+      data: {
+        authMode: config.authMode,
+        managedOAuthUrl: host ? `https://${host}/mcp` : null,
+        apiKeyGateway: config.apiKeyAuthEnabled
+          ? { enabled: true, endpoint: config.apiKeyGatewayPublicUrl ?? null }
+          : { enabled: false },
+        limits: { maxRequestBytes: config.maxBodyBytes, requestTimeoutMs: config.requestTimeoutMs },
+        version: apiVersion,
+        session: {
+          expiresAt: typeof request.auth?.expiresAt === 'number' ? new Date(request.auth.expiresAt * 1_000).toISOString() : null,
+          scopes: request.auth?.scopes ?? []
+        },
+        checkedAt: new Date().toISOString()
+      }
+    });
+  });
+
+  router.put('/api/v1/preferences', (request: DashboardRequest, response) => {
+    const selected = principal(request, response);
+    if (!selected || selected.kind !== 'external') return;
+    const parsed = z.object({ theme: z.enum(['system', 'light', 'dark']) }).strict().safeParse(request.body);
+    if (!parsed.success) { response.status(400).json({ error: 'invalid_request', message: 'Unsupported theme preference.' }); return; }
+    const { theme } = parsed.data;
+    const attributes = 'Path=/dashboard; HttpOnly; Secure; SameSite=Strict';
+    response.setHeader('Set-Cookie', theme === 'system'
+      ? `${THEME_COOKIE}=; ${attributes}; Max-Age=0`
+      : `${THEME_COOKIE}=${theme}; ${attributes}; Max-Age=31536000`);
+    response.json({ data: { theme } });
   });
 
   router.get('/api/v1/workspaces', async (request: DashboardRequest, response, next) => {

--- a/apps/api/test/dashboard-app-mount.test.ts
+++ b/apps/api/test/dashboard-app-mount.test.ts
@@ -41,6 +41,19 @@ describe('dashboard application mount', () => {
     }
   });
 
+  it('injects the forced theme from the preference cookie into the shell', async () => {
+    const app = express();
+    app.use('/dashboard', createDashboardAssetsRouter());
+    server = createServer(app);
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('test server failed');
+    const base = `http://127.0.0.1:${address.port}/dashboard/overview`;
+    expect(await (await fetch(base)).text()).toContain('<html lang="en">');
+    expect(await (await fetch(base, { headers: { cookie: 'ch-dashboard-theme=dark' } })).text()).toContain('<html lang="en" data-theme="dark">');
+    expect(await (await fetch(base, { headers: { cookie: 'ch-dashboard-theme=neon' } })).text()).toContain('<html lang="en">');
+  });
+
   it('does not expose dashboard routes in owner-bearer mode', async () => {
     const url = await serve({
       authMode: 'owner-bearer', host: '127.0.0.1', port: 0, ownerId: 'owner', bearerToken,

--- a/apps/api/test/dashboard-router.test.ts
+++ b/apps/api/test/dashboard-router.test.ts
@@ -170,6 +170,38 @@ describe('dashboard BFF', () => {
     expect(revoked.status).toBe(200);
     expect(revoked.text).not.toContain('.ssss');
   });
+
+  it('exposes safe server configuration and status without control-plane fields', async () => {
+    const response = await send('/api/v1/server');
+    expect(response.status).toBe(200);
+    expect(response.json.data.authMode).toBe('cloudflare-access');
+    expect(response.json.data.managedOAuthUrl).toBe('https://dashboard.example/mcp');
+    expect(response.json.data.apiKeyGateway).toEqual({ enabled: true, endpoint: 'https://api.example/mcp' });
+    expect(response.json.data.limits).toEqual({ maxRequestBytes: 65_536, requestTimeoutMs: 2_000 });
+    expect(typeof response.json.data.version).toBe('string');
+    expect(typeof response.json.data.checkedAt).toBe('string');
+    for (const forbidden of ['runner-token', 'runner:3001', 'api-key-audience', 'cf-service:d29ya2Vy']) expect(response.text).not.toContain(forbidden);
+    expect(response.headers['cache-control']).toBe('no-store');
+  });
+
+  it('persists a valid theme preference by cookie and rejects unknown or unauthenticated changes', async () => {
+    const session = await send('/api/v1/session');
+    const cookie = String(session.headers['set-cookie']?.[0]).split(';', 1)[0];
+    const headers = { origin: 'https://dashboard.example', cookie, 'content-type': 'application/json', 'x-csrf-token': session.json.csrfToken };
+    const missingCsrf = await send('/api/v1/preferences', { method: 'PUT', headers: { origin: 'https://dashboard.example', 'content-type': 'application/json' }, body: JSON.stringify({ theme: 'dark' }) });
+    expect(missingCsrf.status).toBe(401);
+    const dark = await send('/api/v1/preferences', { method: 'PUT', headers, body: JSON.stringify({ theme: 'dark' }) });
+    expect(dark.status).toBe(200);
+    expect(dark.json.data.theme).toBe('dark');
+    const setCookie = String(dark.headers['set-cookie']?.[0]);
+    expect(setCookie).toContain('ch-dashboard-theme=dark');
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('Path=/dashboard');
+    const cleared = await send('/api/v1/preferences', { method: 'PUT', headers, body: JSON.stringify({ theme: 'system' }) });
+    expect(String(cleared.headers['set-cookie']?.[0])).toContain('Max-Age=0');
+    const invalid = await send('/api/v1/preferences', { method: 'PUT', headers, body: JSON.stringify({ theme: 'purple' }) });
+    expect(invalid.status).toBe(400);
+  });
 });
 
 describe('dashboard profile', () => {
@@ -239,5 +271,50 @@ describe('dashboard profile', () => {
   it('rejects a request that has no verified external principal', async () => {
     await serveProfile({ token: 'owner', clientId: 'owner', scopes: [], extra: { principal: { kind: 'owner', ownerId: 'owner' } } });
     expect((await get()).status).toBe(401);
+  });
+});
+
+describe('dashboard server access control', () => {
+  let srv: Server;
+  let srvPort: number;
+
+  async function serve(auth: AuthInfo): Promise<void> {
+    const app = express();
+    app.use((request, _response, next) => { (request as DashboardRequest).auth = auth; next(); });
+    app.use('/dashboard', createDashboardRouter(config, runner));
+    srv = createServer(app);
+    const listening = Promise.withResolvers<void>();
+    srv.listen(0, '127.0.0.1', () => listening.resolve());
+    await listening.promise;
+    const address = srv.address();
+    if (!address || typeof address === 'string') throw new Error('server unavailable');
+    srvPort = address.port;
+  }
+
+  function statusOf(): Promise<number> {
+    const { promise, resolve, reject } = Promise.withResolvers<number>();
+    const request = httpRequest({ hostname: '127.0.0.1', port: srvPort, path: '/dashboard/api/v1/server', method: 'GET', headers: { host: 'dashboard.example' } }, (response) => {
+      response.resume();
+      response.on('end', () => resolve(response.statusCode ?? 0));
+    });
+    request.on('error', reject); request.end();
+    return promise;
+  }
+
+  afterEach(async () => {
+    if (!srv) return;
+    const closed = Promise.withResolvers<void>();
+    srv.close(() => closed.resolve());
+    await closed.promise;
+  });
+
+  it('serves server info to a verified external principal', async () => {
+    await serve({ token: 'cloudflare-access', clientId: 'operator', scopes: [], extra: { principal } });
+    expect(await statusOf()).toBe(200);
+  });
+
+  it('rejects server info for a non-external principal', async () => {
+    await serve({ token: 'owner', clientId: 'owner', scopes: [], extra: { principal: { kind: 'owner', ownerId: 'owner' } } });
+    expect(await statusOf()).toBe(401);
   });
 });

--- a/apps/api/test/dashboard-ui-contract.test.ts
+++ b/apps/api/test/dashboard-ui-contract.test.ts
@@ -71,4 +71,17 @@ describe('dashboard static UI contract', () => {
     for (const forbidden of ['localStorage', 'sessionStorage', 'document.cookie', 'console.', 'sendBeacon(', 'analytics']) expect(script).not.toContain(forbidden);
     expect(html).not.toContain('value="chm_key_');
   });
+
+  it('provides a top header with profile, theme control, sign out, an icon collapse, and server status', () => {
+    expect(html).toContain('<header class="topbar">');
+    expect(html).toContain('href="/cdn-cgi/access/logout"');
+    for (const theme of ['data-theme-value="system"', 'data-theme-value="light"', 'data-theme-value="dark"']) expect(html).toContain(theme);
+    expect(html).toContain('id="profile-name"');
+    expect(html).toContain('id="nav-toggle"');
+    expect(html).not.toContain('>Collapse navigation</button>');
+    expect(script).toContain("api('/server')");
+    expect(script).toContain("api('/preferences'");
+    expect(script).toContain("classList.toggle('nav-collapsed')");
+    expect(css).toContain('.app-shell.nav-collapsed');
+  });
 });


### PR DESCRIPTION
Three operator-requested dashboard improvements. Client assets + a small BFF addition; DOM/security contracts preserved, CSP-safe.

## 1. Top header
- Sticky top bar: brand + `MCP Control Plane` tag, a **system/light/dark theme control**, a **profile chip** (name, email, initials avatar), and **Sign out** (Cloudflare Access logout `/cdn-cgi/access/logout`).
- **Theme persists without client storage** (contract bans `localStorage`/cookies in the script): CSRF-guarded `PUT /api/v1/preferences` sets an HttpOnly `ch-dashboard-theme` cookie; the shell handler injects `html[data-theme]` (no first-paint flash). Client only reads the DOM attribute. CSS: `system` follows `prefers-color-scheme`, `light`/`dark` forced via `:root[data-theme]`.

## 2. Navigation collapse (bug fix)
- Root cause: the toggle flipped `aria-expanded` but **no rule reacted on desktop**, so it did nothing. It now toggles `.app-shell.nav-collapsed` (icon rail) and is an **icon button** (chevron) instead of a text button. Mobile keeps the drawer menu.

## 3. Overview server status
- New `GET /api/v1/server` returns **allowlisted** config + status (auth mode, managed OAuth URL, API-key gateway readiness, request limits, version, session, checked time) from `ApiConfig` + the verified assertion. **No** ownerId, runner URL/token, audiences, or secrets. Overview renders a **Server** panel with an Online status.

## Verification
- `dashboard-*` tests **41 pass** (added: router server allowlist + external-only 401; preferences cookie/validation/CSRF; app-mount `data-theme` injection; UI-contract top header + icon collapse + new endpoints).
- `npm run verify` (lint + typecheck + tests + build) passes.
- Browser-verified in **light + dark + 390px**: header controls, collapse toggles the rail, theme control forces light/dark, Server panel renders; 0 horizontal overflow.

## Contract safety
- OKLCH-only, no hex/gradient; required tokens, both media queries, `min-height: 2.75rem`, exact `.drawer-close` rule preserved. Single `<h1>`, landmarks, dialogs, nav labels intact. No client storage/telemetry; no control-plane fields rendered.