### PR TITLE
docs(dashboard): reconcile design guidelines with theme control, top bar, and server status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ instead of copying behavior, defaults, command inventories, or configuration.
 | Configuration | [`docs/configuration.md`](docs/configuration.md) | `.env.example`, `packages/contracts/src/config.ts`, `apps/api/src/config.ts`, `apps/runner/src/config.ts`, `compose*.yaml` |
 | Development and verification | [`docs/development.md`](docs/development.md) | `package.json`, `.github/workflows/ci.yml`, tests |
 | Deployment and recovery | [`docs/deployment.md`](docs/deployment.md), [`docs/operations.md`](docs/operations.md), [`docs/troubleshooting.md`](docs/troubleshooting.md) | `deploy/`, `compose.production.yaml`, `scripts/verify-production.mjs`, `scripts/deploy-canary.mjs` |
+| Operator dashboard UI | [`docs/design-guidelines.md`](docs/design-guidelines.md) | `apps/api/dashboard/`, `apps/api/src/dashboard-router.ts`, `apps/api/src/dashboard-assets.ts`, `apps/api/test/dashboard-ui-contract.test.ts` |
 
 ## Safety-critical invariants
 

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -57,12 +57,20 @@ fonts the CSP forbids. We carry the same voice with a native stack instead:
 
 ### Adaptive dark theme
 
-The theme follows `prefers-color-scheme` (no toggle, no persistence - storage is
-forbidden). Dark is a tinted graphite, not black: surfaces **elevate by
-lightening** (`--canvas` -> `--surface` -> `--surface-raised`), the amber accent
-is **brightened** so it stays legible, and shadows deepen. Both themes are
-verified at WCAG AA: body text and muted text >= 4.5:1, primary-button text and
-status pills pass against their actual backgrounds, and the focus ring is >= 3:1
+The default follows `prefers-color-scheme`; a **system / light / dark** control
+in the top bar lets an operator force a theme. Client storage is forbidden, so
+the choice persists **server-side, not in the browser**: `PUT
+/api/v1/preferences` (CSRF-guarded) sets an HttpOnly `ch-dashboard-theme`
+cookie, and the shell handler injects `html[data-theme]` on first paint so a
+forced theme never flashes. The client only reads that DOM attribute. Owners:
+[`apps/api/src/dashboard-router.ts`](../apps/api/src/dashboard-router.ts) and
+[`apps/api/src/dashboard-assets.ts`](../apps/api/src/dashboard-assets.ts).
+
+Dark is a tinted graphite, not black: surfaces **elevate by lightening**
+(`--canvas` -> `--surface` -> `--surface-raised`), the amber accent is
+**brightened** so it stays legible, and shadows deepen. Both themes are verified
+at WCAG AA: body text and muted text >= 4.5:1, primary-button text and status
+pills pass against their actual backgrounds, and the focus ring is >= 3:1
 against its surface.
 
 ## Depth, shape, motion
@@ -77,13 +85,19 @@ against its surface.
 
 ## Components
 
+- **Top bar:** sticky header carrying the wordmark + `MCP Control Plane` tag,
+  the theme control, a profile chip (name, email, initials avatar), and Sign
+  out (Cloudflare Access logout at `/cdn-cgi/access/logout`).
 - **Navigation:** left icon+label rail, grouped by concern (Runtime,
   Configuration, Observability, Account) with an Overview home. Active item gets
-  the amber rail + soft fill; the rail collapses to icons on tablet and to a
-  drawer on mobile.
-- **Overview:** monospace metric tiles (corner-bracketed) capped at four
-  above the fold, a recent-activity feed, and an Access panel. Aggregated
-  client-side from existing allowlisted endpoints; it adds no new data surface.
+  the amber rail + soft fill. A chevron control collapses the rail to icons on
+  desktop (toggling `.app-shell.nav-collapsed`); it also collapses to icons on
+  tablet and to a drawer on mobile.
+- **Overview:** monospace metric tiles (corner-bracketed) capped at four above
+  the fold, a recent-activity feed, an Access panel, and a Server panel. Tiles
+  and feed aggregate client-side from allowlisted endpoints; the Server panel
+  reads `GET /api/v1/server`, a read-only projection of config and status that
+  exposes no owner ID, runner URL, token, or secret.
 - **Tables:** rounded hairline container, uppercase column headers, row hover,
   tabular numerals, `nowrap` timestamps; collapse to stacked cards on mobile.
 - **Interaction states:** every control ships default / hover / `:focus-visible`


### PR DESCRIPTION
## Summary
Docs-only change. Reconciles `docs/design-guidelines.md` with the dashboard behavior already merged in #50 (top header, theme control + server-side persistence, desktop nav collapse, Overview server status), and makes the doc discoverable from the navigation table.

No code changes: the dashboard code and its tests already landed and passed on #50 / v0.12.0. This PR carries only Markdown.

## Changes
- **`docs/design-guidelines.md`**
  - Theme section: replaced the stale *"no toggle, no persistence"* claim with the actual model — a system/light/dark control persisted **server-side** (HttpOnly `ch-dashboard-theme` cookie via CSRF-guarded `PUT /api/v1/preferences`; `html[data-theme]` injected on first paint to avoid flash; client storage still forbidden). Points to `dashboard-router.ts` and `dashboard-assets.ts` as owners.
  - Added a **Top bar** component (wordmark + `MCP Control Plane` tag, theme control, profile chip, Cloudflare Access sign out).
  - Updated **Navigation** to document the desktop icon-rail collapse (`.app-shell.nav-collapsed` chevron), alongside tablet/mobile.
  - Updated **Overview** to document the **Server panel** (`GET /api/v1/server`, read-only projection of config/status exposing no secrets); corrected the "no new data surface" line.
- **`AGENTS.md`**: added an *Operator dashboard UI* row to the navigation table pointing to `design-guidelines.md` with its executable owners (`apps/api/dashboard/`, `dashboard-router.ts`, `dashboard-assets.ts`, `dashboard-ui-contract.test.ts`).

## Evidence / grounding
Every claim verified against source: `apps/api/src/dashboard-router.ts:74-107` (server + preferences handlers), `apps/api/src/dashboard-assets.ts` (cookie parse + `data-theme` injection), and commit `51ca575` (#50). All referenced paths and relative links confirmed to resolve.

## Tests
Not run — Markdown-only diff vs `main`; no code delta to exercise. Dashboard code + tests already green on #50.

## Ship Mode
official (target `main`).