### PR TITLE
feat(github-app): support multiple installations per principal (#54)

### DIFF
--- a/apps/api/dashboard/dashboard-render.js
+++ b/apps/api/dashboard/dashboard-render.js
@@ -73,13 +73,25 @@ function renderApiKey(key) {
   return `<li class="panel api-key-card"><div class="record-heading"><div><h3>${escape(key?.name)}</h3><p><code class="mono">${escape(key?.displayPrefix)}</code> <span class="status ${state === 'ACTIVE' ? 'active' : state === 'EXPIRED' ? 'expired' : ''}">${escape(stateLabel(state))}</span></p></div>${action}</div><dl class="facts"><dt>Created</dt><dd>${optionalTime(key?.createdAt)}</dd><dt>Expires</dt><dd>${optionalTime(key?.expiresAt)}</dd><dt>Last used</dt><dd>${optionalTime(key?.lastUsedAt)}</dd><dt>Revoked</dt><dd>${optionalTime(key?.revokedAt)}</dd></dl></li>`;
 }
 
-export function renderGitHub(status, callbackPending = false) {
-  const installation = status.installation;
-  const installationView = installation ? `<dl class="facts"><dt>Account</dt><dd>${escape(installation.accountLogin ?? installation.accountId)}</dd><dt>Status</dt><dd>${escape(installation.status)}</dd><dt>Installation ID</dt><dd class="mono">${escape(installation.installationId)}</dd><dt>Last checked</dt><dd>${installation.checkedAt ? time(installation.checkedAt) : 'Not yet reconciled'}</dd></dl>` : '<p>No GitHub App installation is bound to this identity.</p>';
-  const repositories = status.repositories?.length ? `<ul class="record-list">${status.repositories.map((repository) => `<li><strong>${escape(repository.owner)}/${escape(repository.repository)}</strong><span>${escape(repository.status)} · Contents ${escape(repository.contents)}</span></li>`).join('')}</ul>` : '<p>No authorized repositories reported.</p>';
-  return `<div class="page-note"><strong>GitHub App authorization metadata.</strong> Provider private keys and minted tokens remain runner-only and are never rendered.</div>${callbackPending ? '<p class="status-message" role="status">Completing GitHub App connection…</p>' : ''}<section class="panel"><h2>Installation status</h2>${installationView}<button id="reconcile-github" type="button">Reconcile installation</button><p id="github-status-message" class="form-status" aria-live="polite"></p></section><section class="panel"><h2>Connect GitHub App</h2><form id="github-setup-form" class="stack-form"><label for="github-account-id">Expected account ID <span class="optional">Optional</span></label><input id="github-account-id" name="expectedAccountId" maxlength="100"><button type="submit">Connect GitHub App</button><p class="form-status" aria-live="polite"></p></form></section><section><h2>Authorized repositories</h2>${repositories}</section>`;
+function renderInstallationCard(installation) {
+  const id = escape(installation.installationId);
+  const account = escape(installation.accountLogin ?? installation.accountId);
+  const instStatus = escape(installation.status);
+  const checked = installation.checkedAt ? time(installation.checkedAt) : 'Not yet reconciled';
+  return `<li class="panel installation-card" data-installation-id="${id}"><div class="record-heading"><div><h3>${account}</h3><p><code class="mono">${id}</code> <span class="status ${installation.status === 'active' ? 'active' : ''}">${instStatus}</span></p></div><div class="row-actions"><button class="reconcile-installation" type="button" data-installation-id="${id}">Reconcile</button><button class="danger disconnect-installation" type="button" data-installation-id="${id}" data-account="${account}">Disconnect</button></div></div><dl class="facts"><dt>Account</dt><dd>${account}</dd><dt>Status</dt><dd>${instStatus}</dd><dt>Installation ID</dt><dd class="mono">${id}</dd><dt>Last checked</dt><dd>${checked}</dd></dl></li>`;
 }
 
+export function renderGitHub(status, callbackPending = false) {
+  const installations = Array.isArray(status?.installations) && status.installations.length
+    ? status.installations
+    : (status?.installation ? [status.installation] : []);
+  const installationView = installations.length
+    ? `<ul class="record-list">${installations.map(renderInstallationCard).join('')}</ul>`
+    : '<p>No GitHub App installation is bound to this identity.</p>';
+  const repositories = status?.repositories?.length ? `<ul class="record-list">${status.repositories.map((repository) => `<li><strong>${escape(repository.owner)}/${escape(repository.repository)}</strong><span>${escape(repository.status)} · Contents ${escape(repository.contents)}${repository.installationId ? ` · ID <code class="mono">${escape(repository.installationId)}</code>` : ''}</span></li>`).join('')}</ul>` : '<p>No authorized repositories reported.</p>';
+  const reconcileLabel = installations.length > 1 ? 'Reconcile all installations' : 'Reconcile installation';
+  return `<div class="page-note"><strong>GitHub App authorization metadata.</strong> Provider private keys and minted tokens remain runner-only and are never rendered.</div>${callbackPending ? '<p class="status-message" role="status">Completing GitHub App connection…</p>' : ''}<section class="panel"><h2>Installation status</h2>${installationView}<button id="reconcile-github" type="button"${installations.length === 0 ? ' disabled' : ''}>${reconcileLabel}</button><p id="github-status-message" class="form-status" aria-live="polite"></p></section><section class="panel"><h2>Connect GitHub App</h2><form id="github-setup-form" class="stack-form"><label for="github-account-id">Expected account ID <span class="optional">Optional</span></label><input id="github-account-id" name="expectedAccountId" maxlength="100"><button type="submit">Connect GitHub App</button><p class="form-status" aria-live="polite"></p></form></section><section><h2>Authorized repositories</h2>${repositories}</section>`;
+}
 export function renderProfile(profile) {
   const identity = profile?.identity ?? {};
   const scopes = Array.isArray(profile?.scopes) ? profile.scopes : [];

--- a/apps/api/dashboard/dashboard.js
+++ b/apps/api/dashboard/dashboard.js
@@ -233,15 +233,23 @@ export function initializeDashboard() {
     const keyData = data(keys);
     const apiKeys = Array.isArray(keyData?.keys) ? keyData.keys : [];
     const events = data(auditResult)?.events ?? [];
-    const installation = data(github)?.installation;
+    const githubData = data(github);
+    const installations = Array.isArray(githubData?.installations) ? githubData.installations : (githubData?.installation ? [githubData.installation] : []);
+    const activeInstallations = installations.filter((inst) => inst.status === 'active');
+    const installationCount = installations.length;
+    const githubNote = installationCount === 1
+      ? (installations[0].accountLogin ?? installations[0].accountId ?? '1 account bound')
+      : installationCount > 1
+        ? `${installationCount} accounts/orgs bound`
+        : 'No installation bound';
+    const githubConnected = activeInstallations.length > 0;
     const identity = data(profile)?.identity ?? {};
     const endpoint = keyData?.readiness?.ready === true ? (keyData.readiness.publicUrl ?? keyData.publicUrl) : undefined;
-    const account = installation?.accountLogin ?? installation?.accountId;
     content.innerHTML = renderOverview({
       metrics: [
         { label: 'Active workspaces', value: workspaces.filter((item) => item.status === 'ACTIVE').length, note: `${workspaces.length} total` },
         { label: 'API keys', value: `${apiKeys.filter((item) => item.state === 'ACTIVE').length}/10`, note: 'Active of limit' },
-        { label: 'GitHub', value: installation ? 'Connected' : 'Not connected', small: true, note: installation ? (account ?? 'Installation bound') : 'No installation bound' },
+        { label: 'GitHub', value: githubConnected ? 'Connected' : 'Not connected', small: true, note: githubNote },
         { label: 'Recent events', value: events.length, note: 'Retained audit records' }
       ],
       activity: events.slice(0, 6).map((event) => ({ action: event.action, subjectType: event.subjectType, subjectId: event.subjectId, createdAt: event.createdAt })),
@@ -368,19 +376,52 @@ export function initializeDashboard() {
     const result = await api('/github'); content.innerHTML = renderGitHub(result.data); bindGitHubControls();
   }
   function bindGitHubControls() {
-    const form = document.querySelector('#github-setup-form'); form.addEventListener('submit', (event) => {
-      event.preventDefault(); const values = new FormData(form); const expectedAccountId = String(values.get('expectedAccountId') ?? '').trim();
-      void submitForm(form, 'Preparing connection…', async () => {
-        const result = await api('/github/setup', { method: 'POST', body: requestBody(expectedAccountId ? { expectedAccountId } : {}) });
-        const destination = new URL(result.data.url); if (destination.protocol !== 'https:') throw new Error('GitHub setup URL was invalid.');
-        location.assign(destination.toString());
-      }, async () => {});
-    });
-    document.querySelector('#reconcile-github').addEventListener('click', async (event) => {
-      const button = event.currentTarget; button.disabled = true; button.textContent = 'Reconciling…';
-      try { await api('/github/reconcile', { method: 'POST', body: requestBody({}) }); announce('GitHub installation reconciled.'); await loadGitHub(); }
-      catch (error) { showError(error); } finally { button.disabled = false; button.textContent = 'Reconcile installation'; }
-    });
+    const form = document.querySelector('#github-setup-form');
+    if (form) {
+      form.addEventListener('submit', (event) => {
+        event.preventDefault(); const values = new FormData(form); const expectedAccountId = String(values.get('expectedAccountId') ?? '').trim();
+        void submitForm(form, 'Preparing connection…', async () => {
+          const result = await api('/github/setup', { method: 'POST', body: requestBody(expectedAccountId ? { expectedAccountId } : {}) });
+          const destination = new URL(result.data.url); if (destination.protocol !== 'https:') throw new Error('GitHub setup URL was invalid.');
+          location.assign(destination.toString());
+        }, async () => {});
+      });
+    }
+    const reconcileAllButton = document.querySelector('#reconcile-github');
+    if (reconcileAllButton) {
+      reconcileAllButton.addEventListener('click', async (event) => {
+        const button = event.currentTarget;
+        const originalText = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Reconciling…';
+        try { await api('/github/reconcile', { method: 'POST', body: requestBody({}) }); announce('GitHub installations reconciled.'); await loadGitHub(); }
+        catch (error) { showError(error); } finally { button.disabled = false; button.textContent = originalText; }
+      });
+    }
+    for (const button of document.querySelectorAll('.reconcile-installation')) {
+      button.addEventListener('click', async (event) => {
+        const btn = event.currentTarget; btn.disabled = true; btn.textContent = 'Reconciling…';
+        try {
+          await api('/github/reconcile', { method: 'POST', body: requestBody({ installationId: btn.dataset.installationId }) });
+          announce('GitHub installation reconciled.');
+          await loadGitHub();
+        } catch (error) { showError(error); } finally { btn.disabled = false; btn.textContent = 'Reconcile'; }
+      });
+    }
+    for (const button of document.querySelectorAll('.disconnect-installation')) {
+      button.addEventListener('click', (event) => confirmAction({
+        title: 'Disconnect GitHub App installation?',
+        description: 'Disconnect this account/organization and remove associated repository authorizations?',
+        target: `${button.dataset.account ?? 'Installation'} (ID ${button.dataset.installationId})`,
+        label: 'Disconnect',
+        pendingLabel: 'Disconnecting…',
+        action: async () => {
+          await api('/github/disconnect', { method: 'POST', body: requestBody({ installationId: button.dataset.installationId }) });
+          announce('GitHub installation disconnected.');
+          await loadGitHub();
+        }
+      }, event.currentTarget));
+    }
   }
   async function loadProfile() {
     selectNavigation('profile'); setTitle('Profile', 'Your signed-in identity and session details.'); document.querySelector('#command-surface').hidden = true;

--- a/apps/api/src/dashboard-control-router.ts
+++ b/apps/api/src/dashboard-control-router.ts
@@ -33,7 +33,9 @@ export function registerDashboardControlRoutes(
   router.get('/api/v1/github', endpoint('github_status', () => ({})));
   router.post('/api/v1/github/setup', endpoint('github_setup_begin', (request) => request.body as Record<string, unknown>));
   router.post('/api/v1/github/complete', endpoint('github_setup_complete', (request) => request.body as Record<string, unknown>));
-  router.post('/api/v1/github/reconcile', endpoint('github_reconcile', () => ({})));
+  router.post('/api/v1/github/reconcile', endpoint('github_reconcile', (request) => (request.body && typeof request.body === 'object' ? request.body as Record<string, unknown> : {})));
+  router.delete('/api/v1/github/installations/:installationId', endpoint('github_disconnect', (request) => ({ installationId: request.params.installationId })));
+  router.post('/api/v1/github/disconnect', endpoint('github_disconnect', (request) => request.body as Record<string, unknown>));
   router.get('/api/v1/api-keys', apiKeyEndpoint('api_key_list', () => ({})));
   router.post('/api/v1/api-keys', apiKeyEndpoint('api_key_create', (request) => z.object({
     name: z.string().trim().min(1).max(100), expiresInDays: z.number().int().min(1).max(365)

--- a/apps/api/src/dashboard-response.ts
+++ b/apps/api/src/dashboard-response.ts
@@ -48,7 +48,7 @@ export type DashboardResponseOperation =
   | 'environment_list' | 'environment_create' | 'environment_update' | 'environment_delete'
   | 'secret_list' | 'secret_create' | 'secret_rotate' | 'secret_delete' | 'audit_list'
   | 'artifact_list' | 'artifact_snapshot' | 'artifact_delete'
-  | 'github_status' | 'github_setup_begin' | 'github_setup_complete' | 'github_reconcile';
+  | 'github_status' | 'github_setup_begin' | 'github_setup_complete' | 'github_reconcile' | 'github_disconnect';
 
 function pick(value: unknown, keys: readonly string[]): Record<string, unknown> {
   const item = value && typeof value === 'object' ? value as Record<string, unknown> : {};
@@ -63,10 +63,18 @@ const list = (data: Record<string, unknown>, key: string, keys: readonly string[
   [key]: Array.isArray(data[key]) ? data[key].map((record) => pick(record, keys)) : []
 });
 
+const installationKeys = ['appId', 'installationId', 'accountId', 'accountLogin', 'status', 'generation', 'createdAt', 'updatedAt', 'checkedAt'] as const;
 function githubStatus(data: Record<string, unknown>): Record<string, unknown> {
-  const installation = data.installation && typeof data.installation === 'object'
-    ? pick(data.installation, ['appId', 'installationId', 'accountId', 'accountLogin', 'status', 'generation', 'createdAt', 'updatedAt', 'checkedAt']) : null;
-  return { configured: data.configured === true, installation, ...list(data, 'repositories', ['installationId', 'owner', 'repository', 'contents', 'status', 'generation', 'createdAt', 'updatedAt', 'checkedAt']) };
+  const installations = Array.isArray(data.installations)
+    ? data.installations.map((item) => pick(item, installationKeys))
+    : (data.installation && typeof data.installation === 'object' ? [pick(data.installation, installationKeys)] : []);
+  const installation = installations[0] ?? (data.installation && typeof data.installation === 'object' ? pick(data.installation, installationKeys) : null);
+  return {
+    configured: data.configured === true,
+    installation,
+    installations,
+    ...list(data, 'repositories', ['installationId', 'owner', 'repository', 'contents', 'status', 'generation', 'createdAt', 'updatedAt', 'checkedAt'])
+  };
 }
 
 export function mapDashboardData(operation: DashboardResponseOperation, value: unknown): unknown {
@@ -107,7 +115,7 @@ export function mapDashboardData(operation: DashboardResponseOperation, value: u
   if (operation === 'artifact_list') return list(data, 'artifacts', artifactKeys);
   if (operation === 'artifact_snapshot' || operation === 'artifact_delete') return pick(data, artifactKeys);
   if (operation === 'github_setup_begin') return pick(data, ['url', 'state', 'expiresAt']);
-  if (operation === 'github_status' || operation === 'github_setup_complete' || operation === 'github_reconcile') return githubStatus(data);
+  if (['github_status', 'github_setup_complete', 'github_reconcile', 'github_disconnect'].includes(operation)) return githubStatus(data);
   return {};
 }
 

--- a/apps/api/test/dashboard-router.test.ts
+++ b/apps/api/test/dashboard-router.test.ts
@@ -38,8 +38,8 @@ beforeEach(async () => {
       if (operation === 'files_write') return { ok: true, message: 'written', truncated: false, data: { path: input.path, sha256: 'b'.repeat(64) } };
       return { ok: true, message: 'ok', truncated: false, data: {} };
     }),
-    callInternal: vi.fn(async (_operation, input, selected): Promise<RunnerResponse> => {
-      calls.push({ operation: 'workspace_detail', input, principal: selected });
+    callInternal: vi.fn(async (operation, input, selected): Promise<RunnerResponse> => {
+      calls.push({ operation, input, principal: selected });
       return { ok: true, message: 'detail', truncated: false, data: {
         workspaceId, repositoryUrl: 'https://github.com/example/project.git', status: 'ACTIVE', networkMode: 'none', generation: 7,
         createdAt: '2026-08-17T00:00:00.000Z', lastActivityAt: '2026-08-17T00:01:00.000Z', expiresAt: '2026-08-17T00:10:00.000Z'
@@ -104,6 +104,59 @@ describe('dashboard BFF', () => {
     }
   });
 
+  it('maps multi-installation github status and disconnect operations cleanly', async () => {
+    const hostile = { ownerId: 'hostile-owner', secretToken: 'secret' };
+    const rawStatus = {
+      configured: true,
+      installations: [
+        { appId: '1', installationId: '101', accountId: '201', accountLogin: 'org-one', status: 'active', ...hostile },
+        { appId: '1', installationId: '102', accountId: '202', accountLogin: 'org-two', status: 'active', ...hostile }
+      ],
+      repositories: [
+        { installationId: '101', owner: 'org-one', repository: 'repo1', contents: 'write', status: 'granted', ...hostile }
+      ],
+      ...hostile
+    };
+
+    const mapped = mapDashboardData('github_status', rawStatus) as Record<string, unknown>;
+    expect(mapped.configured).toBe(true);
+    expect(mapped.installations).toHaveLength(2);
+    expect(mapped.installation).toMatchObject({ installationId: '101', accountLogin: 'org-one' });
+    expect(mapped.repositories).toHaveLength(1);
+    const serialized = JSON.stringify(mapped);
+    expect(serialized).not.toContain('hostile-owner');
+    expect(serialized).not.toContain('secretToken');
+
+    const session = await send('/api/v1/session');
+    const cookie = String(session.headers['set-cookie']?.[0]).split(';', 1)[0];
+    const csrfHeaders = { origin: 'https://dashboard.example', cookie, 'content-type': 'application/json', 'x-csrf-token': session.json.csrfToken };
+
+    // Reconcile with specific installation
+    await send('/api/v1/github/reconcile', {
+      method: 'POST', headers: csrfHeaders, body: JSON.stringify({ installationId: '101' })
+    });
+    expect(calls.at(-1)).toEqual({ operation: 'github_reconcile', input: { installationId: '101' }, principal });
+
+    // Disconnect via DELETE endpoint
+    const body = JSON.stringify({});
+    const res = await send('/api/v1/github/installations/101', {
+      method: 'DELETE',
+      headers: { ...csrfHeaders, 'content-length': String(Buffer.byteLength(body)) },
+      body
+    });
+    expect(res.status).toBe(200);
+    expect(calls.at(-1)).toEqual({ operation: 'github_disconnect', input: { installationId: '101' }, principal });
+
+    // Disconnect via POST endpoint
+    const postBody = JSON.stringify({ installationId: '102' });
+    const postRes = await send('/api/v1/github/disconnect', {
+      method: 'POST',
+      headers: { ...csrfHeaders, 'content-length': String(Buffer.byteLength(postBody)) },
+      body: postBody
+    });
+    expect(postRes.status).toBe(200);
+    expect(calls.at(-1)).toEqual({ operation: 'github_disconnect', input: { installationId: '102' }, principal });
+  });
   it('uses only the verified request principal and strips control-plane fields', async () => {
     const response = await send('/api/v1/workspaces');
     expect(response.status).toBe(200);

--- a/apps/api/test/dashboard-ui-behavior.test.ts
+++ b/apps/api/test/dashboard-ui-behavior.test.ts
@@ -3,7 +3,7 @@ import {
   apiKeyCreateInput, conflictRecovery, createApiKeyRevealController, createAsyncDialogController, createModalController, githubCallbackParameters,
   renderWorkspaceDrawer, resetWriteOnlyFields, submitPatchEdit, submitPatchForm
 } from '../dashboard/dashboard.js';
-import { renderApiKeyIndex, renderOverview, renderProfile, renderProjectDetail } from '../dashboard/dashboard-render.js';
+import { renderApiKeyIndex, renderGitHub, renderOverview, renderProfile, renderProjectDetail } from '../dashboard/dashboard-render.js';
 
 class FakeElement {
   hidden = false;
@@ -176,6 +176,36 @@ describe('dashboard UI behavior', () => {
     expect(githubCallbackParameters('?state=state-value&installation_id=12345')).toEqual({ state: 'state-value', installationId: '12345' });
     expect(githubCallbackParameters('?state=state-value')).toBeUndefined();
     expect(githubCallbackParameters('?installation_id=12345')).toBeUndefined();
+  });
+
+  it('renders multiple GitHub installations with per-installation action controls', () => {
+    const status = {
+      configured: true,
+      installations: [
+        { appId: '1', installationId: '101', accountId: '201', accountLogin: 'mrgoonie', status: 'active', checkedAt: 1_700_000_000_000 },
+        { appId: '1', installationId: '102', accountId: '202', accountLogin: 'bestagentkits', status: 'active', checkedAt: 1_700_000_000_000 }
+      ],
+      repositories: [
+        { installationId: '101', owner: 'mrgoonie', repository: 'repo1', contents: 'write', status: 'granted' },
+        { installationId: '102', owner: 'bestagentkits', repository: 'repo2', contents: 'read', status: 'granted' }
+      ]
+    };
+    const html = renderGitHub(status);
+    expect(html).toContain('mrgoonie');
+    expect(html).toContain('bestagentkits');
+    expect(html).toContain('data-installation-id="101"');
+    expect(html).toContain('data-installation-id="102"');
+    expect(html).toContain('class="reconcile-installation"');
+    expect(html).toContain('class="danger disconnect-installation"');
+    expect(html).toContain('Reconcile all installations');
+    expect(html).toContain('repo1');
+    expect(html).toContain('repo2');
+  });
+
+  it('renders a friendly placeholder when no GitHub installations are bound', () => {
+    const html = renderGitHub({ configured: true, installations: [], repositories: [] });
+    expect(html).toContain('No GitHub App installation is bound to this identity.');
+    expect(html).toContain('disabled');
   });
 
   it('clears write-only inputs after secret submission', () => {

--- a/apps/api/test/dashboard-ui-contract.test.ts
+++ b/apps/api/test/dashboard-ui-contract.test.ts
@@ -51,7 +51,7 @@ describe('dashboard static UI contract', () => {
     }
     for (const endpoint of [
       "api('/projects')", "api('/artifacts',", '`/audit?limit=50', "api('/github')", "api('/profile')",
-      "'/github/setup'", "'/github/complete'", "'/github/reconcile'", '`/environments/${'
+      "'/github/setup'", "'/github/complete'", "'/github/reconcile'", "'/github/disconnect'", '`/environments/${'
     ]) expect(script).toContain(endpoint);
     expect(script).toContain('expectedGeneration');
     expect(script).toContain('retentionSeconds');

--- a/apps/runner/src/dashboard-control-service.ts
+++ b/apps/runner/src/dashboard-control-service.ts
@@ -103,9 +103,21 @@ export class DashboardControlService {
               this.principals.database, principalId,
               record.status === 'uninstalled' ? 'github.uninstalled' : 'github.reconciled',
               'github_installation', record.installationId, record.generation, { status: record.status }
-            )
+            ),
+            parsed.input.installationId
           );
           return ok('GitHub authorization reconciled', this.githubStatus(principalId));
+        }
+        case 'github_disconnect': {
+          this.requireGitHubBinding().disconnect(
+            principalId,
+            parsed.input.installationId,
+            (record) => this.metadata.recordAuditInTransaction(
+              this.principals.database, principalId, 'github.disconnected', 'github_installation',
+              record.installationId, record.generation, { accountLogin: record.accountLogin }
+            )
+          );
+          return ok('GitHub installation disconnected', this.githubStatus(principalId));
         }
       }
     } catch (error) {
@@ -116,8 +128,14 @@ export class DashboardControlService {
   }
 
   private githubStatus(principalId: string) {
+    const installations = this.githubInstallations?.listInstallations(principalId) ?? [];
     const record = this.githubInstallations?.getInstallation(principalId);
-    return { configured: Boolean(this.config.githubApp?.appSlug), installation: record ?? null, repositories: this.githubInstallations?.listRepositoryGrants(principalId) ?? [] };
+    return {
+      configured: Boolean(this.config.githubApp?.appSlug),
+      installations,
+      installation: record ?? null,
+      repositories: this.githubInstallations?.listRepositoryGrants(principalId) ?? []
+    };
   }
   private secrets() {
     if (!this.metadata.secretReadiness().ready) {

--- a/apps/runner/src/github-app-broker.ts
+++ b/apps/runner/src/github-app-broker.ts
@@ -18,17 +18,19 @@ export async function mintPrincipalRepositoryToken(input: {
 }): Promise<string | undefined> {
   if (!input.config.githubApp || input.repositoryUrl.hostname.toLowerCase() !== 'github.com') return undefined;
   const { owner, repository } = parseGitHubRepository(input.repositoryUrl);
-  const installation = input.installations.getInstallation(input.principalId);
   const grant = input.installations.getRepositoryGrant(input.principalId, owner, repository);
   const requiredPermission = input.requiredPermission ?? 'read';
   if (
-    !installation ||
-    installation.status !== 'active' ||
-    String(input.config.githubApp.appId) !== installation.appId ||
     !grant ||
-    grant.installationId !== installation.installationId ||
     grant.status !== 'granted' ||
     (requiredPermission === 'write' && grant.contents !== 'write')
+  ) throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
+
+  const installation = input.installations.getInstallation(input.principalId, grant.installationId);
+  if (
+    !installation ||
+    installation.status !== 'active' ||
+    String(input.config.githubApp.appId) !== installation.appId
   ) throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
 
   return mintForInstallation(input.config.githubApp, installation.installationId, repository);

--- a/apps/runner/src/github-binding-service.ts
+++ b/apps/runner/src/github-binding-service.ts
@@ -187,27 +187,45 @@ export class GitHubBindingService {
 
   async reconcile(
     principalId: string,
-    audit?: GitHubInstallationMutationAudit
+    audit?: GitHubInstallationMutationAudit,
+    targetInstallationId?: string | number
   ): Promise<GitHubInstallationRecord | undefined> {
-    const installation = this.installations.getInstallation(principalId);
-    if (!installation) return undefined;
-    let verified: VerifiedGitHubInstallation;
-    try {
-      verified = await this.verifier.verifyInstallation(installation.installationId);
-    } catch (error) {
-      if (error instanceof HarnessError && error.code === 'NOT_FOUND') {
-        return this.installations.markUninstalled(principalId, this.now(), audit);
+    const list = targetInstallationId !== undefined
+      ? [this.installations.getInstallation(principalId, targetInstallationId)].filter((x): x is GitHubInstallationRecord => x !== undefined)
+      : this.installations.listInstallations(principalId);
+    if (list.length === 0) return undefined;
+
+    let lastRecord: GitHubInstallationRecord | undefined;
+    for (const installation of list) {
+      if (installation.status === 'uninstalled') continue;
+      let verified: VerifiedGitHubInstallation;
+      try {
+        verified = await this.verifier.verifyInstallation(installation.installationId);
+      } catch (error) {
+        if (error instanceof HarnessError && error.code === 'NOT_FOUND') {
+          lastRecord = this.installations.markUninstalled(principalId, installation.installationId, this.now(), audit);
+          continue;
+        }
+        throw error;
       }
-      throw error;
+      if (
+        !sameId(installation.appId, verified.appId) ||
+        !sameId(installation.accountId, verified.accountId) ||
+        !sameId(installation.installationId, verified.installationId)
+      ) {
+        throw new HarnessError('CONFLICT', 'GitHub installation identity changed during reconciliation', 409);
+      }
+      lastRecord = this.installations.replaceVerified(principalId, verified, this.now(), audit);
     }
-    if (
-      !sameId(installation.appId, verified.appId) ||
-      !sameId(installation.accountId, verified.accountId) ||
-      !sameId(installation.installationId, verified.installationId)
-    ) {
-      throw new HarnessError('CONFLICT', 'GitHub installation identity changed during reconciliation', 409);
-    }
-    return this.installations.replaceVerified(principalId, verified, this.now(), audit);
+    return lastRecord ?? list[0];
+  }
+
+  disconnect(
+    principalId: string,
+    installationId: string | number,
+    audit?: GitHubInstallationMutationAudit
+  ): boolean {
+    return this.installations.removeInstallation(principalId, installationId, this.now(), audit);
   }
 }
 

--- a/apps/runner/src/github-installation-sqlite-store.ts
+++ b/apps/runner/src/github-installation-sqlite-store.ts
@@ -30,26 +30,69 @@ const grant = (row: GrantRow): GitHubRepositoryGrantRecord => ({
 });
 
 export function migrateGitHubInstallationSchema(database: DatabaseSync): void {
-  database.exec(`
-    CREATE TABLE IF NOT EXISTS github_installations (
-      principal_id TEXT PRIMARY KEY REFERENCES principals(id) ON DELETE CASCADE,
-      app_id TEXT NOT NULL, installation_id TEXT NOT NULL, account_id TEXT NOT NULL, account_login TEXT NOT NULL,
-      status TEXT NOT NULL CHECK(status IN ('active','suspended','uninstalled')),
-      generation INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, checked_at INTEGER NOT NULL
-    );
-    CREATE TABLE IF NOT EXISTS github_repository_grants (
-      principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
-      installation_id TEXT NOT NULL, owner TEXT NOT NULL, repository TEXT NOT NULL,
-      contents TEXT NOT NULL CHECK(contents IN ('read','write')),
-      status TEXT NOT NULL CHECK(status IN ('granted','removed')),
-      generation INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, checked_at INTEGER NOT NULL,
-      PRIMARY KEY(principal_id, owner, repository)
-    );
-    CREATE INDEX IF NOT EXISTS github_repository_grants_principal_status
-      ON github_repository_grants(principal_id, status, owner, repository);
-    CREATE UNIQUE INDEX IF NOT EXISTS github_installations_installation_identity
-      ON github_installations(installation_id);
-  `);
+  database.exec('BEGIN IMMEDIATE');
+  try {
+    const tableExists = database.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='github_installations'"
+    ).get() as { name: string } | undefined;
+
+    if (tableExists) {
+      const columns = database.prepare("PRAGMA table_info(github_installations)").all() as Array<{ name: string; pk: number }>;
+      const principalPk = columns.find((c) => c.name === 'principal_id')?.pk ?? 0;
+      const installationPk = columns.find((c) => c.name === 'installation_id')?.pk ?? 0;
+
+      if (principalPk === 1 && installationPk === 0) {
+        database.exec(`
+          CREATE TABLE IF NOT EXISTS github_installations_v2 (
+            principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+            app_id TEXT NOT NULL, installation_id TEXT NOT NULL, account_id TEXT NOT NULL, account_login TEXT NOT NULL,
+            status TEXT NOT NULL CHECK(status IN ('active','suspended','uninstalled')),
+            generation INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, checked_at INTEGER NOT NULL,
+            PRIMARY KEY(principal_id, installation_id)
+          );
+          INSERT OR IGNORE INTO github_installations_v2
+            (principal_id, app_id, installation_id, account_id, account_login, status, generation, created_at, updated_at, checked_at)
+            SELECT principal_id, app_id, installation_id, account_id, account_login, status, generation, created_at, updated_at, checked_at
+            FROM github_installations;
+          DROP TABLE github_installations;
+          ALTER TABLE github_installations_v2 RENAME TO github_installations;
+        `);
+      }
+    } else {
+      database.exec(`
+        CREATE TABLE IF NOT EXISTS github_installations (
+          principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+          app_id TEXT NOT NULL, installation_id TEXT NOT NULL, account_id TEXT NOT NULL, account_login TEXT NOT NULL,
+          status TEXT NOT NULL CHECK(status IN ('active','suspended','uninstalled')),
+          generation INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, checked_at INTEGER NOT NULL,
+          PRIMARY KEY(principal_id, installation_id)
+        );
+      `);
+    }
+
+    database.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS github_installations_principal_account
+        ON github_installations(principal_id, account_id);
+      CREATE UNIQUE INDEX IF NOT EXISTS github_installations_installation_identity
+        ON github_installations(installation_id);
+      CREATE TABLE IF NOT EXISTS github_repository_grants (
+        principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+        installation_id TEXT NOT NULL, owner TEXT NOT NULL, repository TEXT NOT NULL,
+        contents TEXT NOT NULL CHECK(contents IN ('read','write')),
+        status TEXT NOT NULL CHECK(status IN ('granted','removed')),
+        generation INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, checked_at INTEGER NOT NULL,
+        PRIMARY KEY(principal_id, owner, repository)
+      );
+      CREATE INDEX IF NOT EXISTS github_repository_grants_principal_status
+        ON github_repository_grants(principal_id, status, owner, repository);
+      CREATE INDEX IF NOT EXISTS github_repository_grants_principal_installation
+        ON github_repository_grants(principal_id, installation_id);
+    `);
+    database.exec('COMMIT');
+  } catch (error) {
+    database.exec('ROLLBACK');
+    throw error;
+  }
 }
 
 export class SqliteGitHubInstallationStore implements GitHubInstallationStore {
@@ -68,37 +111,59 @@ export class SqliteGitHubInstallationStore implements GitHubInstallationStore {
         'SELECT principal_id FROM github_installations WHERE installation_id=? AND principal_id<>?'
       ).get(installationId, principalId) as { principal_id: string } | undefined;
       if (duplicate) throw new HarnessError('CONFLICT', 'GitHub installation is already bound', 409, false);
-      const prior = this.getInstallation(principalId);
+
+      const accountId = String(verified.accountId);
+      const sameAccount = this.database.prepare(
+        'SELECT installation_id FROM github_installations WHERE principal_id=? AND account_id=? AND installation_id<>?'
+      ).get(principalId, accountId, installationId) as { installation_id: string } | undefined;
+      if (sameAccount) {
+        this.database.prepare(
+          'DELETE FROM github_installations WHERE principal_id=? AND installation_id=?'
+        ).run(principalId, sameAccount.installation_id);
+        this.database.prepare(
+          `UPDATE github_repository_grants SET status='removed',generation=generation+1,updated_at=?,checked_at=?
+           WHERE principal_id=? AND installation_id=? AND status<>'removed'`
+        ).run(checkedAt, checkedAt, principalId, sameAccount.installation_id);
+      }
+      const prior = this.getInstallation(principalId, installationId);
       const record: GitHubInstallationRecord = {
         principalId, appId: String(verified.appId), installationId,
-        accountId: String(verified.accountId), accountLogin: verified.accountLogin, status: verified.status,
+        accountId, accountLogin: verified.accountLogin, status: verified.status,
         generation: (prior?.generation ?? 0) + 1, createdAt: prior?.createdAt ?? checkedAt,
         updatedAt: checkedAt, checkedAt
       };
       this.database.prepare(`INSERT INTO github_installations
         (principal_id,app_id,installation_id,account_id,account_login,status,generation,created_at,updated_at,checked_at)
-        VALUES (?,?,?,?,?,?,?,?,?,?) ON CONFLICT(principal_id) DO UPDATE SET
-        app_id=excluded.app_id,installation_id=excluded.installation_id,account_id=excluded.account_id,
-        account_login=excluded.account_login,status=excluded.status,generation=excluded.generation,
-        updated_at=excluded.updated_at,checked_at=excluded.checked_at`)
+        VALUES (?,?,?,?,?,?,?,?,?,?) ON CONFLICT(principal_id, installation_id) DO UPDATE SET
+        app_id=excluded.app_id,account_id=excluded.account_id,account_login=excluded.account_login,
+        status=excluded.status,generation=excluded.generation,updated_at=excluded.updated_at,checked_at=excluded.checked_at`)
         .run(principalId, record.appId, record.installationId, record.accountId, record.accountLogin, record.status,
           record.generation, record.createdAt, record.updatedAt, record.checkedAt);
+
       const current = new Set<string>();
-      if (verified.status === 'active') for (const repository of verified.repositories) {
-        const owner = repository.owner.toLowerCase(); const name = repository.repository.toLowerCase();
-        current.add(`${owner}\0${name}`);
-        const previous = this.getRepositoryGrant(principalId, owner, name);
-        this.database.prepare(`INSERT INTO github_repository_grants
-          (principal_id,installation_id,owner,repository,contents,status,generation,created_at,updated_at,checked_at)
-          VALUES (?,?,?,?,?,'granted',?,?,?,?) ON CONFLICT(principal_id,owner,repository) DO UPDATE SET
-          installation_id=excluded.installation_id,contents=excluded.contents,status='granted',generation=excluded.generation,
-          updated_at=excluded.updated_at,checked_at=excluded.checked_at`)
-          .run(principalId, record.installationId, owner, name, repository.contents,
-            (previous?.generation ?? 0) + 1, previous?.createdAt ?? checkedAt, checkedAt, checkedAt);
+      if (verified.status === 'active') {
+        for (const repository of verified.repositories) {
+          const owner = repository.owner.toLowerCase();
+          const name = repository.repository.toLowerCase();
+          current.add(`${owner}\0${name}`);
+          const previous = this.getRepositoryGrant(principalId, owner, name);
+          this.database.prepare(`INSERT INTO github_repository_grants
+            (principal_id,installation_id,owner,repository,contents,status,generation,created_at,updated_at,checked_at)
+            VALUES (?,?,?,?,?,'granted',?,?,?,?) ON CONFLICT(principal_id,owner,repository) DO UPDATE SET
+            installation_id=excluded.installation_id,contents=excluded.contents,status='granted',generation=excluded.generation,
+            updated_at=excluded.updated_at,checked_at=excluded.checked_at`)
+            .run(principalId, record.installationId, owner, name, repository.contents,
+              (previous?.generation ?? 0) + 1, previous?.createdAt ?? checkedAt, checkedAt, checkedAt);
+        }
       }
-      for (const existing of this.listRepositoryGrants(principalId)) if (existing.status !== 'removed' && !current.has(`${existing.owner}\0${existing.repository}`)) {
-        this.database.prepare(`UPDATE github_repository_grants SET status='removed',generation=generation+1,updated_at=?,checked_at=?
-          WHERE principal_id=? AND owner=? AND repository=?`).run(checkedAt, checkedAt, principalId, existing.owner, existing.repository);
+
+      const existingGrants = this.listRepositoryGrants(principalId, record.installationId);
+      for (const existing of existingGrants) {
+        if (existing.status !== 'removed' && !current.has(`${existing.owner}\0${existing.repository}`)) {
+          this.database.prepare(`UPDATE github_repository_grants SET status='removed',generation=generation+1,updated_at=?,checked_at=?
+            WHERE principal_id=? AND installation_id=? AND owner=? AND repository=?`)
+            .run(checkedAt, checkedAt, principalId, record.installationId, existing.owner, existing.repository);
+        }
       }
       audit?.(record);
       this.database.exec('COMMIT');
@@ -108,10 +173,11 @@ export class SqliteGitHubInstallationStore implements GitHubInstallationStore {
 
   markUninstalled(
     principalId: string,
+    installationId: string | number,
     checkedAt: number,
     audit?: GitHubInstallationMutationAudit
   ): GitHubInstallationRecord | undefined {
-    const current = this.getInstallation(principalId);
+    const current = this.getInstallation(principalId, installationId);
     if (!current) return undefined;
     return this.replaceVerified(principalId, {
       appId: current.appId,
@@ -123,16 +189,65 @@ export class SqliteGitHubInstallationStore implements GitHubInstallationStore {
     }, checkedAt, audit);
   }
 
-  getInstallation(principalId: string): GitHubInstallationRecord | undefined {
-    const row = this.database.prepare('SELECT * FROM github_installations WHERE principal_id=?').get(principalId) as InstallationRow | undefined;
+  removeInstallation(
+    principalId: string,
+    installationId: string | number,
+    checkedAt: number,
+    audit?: GitHubInstallationMutationAudit
+  ): boolean {
+    this.database.exec('BEGIN IMMEDIATE');
+    try {
+      const id = String(installationId);
+      const current = this.getInstallation(principalId, id);
+      if (!current) {
+        this.database.exec('ROLLBACK');
+        return false;
+      }
+      this.database.prepare('DELETE FROM github_installations WHERE principal_id=? AND installation_id=?')
+        .run(principalId, id);
+      this.database.prepare(`UPDATE github_repository_grants SET status='removed',generation=generation+1,updated_at=?,checked_at=?
+        WHERE principal_id=? AND installation_id=? AND status<>'removed'`)
+        .run(checkedAt, checkedAt, principalId, id);
+      audit?.(current);
+      this.database.exec('COMMIT');
+      return true;
+    } catch (error) {
+      this.database.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  getInstallation(principalId: string, installationId?: string | number): GitHubInstallationRecord | undefined {
+    if (installationId !== undefined) {
+      const row = this.database.prepare(
+        'SELECT * FROM github_installations WHERE principal_id=? AND installation_id=?'
+      ).get(principalId, String(installationId)) as InstallationRow | undefined;
+      return row ? installation(row) : undefined;
+    }
+    const row = this.database.prepare(
+      "SELECT * FROM github_installations WHERE principal_id=? ORDER BY (CASE status WHEN 'active' THEN 0 WHEN 'suspended' THEN 1 ELSE 2 END), created_at ASC LIMIT 1"
+    ).get(principalId) as InstallationRow | undefined;
     return row ? installation(row) : undefined;
   }
+
+  listInstallations(principalId: string): GitHubInstallationRecord[] {
+    const rows = this.database.prepare(
+      'SELECT * FROM github_installations WHERE principal_id=? ORDER BY created_at ASC'
+    ).all(principalId) as InstallationRow[];
+    return rows.map(installation);
+  }
+
   getRepositoryGrant(principalId: string, owner: string, repository: string): GitHubRepositoryGrantRecord | undefined {
     const row = this.database.prepare('SELECT * FROM github_repository_grants WHERE principal_id=? AND owner=? AND repository=?')
       .get(principalId, owner.toLowerCase(), repository.toLowerCase()) as GrantRow | undefined;
     return row ? grant(row) : undefined;
   }
-  listRepositoryGrants(principalId: string): GitHubRepositoryGrantRecord[] {
+
+  listRepositoryGrants(principalId: string, installationId?: string | number): GitHubRepositoryGrantRecord[] {
+    if (installationId !== undefined) {
+      return (this.database.prepare('SELECT * FROM github_repository_grants WHERE principal_id=? AND installation_id=? ORDER BY owner,repository')
+        .all(principalId, String(installationId)) as GrantRow[]).map(grant);
+    }
     return (this.database.prepare('SELECT * FROM github_repository_grants WHERE principal_id=? ORDER BY owner,repository')
       .all(principalId) as GrantRow[]).map(grant);
   }

--- a/apps/runner/src/github-installation-store.ts
+++ b/apps/runner/src/github-installation-store.ts
@@ -54,16 +54,26 @@ export interface GitHubInstallationStore {
   ): GitHubInstallationRecord;
   markUninstalled(
     principalId: string,
+    installationId: string | number,
     checkedAt: number,
     audit?: GitHubInstallationMutationAudit
   ): GitHubInstallationRecord | undefined;
-  getInstallation(principalId: string): GitHubInstallationRecord | undefined;
+  removeInstallation(
+    principalId: string,
+    installationId: string | number,
+    checkedAt: number,
+    audit?: GitHubInstallationMutationAudit
+  ): boolean;
+  getInstallation(principalId: string, installationId?: string | number): GitHubInstallationRecord | undefined;
+  listInstallations(principalId: string): GitHubInstallationRecord[];
   getRepositoryGrant(principalId: string, owner: string, repository: string): GitHubRepositoryGrantRecord | undefined;
-  listRepositoryGrants(principalId: string): GitHubRepositoryGrantRecord[];
+  listRepositoryGrants(principalId: string, installationId?: string | number): GitHubRepositoryGrantRecord[];
 }
 
 const repositoryKey = (principalId: string, owner: string, repository: string) =>
   `${principalId}\0${owner.toLowerCase()}\0${repository.toLowerCase()}`;
+const installationKey = (principalId: string, installationId: string | number) =>
+  `${principalId}\0${String(installationId)}`;
 
 export class InMemoryGitHubInstallationStore implements GitHubInstallationStore {
   readonly #installations = new Map<string, GitHubInstallationRecord>();
@@ -87,15 +97,16 @@ export class InMemoryGitHubInstallationStore implements GitHubInstallationStore 
       for (const entry of installationsBefore) this.#installations.set(...entry);
       for (const entry of repositoriesBefore) this.#repositories.set(...entry);
       throw error;
-    }
+      }
   }
 
   markUninstalled(
     principalId: string,
+    installationId: string | number,
     checkedAt: number,
     audit?: GitHubInstallationMutationAudit
   ): GitHubInstallationRecord | undefined {
-    const current = this.#installations.get(principalId);
+    const current = this.getInstallation(principalId, installationId);
     if (!current) return undefined;
     return this.replaceVerified(principalId, {
       appId: current.appId,
@@ -107,18 +118,66 @@ export class InMemoryGitHubInstallationStore implements GitHubInstallationStore 
     }, checkedAt, audit);
   }
 
+  removeInstallation(
+    principalId: string,
+    installationId: string | number,
+    checkedAt: number,
+    audit?: GitHubInstallationMutationAudit
+  ): boolean {
+    const id = String(installationId);
+    const key = installationKey(principalId, id);
+    const current = this.#installations.get(key);
+    if (!current) return false;
+
+    this.#installations.delete(key);
+    for (const [rKey, grant] of this.#repositories) {
+      if (grant.principalId === principalId && grant.installationId === id && grant.status !== 'removed') {
+        this.#repositories.set(rKey, {
+          ...grant,
+          status: 'removed',
+          generation: grant.generation + 1,
+          updatedAt: checkedAt,
+          checkedAt
+        });
+      }
+    }
+    audit?.(current);
+    return true;
+  }
+
   private replace(principalId: string, verified: VerifiedGitHubInstallation, checkedAt: number): GitHubInstallationRecord {
     const installationId = String(verified.installationId);
     const duplicate = [...this.#installations.values()].find(
       (record) => record.principalId !== principalId && record.installationId === installationId
     );
     if (duplicate) throw new HarnessError('CONFLICT', 'GitHub installation is already bound', 409, false);
-    const previous = this.#installations.get(principalId);
+
+    const accountId = String(verified.accountId);
+    const sameAccountDifferentInstallation = [...this.#installations.values()].find(
+      (record) => record.principalId === principalId && record.accountId === accountId && record.installationId !== installationId
+    );
+    if (sameAccountDifferentInstallation) {
+      const oldId = sameAccountDifferentInstallation.installationId;
+      this.#installations.delete(installationKey(principalId, oldId));
+      for (const [rKey, grant] of this.#repositories) {
+        if (grant.principalId === principalId && grant.installationId === oldId && grant.status !== 'removed') {
+          this.#repositories.set(rKey, {
+            ...grant,
+            status: 'removed',
+            generation: grant.generation + 1,
+            updatedAt: checkedAt,
+            checkedAt
+          });
+        }
+      }
+    }
+    const key = installationKey(principalId, installationId);
+    const previous = this.#installations.get(key);
     const installation: GitHubInstallationRecord = {
       principalId,
       appId: String(verified.appId),
       installationId,
-      accountId: String(verified.accountId),
+      accountId,
       accountLogin: verified.accountLogin,
       status: verified.status,
       generation: (previous?.generation ?? 0) + 1,
@@ -126,15 +185,15 @@ export class InMemoryGitHubInstallationStore implements GitHubInstallationStore 
       updatedAt: checkedAt,
       checkedAt
     };
-    this.#installations.set(principalId, installation);
+    this.#installations.set(key, installation);
 
     const currentKeys = new Set<string>();
     if (verified.status === 'active') {
       for (const repository of verified.repositories) {
-        const key = repositoryKey(principalId, repository.owner, repository.repository);
-        currentKeys.add(key);
-        const priorGrant = this.#repositories.get(key);
-        this.#repositories.set(key, {
+        const rKey = repositoryKey(principalId, repository.owner, repository.repository);
+        currentKeys.add(rKey);
+        const priorGrant = this.#repositories.get(rKey);
+        this.#repositories.set(rKey, {
           principalId,
           installationId: installation.installationId,
           owner: repository.owner.toLowerCase(),
@@ -149,9 +208,9 @@ export class InMemoryGitHubInstallationStore implements GitHubInstallationStore 
       }
     }
 
-    for (const [key, grant] of this.#repositories) {
-      if (grant.principalId !== principalId || currentKeys.has(key) || grant.status === 'removed') continue;
-      this.#repositories.set(key, {
+    for (const [rKey, grant] of this.#repositories) {
+      if (grant.principalId !== principalId || grant.installationId !== installation.installationId || currentKeys.has(rKey) || grant.status === 'removed') continue;
+      this.#repositories.set(rKey, {
         ...grant,
         status: 'removed',
         generation: grant.generation + 1,
@@ -162,9 +221,21 @@ export class InMemoryGitHubInstallationStore implements GitHubInstallationStore 
     return { ...installation };
   }
 
-  getInstallation(principalId: string): GitHubInstallationRecord | undefined {
-    const record = this.#installations.get(principalId);
-    return record ? { ...record } : undefined;
+  getInstallation(principalId: string, installationId?: string | number): GitHubInstallationRecord | undefined {
+    if (installationId !== undefined) {
+      const record = this.#installations.get(installationKey(principalId, installationId));
+      return record ? { ...record } : undefined;
+    }
+    const all = this.listInstallations(principalId);
+    if (all.length === 0) return undefined;
+    const active = all.find((record) => record.status === 'active');
+    return active ?? all[0];
+  }
+
+  listInstallations(principalId: string): GitHubInstallationRecord[] {
+    return [...this.#installations.values()]
+      .filter((record) => record.principalId === principalId)
+      .map((record) => ({ ...record }));
   }
 
   getRepositoryGrant(principalId: string, owner: string, repository: string): GitHubRepositoryGrantRecord | undefined {
@@ -172,7 +243,10 @@ export class InMemoryGitHubInstallationStore implements GitHubInstallationStore 
     return record ? { ...record } : undefined;
   }
 
-  listRepositoryGrants(principalId: string): GitHubRepositoryGrantRecord[] {
-    return [...this.#repositories.values()].filter((record) => record.principalId === principalId).map((record) => ({ ...record }));
+  listRepositoryGrants(principalId: string, installationId?: string | number): GitHubRepositoryGrantRecord[] {
+    const id = installationId !== undefined ? String(installationId) : undefined;
+    return [...this.#repositories.values()]
+      .filter((record) => record.principalId === principalId && (id === undefined || record.installationId === id))
+      .map((record) => ({ ...record }));
   }
 }

--- a/apps/runner/test/dashboard-control-service.test.ts
+++ b/apps/runner/test/dashboard-control-service.test.ts
@@ -6,11 +6,12 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { MetadataRunnerRequest, RunnerConfig } from '@cloud-harness/contracts';
 import { ArtifactStore } from '../src/artifact-store.js';
 import { DashboardControlService } from '../src/dashboard-control-service.js';
+import { GitHubBindingService, GitHubSetupStateStore } from '../src/github-binding-service.js';
+import { InMemoryGitHubInstallationStore } from '../src/github-installation-store.js';
 import { MetadataStore } from '../src/metadata-store.js';
 import { SecretKeyring } from '../src/secret-keyring.js';
 import { StateStore } from '../src/state-store.js';
 import type { WorkspaceService } from '../src/workspace-service.js';
-
 const roots: string[] = [];
 afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
 
@@ -112,5 +113,51 @@ describe('dashboard control service', () => {
         projectId: `prj_${'x'.repeat(24)}`, name: 'Nope', expectedGeneration: 1
       }, selected))).rejects.toMatchObject({ code: 'CONFLICT', status: 409 });
     }
+  });
+
+  it('returns multiple GitHub installations and handles disconnect with audit logging', async () => {
+    const { principals, metadata, artifacts, workspaces } = setup();
+    const store = new InMemoryGitHubInstallationStore();
+    const verifier = { verifyInstallation: async (id: string) => ({ appId: '1', installationId: id, accountId: id, accountLogin: `org-${id}`, status: 'active' as const, repositories: [] }) };
+    const binding = new GitHubBindingService(new GitHubSetupStateStore(principals.database), store, verifier);
+    const githubControls = new DashboardControlService(
+      { artifactRetentionSeconds: 60, githubApp: { appSlug: 'test-app', appId: 1 } } as RunnerConfig,
+      principals, metadata, artifacts, workspaces, store, binding
+    );
+
+    const principalId = principals.resolvePrincipal(principal);
+    store.replaceVerified(principalId, {
+      appId: 1, installationId: 101, accountId: 201, accountLogin: 'org-one', status: 'active',
+      repositories: [{ owner: 'org-one', repository: 'repo1', contents: 'write' }]
+    }, 100);
+    store.replaceVerified(principalId, {
+      appId: 1, installationId: 102, accountId: 202, accountLogin: 'org-two', status: 'active',
+      repositories: [{ owner: 'org-two', repository: 'repo2', contents: 'read' }]
+    }, 110);
+
+    // Status returns both installations
+    const statusResult = await githubControls.execute(request('github_status', {}));
+    expect(statusResult.data).toMatchObject({
+      configured: true,
+      installations: expect.arrayContaining([
+        expect.objectContaining({ installationId: '101', accountLogin: 'org-one' }),
+        expect.objectContaining({ installationId: '102', accountLogin: 'org-two' })
+      ]),
+      repositories: expect.arrayContaining([
+        expect.objectContaining({ repository: 'repo1', installationId: '101' }),
+        expect.objectContaining({ repository: 'repo2', installationId: '102' })
+      ])
+    });
+
+    // Disconnect installation 101
+    const disconnectResult = await githubControls.execute(request('github_disconnect', { installationId: '101' }));
+    expect(disconnectResult.data).toMatchObject({
+      installations: [expect.objectContaining({ installationId: '102' })]
+    });
+
+    const audits = metadata.listAudit(principalId, 10);
+    expect(audits).toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: 'github.disconnected', subjectId: '101' })
+    ]));
   });
 });

--- a/apps/runner/test/github-app-broker.test.ts
+++ b/apps/runner/test/github-app-broker.test.ts
@@ -76,4 +76,34 @@ describe('GitHub App broker', () => {
     await expect(mintPrincipalRepositoryToken({ ...request, principalId: 'principal-a' })).rejects.toThrow('not authorized');
     expect(authMocks.createAppAuth).not.toHaveBeenCalled();
   });
+
+  it('selects the correct installation when principal has multiple active installations', async () => {
+    const installations = new InMemoryGitHubInstallationStore();
+    installations.replaceVerified('principal-a', {
+      appId: 123, installationId: 101, accountId: 201, accountLogin: 'user-org', status: 'active',
+      repositories: [{ owner: 'user-org', repository: 'repo-one', contents: 'read' }]
+    }, 1_000);
+    installations.replaceVerified('principal-a', {
+      appId: 123, installationId: 102, accountId: 202, accountLogin: 'other-org', status: 'active',
+      repositories: [{ owner: 'other-org', repository: 'repo-two', contents: 'write' }]
+    }, 1_100);
+
+    // Mint for repo in first installation
+    await expect(mintPrincipalRepositoryToken({
+      config, principalId: 'principal-a',
+      repositoryUrl: new URL('https://github.com/user-org/repo-one.git'),
+      installations
+    })).resolves.toBe('repository-scoped-token');
+    expect(authMocks.createAppAuth).toHaveBeenLastCalledWith(expect.objectContaining({ installationId: '101' }));
+    expect(authMocks.installationAuth).toHaveBeenLastCalledWith({ type: 'installation', repositoryNames: ['repo-one'] });
+
+    // Mint for repo in second installation
+    await expect(mintPrincipalRepositoryToken({
+      config, principalId: 'principal-a',
+      repositoryUrl: new URL('https://github.com/other-org/repo-two.git'),
+      installations, requiredPermission: 'write'
+    })).resolves.toBe('repository-scoped-token');
+    expect(authMocks.createAppAuth).toHaveBeenLastCalledWith(expect.objectContaining({ installationId: '102' }));
+    expect(authMocks.installationAuth).toHaveBeenLastCalledWith({ type: 'installation', repositoryNames: ['repo-two'] });
+  });
 });

--- a/apps/runner/test/github-binding-service.test.ts
+++ b/apps/runner/test/github-binding-service.test.ts
@@ -167,4 +167,42 @@ describe('GitHub installation binding', () => {
     expect(persisted).not.toContain('provider-secret');
     expect(persisted).not.toContain('private-key-secret');
   });
+
+  it('supports binding and reconciling multiple concurrent installations per principal', async () => {
+    const setup1 = service.beginSetup({ principalId: 'principal-a', expectedAppId: '123' });
+    await service.completeSetup({
+      principalId: 'principal-a', state: setup1.state, appId: '123', accountId: '789', installationId: '456'
+    });
+
+    verifyInstallation.mockResolvedValueOnce(activeInstallation({
+      installationId: '457', accountId: '790', accountLogin: 'org-two',
+      repositories: [{ owner: 'Org-Two', repository: 'Repo-Two', contents: 'read' }]
+    }));
+    const setup2 = service.beginSetup({ principalId: 'principal-a', expectedAppId: '123' });
+    await service.completeSetup({
+      principalId: 'principal-a', state: setup2.state, appId: '123', accountId: '790', installationId: '457'
+    });
+
+    expect(store.listInstallations('principal-a')).toHaveLength(2);
+    expect(store.getRepositoryGrant('principal-a', 'example', 'private-repo')).toMatchObject({ status: 'granted', installationId: '456' });
+    expect(store.getRepositoryGrant('principal-a', 'org-two', 'repo-two')).toMatchObject({ status: 'granted', installationId: '457' });
+
+    // Reconcile: first installation 404 (uninstalled), second installation still active
+    verifyInstallation.mockRejectedValueOnce(new HarnessError('NOT_FOUND', 'installation deleted', 404));
+    verifyInstallation.mockResolvedValueOnce(activeInstallation({
+      installationId: '457', accountId: '790', accountLogin: 'org-two',
+      repositories: [{ owner: 'Org-Two', repository: 'Repo-Two', contents: 'read' }]
+    }));
+
+    await service.reconcile('principal-a');
+    expect(store.getInstallation('principal-a', '456')).toMatchObject({ status: 'uninstalled' });
+    expect(store.getInstallation('principal-a', '457')).toMatchObject({ status: 'active' });
+    expect(store.getRepositoryGrant('principal-a', 'example', 'private-repo')).toMatchObject({ status: 'removed' });
+    expect(store.getRepositoryGrant('principal-a', 'org-two', 'repo-two')).toMatchObject({ status: 'granted' });
+
+    // Disconnect installation 457
+    expect(service.disconnect('principal-a', '457')).toBe(true);
+    expect(store.getInstallation('principal-a', '457')).toBeUndefined();
+    expect(store.getRepositoryGrant('principal-a', 'org-two', 'repo-two')).toMatchObject({ status: 'removed' });
+  });
 });

--- a/apps/runner/test/github-installation-sqlite-store.test.ts
+++ b/apps/runner/test/github-installation-sqlite-store.test.ts
@@ -114,4 +114,122 @@ describe('SQLite GitHub installation store', () => {
     expect(() => states.consume(third.state, principalA, 2_000)).toThrow('invalid or expired');
     state.close();
   });
+
+  it('supports multiple concurrent installations per principal with scoped grant reconciliation', () => {
+    const root = mkdtempSync(join(tmpdir(), 'cloud-harness-github-multi-')); roots.push(root);
+    const state = new StateStore(join(root, 'state.db'));
+    const principal = state.resolveExternalPrincipal({ kind: 'external', issuer: 'https://access.example.com', subject: 'multi-owner' });
+    const store = new SqliteGitHubInstallationStore(state.database);
+
+    // Bind first installation: personal account
+    store.replaceVerified(principal, {
+      appId: 1, installationId: 101, accountId: 201, accountLogin: 'mrgoonie', status: 'active',
+      repositories: [{ owner: 'mrgoonie', repository: 'personal-repo', contents: 'write' }]
+    }, 100);
+
+    // Bind second installation: organization
+    store.replaceVerified(principal, {
+      appId: 1, installationId: 102, accountId: 202, accountLogin: 'bestagentkits', status: 'active',
+      repositories: [{ owner: 'bestagentkits', repository: 'agentkit', contents: 'read' }]
+    }, 110);
+
+    // Both installations exist
+    const installations = store.listInstallations(principal);
+    expect(installations).toHaveLength(2);
+    expect(installations.map((i) => i.accountLogin)).toEqual(['mrgoonie', 'bestagentkits']);
+    expect(store.getInstallation(principal, 101)).toMatchObject({ accountLogin: 'mrgoonie', installationId: '101' });
+    expect(store.getInstallation(principal, 102)).toMatchObject({ accountLogin: 'bestagentkits', installationId: '102' });
+
+    // Both repository grants exist
+    expect(store.getRepositoryGrant(principal, 'mrgoonie', 'personal-repo')).toMatchObject({ status: 'granted', installationId: '101' });
+    expect(store.getRepositoryGrant(principal, 'bestagentkits', 'agentkit')).toMatchObject({ status: 'granted', installationId: '102' });
+    expect(store.listRepositoryGrants(principal)).toHaveLength(2);
+    expect(store.listRepositoryGrants(principal, 101)).toHaveLength(1);
+    expect(store.listRepositoryGrants(principal, 102)).toHaveLength(1);
+
+    // Reconciling installation 102 removes its removed repo but DOES NOT touch 101's repos
+    store.replaceVerified(principal, {
+      appId: 1, installationId: 102, accountId: 202, accountLogin: 'bestagentkits', status: 'active',
+      repositories: []
+    }, 120);
+    expect(store.getRepositoryGrant(principal, 'mrgoonie', 'personal-repo')).toMatchObject({ status: 'granted', installationId: '101' });
+    expect(store.getRepositoryGrant(principal, 'bestagentkits', 'agentkit')).toMatchObject({ status: 'removed', installationId: '102' });
+
+    state.close();
+  });
+
+  it('supports removing an individual installation and its grants', () => {
+    const root = mkdtempSync(join(tmpdir(), 'cloud-harness-github-remove-')); roots.push(root);
+    const state = new StateStore(join(root, 'state.db'));
+    const principal = state.resolveExternalPrincipal({ kind: 'external', issuer: 'https://access.example.com', subject: 'remove-owner' });
+    const store = new SqliteGitHubInstallationStore(state.database);
+
+    store.replaceVerified(principal, {
+      appId: 1, installationId: 101, accountId: 201, accountLogin: 'mrgoonie', status: 'active',
+      repositories: [{ owner: 'mrgoonie', repository: 'repo1', contents: 'write' }]
+    }, 100);
+    store.replaceVerified(principal, {
+      appId: 1, installationId: 102, accountId: 202, accountLogin: 'bestagentkits', status: 'active',
+      repositories: [{ owner: 'bestagentkits', repository: 'repo2', contents: 'read' }]
+    }, 110);
+
+    expect(store.removeInstallation(principal, 101, 120)).toBe(true);
+    expect(store.listInstallations(principal)).toHaveLength(1);
+    expect(store.getInstallation(principal, 101)).toBeUndefined();
+    expect(store.getRepositoryGrant(principal, 'mrgoonie', 'repo1')).toMatchObject({ status: 'removed' });
+    expect(store.getRepositoryGrant(principal, 'bestagentkits', 'repo2')).toMatchObject({ status: 'granted' });
+
+    state.close();
+  });
+
+  it('migrates legacy single-installation SQLite tables in-place without data loss', () => {
+    const root = mkdtempSync(join(tmpdir(), 'cloud-harness-github-migration-')); roots.push(root);
+    const state = new StateStore(join(root, 'state.db'));
+    const principal = state.resolveExternalPrincipal({ kind: 'external', issuer: 'https://access.example.com', subject: 'legacy-owner' });
+
+    // Manually create legacy schema where principal_id is primary key
+    state.database.exec(`
+      DROP TABLE IF EXISTS github_repository_grants;
+      DROP TABLE IF EXISTS github_installations;
+      CREATE TABLE github_installations (
+        principal_id TEXT PRIMARY KEY REFERENCES principals(id) ON DELETE CASCADE,
+        app_id TEXT NOT NULL, installation_id TEXT NOT NULL, account_id TEXT NOT NULL, account_login TEXT NOT NULL,
+        status TEXT NOT NULL CHECK(status IN ('active','suspended','uninstalled')),
+        generation INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, checked_at INTEGER NOT NULL
+      );
+      CREATE TABLE github_repository_grants (
+        principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+        installation_id TEXT NOT NULL, owner TEXT NOT NULL, repository TEXT NOT NULL,
+        contents TEXT NOT NULL CHECK(contents IN ('read','write')),
+        status TEXT NOT NULL CHECK(status IN ('granted','removed')),
+        generation INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, checked_at INTEGER NOT NULL,
+        PRIMARY KEY(principal_id, owner, repository)
+      );
+      INSERT INTO github_installations VALUES ('${principal}', '1', '999', '888', 'legacy-org', 'active', 1, 100, 100, 100);
+      INSERT INTO github_repository_grants VALUES ('${principal}', '999', 'legacy-org', 'legacy-repo', 'write', 'granted', 1, 100, 100, 100);
+    `);
+
+    // Instantiate store which runs migration
+    const store = new SqliteGitHubInstallationStore(state.database);
+
+    // Existing installation & grants preserved
+    expect(store.getInstallation(principal, 999)).toMatchObject({
+      principalId: principal, installationId: '999', accountLogin: 'legacy-org', status: 'active'
+    });
+    expect(store.getRepositoryGrant(principal, 'legacy-org', 'legacy-repo')).toMatchObject({
+      status: 'granted', contents: 'write', installationId: '999'
+    });
+
+    // Now can add second installation without error
+    store.replaceVerified(principal, {
+      appId: 1, installationId: 1000, accountId: 889, accountLogin: 'new-org', status: 'active',
+      repositories: [{ owner: 'new-org', repository: 'new-repo', contents: 'read' }]
+    }, 200);
+
+    expect(store.listInstallations(principal)).toHaveLength(2);
+    expect(store.getRepositoryGrant(principal, 'legacy-org', 'legacy-repo')).toMatchObject({ status: 'granted' });
+    expect(store.getRepositoryGrant(principal, 'new-org', 'new-repo')).toMatchObject({ status: 'granted' });
+
+    state.close();
+  });
 });

--- a/docs/github-app-private-repositories.md
+++ b/docs/github-app-private-repositories.md
@@ -59,10 +59,16 @@ From the new App's settings page:
 4. Select only the private repositories Cloud Harness needs, then finish the
    installation.
 
+To operate across multiple accounts or organizations (e.g. a personal account
+and several organization workspaces), install the same GitHub App on each
+target account or organization. A single principal can bind multiple concurrent
+installations in the operator dashboard; the runner automatically selects the
+correct installation matching the repository owner (`owner/repo`) when minting
+tokens.
+
 Use **All repositories** only when that broader and future access is an
 explicit owner decision. GitHub documents this flow in
 [Installing your own GitHub App](https://docs.github.com/en/apps/using-github-apps/installing-your-own-github-app).
-
 ## 3. Collect the App ID, installation ID, and private key
 
 Cloud Harness requires three values together:

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -141,9 +141,12 @@ stored remote URL to the credential-free URL.
 
 Optional GitHub App settings let the trusted runner mint a short-lived,
 repository-scoped installation token for clone and later remote Git transfers.
-In Access mode the installation and repository grants are bound to the exact
-authenticated principal; GitHub SSO alone grants nothing. In owner-bearer mode
-the fixed configured installation remains the compatibility path.
+In Access mode the installations and repository grants are bound to the exact
+authenticated principal; a principal may bind multiple concurrent installations
+(e.g. personal and organization accounts) and the runner selects the matching
+installation by repository owner. GitHub SSO alone grants nothing. In
+owner-bearer mode the fixed configured installation remains the compatibility
+path.
 The token is passed over stdin only to the ephemeral helper that needs it; it
 is absent from Docker arguments, the checkout remote, result envelopes, and the
 long-lived executor. Public clone/fetch/pull can proceed without an App token.

--- a/packages/contracts/src/internal-runner-api.ts
+++ b/packages/contracts/src/internal-runner-api.ts
@@ -42,7 +42,7 @@ export const MetadataRunnerOperationSchema = z.enum([
   'environment_list', 'environment_create', 'environment_update', 'environment_delete',
   'secret_list', 'secret_create', 'secret_rotate', 'secret_delete', 'audit_list',
   'artifact_list', 'artifact_snapshot', 'artifact_delete',
-  'github_status', 'github_setup_begin', 'github_setup_complete', 'github_reconcile'
+  'github_status', 'github_setup_begin', 'github_setup_complete', 'github_reconcile', 'github_disconnect'
 ]);
 
 const metadataInputs = {
@@ -71,7 +71,8 @@ const metadataInputs = {
   github_setup_complete: z.object({
     state: z.string().min(32).max(128), installationId: z.string().min(1).max(100)
   }).strict(),
-  github_reconcile: z.object({}).strict()
+  github_reconcile: z.object({ installationId: z.string().min(1).max(100).optional() }).strict(),
+  github_disconnect: z.object({ installationId: z.string().min(1).max(100) }).strict()
 } as const;
 
 const metadataRequest = <Operation extends keyof typeof metadataInputs>(operation: Operation) => z.object({
@@ -86,7 +87,8 @@ export const MetadataRunnerRequestSchema = z.discriminatedUnion('operation', [
   metadataRequest('environment_list'), metadataRequest('environment_create'), metadataRequest('environment_update'), metadataRequest('environment_delete'),
   metadataRequest('secret_list'), metadataRequest('secret_create'), metadataRequest('secret_rotate'), metadataRequest('secret_delete'),
   metadataRequest('audit_list'), metadataRequest('artifact_list'), metadataRequest('artifact_snapshot'), metadataRequest('artifact_delete'),
-  metadataRequest('github_status'), metadataRequest('github_setup_begin'), metadataRequest('github_setup_complete'), metadataRequest('github_reconcile')
+  metadataRequest('github_status'), metadataRequest('github_setup_begin'), metadataRequest('github_setup_complete'),
+  metadataRequest('github_reconcile'), metadataRequest('github_disconnect')
 ]);
 
 export type InternalRunnerOperation = z.infer<typeof InternalRunnerOperationSchema>;

--- a/packages/contracts/test/internal-runner-api.test.ts
+++ b/packages/contracts/test/internal-runner-api.test.ts
@@ -66,5 +66,17 @@ describe('internal runner API contract', () => {
       version: 2, principal, operation: 'project_create',
       input: { name: 'Harness', expectedGeneration: 1 }
     })).toThrow();
+    expect(MetadataRunnerRequestSchema.parse({
+      version: 2, principal, operation: 'github_disconnect',
+      input: { installationId: 'inst_12345' }
+    })).toMatchObject({ operation: 'github_disconnect', input: { installationId: 'inst_12345' } });
+    expect(MetadataRunnerRequestSchema.parse({
+      version: 2, principal, operation: 'github_reconcile',
+      input: { installationId: 'inst_12345' }
+    })).toMatchObject({ operation: 'github_reconcile', input: { installationId: 'inst_12345' } });
+    expect(MetadataRunnerRequestSchema.parse({
+      version: 2, principal, operation: 'github_reconcile',
+      input: {}
+    })).toMatchObject({ operation: 'github_reconcile', input: {} });
   });
 });

--- a/plans/260819-1853-support-multiple-github-app-installations-per-principal/phase-01-start.md
+++ b/plans/260819-1853-support-multiple-github-app-installations-per-principal/phase-01-start.md
@@ -1,0 +1,91 @@
+---
+phase: 1
+title: "Contracts and Schema Migration"
+status: completed
+priority: P1
+effort: "1.5h"
+dependencies: []
+---
+
+# Phase 1: Contracts and Schema Migration
+
+## Overview
+Redesign the `GitHubInstallationStore` interface and `SqliteGitHubInstallationStore` implementation to support multiple installations per principal. Rebuild the `github_installations` SQLite table with compound primary key `(principal_id, installation_id)`, add account and global installation uniqueness constraints, implement in-place schema migration from single-installation databases, and scope grant reconciliation per installation.
+
+## Requirements
+- Functional:
+  - `GitHubInstallationStore` interface supports `listInstallations(principalId)`, `getInstallation(principalId, installationId?)`, `markUninstalled(principalId, installationId, checkedAt, audit?)`, and `removeInstallation(principalId, installationId, checkedAt, audit?)`.
+  - SQLite table `github_installations` schema updated: Primary Key is `(principal_id, installation_id)`.
+  - Unique index `github_installations_principal_account` on `(principal_id, account_id)`.
+  - Global unique index `github_installations_installation_identity` on `(installation_id)`.
+  - Schema migration detects old `github_installations` table (where `principal_id` was PK) and migrates rows into new schema without data loss.
+  - `replaceVerified` updates or inserts the specific installation and updates grants for that installation only; existing grants from other installations of the same principal remain untouched.
+  - `markUninstalled` sets `status = 'uninstalled'` on the specific installation and marks its grants as `removed`.
+  - `removeInstallation` deletes or marks removed the specific installation and associated repository grants.
+  - `InMemoryGitHubInstallationStore` updated to match the interface and multi-installation behavior.
+- Non-functional:
+  - Atomic transactions (`BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK`).
+  - Zero downtime / zero manual SQL intervention on existing deployed databases.
+
+## Architecture
+- Table schema:
+  ```sql
+  CREATE TABLE IF NOT EXISTS github_installations (
+    principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+    app_id TEXT NOT NULL,
+    installation_id TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    account_login TEXT NOT NULL,
+    status TEXT NOT NULL CHECK(status IN ('active','suspended','uninstalled')),
+    generation INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    checked_at INTEGER NOT NULL,
+    PRIMARY KEY(principal_id, installation_id)
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS github_installations_principal_account
+    ON github_installations(principal_id, account_id);
+  CREATE UNIQUE INDEX IF NOT EXISTS github_installations_installation_identity
+    ON github_installations(installation_id);
+  ```
+- Migration logic:
+  - Check if `github_installations` exists and if its table info has `pk=1` for `principal_id` only.
+  - If legacy schema detected: rename to `github_installations_old`, create new table and indexes, copy data `INSERT INTO github_installations SELECT * FROM github_installations_old`, drop `github_installations_old`.
+
+## Related Code Files
+- Modify: `apps/runner/src/github-installation-store.ts`
+- Modify: `apps/runner/src/github-installation-sqlite-store.ts`
+- Modify: `apps/runner/test/github-installation-sqlite-store.test.ts`
+- Modify: `packages/contracts/src/internal-runner-api.ts` (if operations/inputs need extension)
+
+## Implementation Steps (TDD)
+1. **Tests First:**
+   - In `apps/runner/test/github-installation-sqlite-store.test.ts`:
+     - Test storing multiple active installations under the same principal (e.g. personal account `mrgoonie` and org `bestagentkits`).
+     - Test that calling `replaceVerified` for org B does NOT remove or modify repository grants for org A.
+     - Test `listInstallations(principalId)` returns all installations.
+     - Test `getInstallation(principalId, installationId)` returns the specific installation.
+     - Test `markUninstalled(principalId, installationId)` updates only the specified installation.
+     - Test `removeInstallation(principalId, installationId)` removes the installation and its grants.
+     - Test uniqueness: binding the same `installation_id` to `principalB` fails with 409 Conflict.
+     - Test uniqueness: binding a second installation for the same `account_id` under the same principal updates/replaces that account's installation.
+     - Test database migration: create a SQLite database with legacy single-row schema and populated grants, run migration, verify data integrity, compound PK, and subsequent multi-installation additions.
+2. **Implement `github-installation-store.ts`:**
+   - Update types and `GitHubInstallationStore` interface.
+   - Update `InMemoryGitHubInstallationStore`.
+3. **Implement `github-installation-sqlite-store.ts`:**
+   - Implement table migration in `migrateGitHubInstallationSchema`.
+   - Update `SqliteGitHubInstallationStore` methods.
+4. **Run and Verify Tests:**
+   - `npx vitest run apps/runner/test/github-installation-sqlite-store.test.ts` passes.
+
+## Success Criteria
+- [x] Multiple installations can be persisted and listed per principal in both InMemory and SQLite stores.
+- [x] Adding/reconciling an installation does not purge repository grants of other installations.
+- [x] Legacy SQLite database with existing single-installation schema migrates cleanly without data loss.
+- [x] All unit tests in `apps/runner/test/github-installation-sqlite-store.test.ts` pass.
+
+## Risk Assessment
+- *Risk:* SQLite table recreation could fail if foreign keys or triggers interfere.
+  *Signal:* Migration error during table rebuild or data copy.
+  *Mitigation:* Run migration inside transaction, verify `PRAGMA foreign_keys` handling, and test with pre-existing data fixtures.

--- a/plans/260819-1853-support-multiple-github-app-installations-per-principal/phase-02-broker-and-binding-service.md
+++ b/plans/260819-1853-support-multiple-github-app-installations-per-principal/phase-02-broker-and-binding-service.md
@@ -1,0 +1,93 @@
+---
+phase: 2
+title: "Broker and Binding Service"
+status: completed
+priority: P1
+effort: "1.5h"
+dependencies: [1]
+---
+
+# Phase 2: Broker and Binding Service
+
+## Overview
+Update `mintPrincipalRepositoryToken` in `github-app-broker.ts` to locate the correct installation via the repository grant's `installationId` instead of assuming a single global installation per principal. Update `GitHubBindingService` in `github-binding-service.ts` to support multi-installation setup completion, multi-installation reconciliation, and installation disconnection.
+
+## Requirements
+- Functional:
+  - `mintPrincipalRepositoryToken`:
+    - Lookup repository grant for `(principalId, owner, repository)`.
+    - Verify grant status is `granted` and contents permission satisfies `requiredPermission`.
+    - Lookup the installation matching `grant.installationId` for `principalId`.
+    - Verify installation status is `active` and `appId` matches runner configuration.
+    - Mint repository token via `mintForInstallation` with `grant.installationId`.
+    - Deny requests with 403 FORBIDDEN if grant missing/removed/insufficient, installation missing/suspended/uninstalled, or wrong app.
+  - `GitHubBindingService`:
+    - `completeSetup`: consumes setup state token, calls `verifier.verifyInstallation`, enforces constraints, and calls `installations.replaceVerified`.
+    - `reconcile`: iterates all active installations for the principal via `installations.listInstallations(principalId)`. For each:
+      - Verifies with `verifier.verifyInstallation`.
+      - If provider returns 404 NOT_FOUND: marks that installation `uninstalled` and removes its grants.
+      - If provider returns mismatch in `appId` or `accountId`: throws 409 CONFLICT or marks installation in conflict.
+      - If verification succeeds: calls `replaceVerified`.
+      - Returns list or summary of reconciled installations.
+    - `disconnect`: removes or marks uninstalled a specific installation.
+- Non-functional:
+  - Preserves credential isolation: tokens minted on demand only; no token or private key persisted.
+
+## Architecture
+- Broker Resolution Flow:
+  ```
+  (principalId, repositoryUrl)
+       │
+       ▼
+  getRepositoryGrant(principalId, owner, repo)
+       │ (checks status === 'granted', permission)
+       ▼
+  getInstallation(principalId, grant.installationId)
+       │ (checks status === 'active', appId match)
+       ▼
+  mintForInstallation(githubApp, grant.installationId, repo)
+  ```
+- Reconciliation Flow:
+  ```
+  listInstallations(principalId)
+       │
+       ├─► Installation 1 ──► verifyInstallation(1) ──► replaceVerified(1)
+       ├─► Installation 2 ──► verifyInstallation(2) ──► 404 ──► markUninstalled(2)
+       └─► Installation 3 ──► verifyInstallation(3) ──► replaceVerified(3)
+  ```
+
+## Related Code Files
+- Modify: `apps/runner/src/github-app-broker.ts`
+- Modify: `apps/runner/src/github-binding-service.ts`
+- Modify: `apps/runner/test/github-app-broker.test.ts`
+- Modify: `apps/runner/test/github-binding-service.test.ts`
+- Modify: `apps/runner/test/github-app-leak.test.ts`
+
+## Implementation Steps (TDD)
+1. **Tests First:**
+   - In `apps/runner/test/github-app-broker.test.ts`:
+     - Test minting tokens for repos belonging to distinct installations (e.g. `ownerA/repoA` on `installation1` and `ownerB/repoB` on `installation2`) under the same principal.
+     - Test token minting failure when one installation is suspended or uninstalled while another remains active.
+     - Test wrong-owner rejection and cross-principal rejection.
+   - In `apps/runner/test/github-binding-service.test.ts`:
+     - Test adding a second installation via `completeSetup` without purging first installation's grants.
+     - Test `reconcile` reconciling multiple installations in sequence.
+     - Test `reconcile` handling 404 NOT_FOUND for one installation (marking it uninstalled) while keeping other installations active.
+     - Test disconnecting an installation.
+2. **Implement Broker Changes:**
+   - Update `mintPrincipalRepositoryToken` in `apps/runner/src/github-app-broker.ts`.
+3. **Implement Binding Service Changes:**
+   - Update `GitHubBindingService` in `apps/runner/src/github-binding-service.ts`.
+4. **Run and Verify Tests:**
+   - `npx vitest run apps/runner/test/github-app-broker.test.ts apps/runner/test/github-binding-service.test.ts apps/runner/test/github-app-leak.test.ts`
+
+## Success Criteria
+- [x] Principal can access private repositories across personal and organization accounts concurrently.
+- [x] Token broker mints repository tokens against the correct installation ID.
+- [x] Binding service reconciles all installations and marks uninstalled accounts appropriately.
+- [x] All broker and binding service tests pass cleanly.
+
+## Risk Assessment
+- *Risk:* Cross-installation grant collision if two orgs have identically named repositories.
+  *Signal:* Grant lookup ambiguity.
+  *Mitigation:* Grants are keyed by `(principal_id, owner, repository)` where `owner` is lowercase GitHub account/org login. Since GitHub repository paths `owner/repo` are unique on GitHub, no collision is possible.

--- a/plans/260819-1853-support-multiple-github-app-installations-per-principal/phase-03-dashboard-bff-and-public-contracts.md
+++ b/plans/260819-1853-support-multiple-github-app-installations-per-principal/phase-03-dashboard-bff-and-public-contracts.md
@@ -1,0 +1,79 @@
+---
+phase: 3
+title: "Dashboard BFF and Public Contracts"
+status: completed
+priority: P1
+effort: "1.5h"
+dependencies: [1, 2]
+---
+
+# Phase 3: Dashboard BFF and Public Contracts
+
+## Overview
+Extend the metadata operations and dashboard BFF to handle multiple GitHub App installations per principal. Update `DashboardControlService` on the runner, `MetadataRunnerOperationSchema` / `MetadataRunnerRequestSchema` in contracts, `mapDashboardData` and `githubStatus` in API response mapping, and `dashboard-control-router.ts`.
+
+## Requirements
+- Functional:
+  - Contracts (`packages/contracts/src/internal-runner-api.ts`):
+    - Support `github_status` returning `installations: [...]` and `repositories: [...]`.
+    - Support `github_reconcile` (optionally accepting `installationId`).
+    - Add `github_disconnect` operation with `installationId: string`.
+  - Runner (`apps/runner/src/dashboard-control-service.ts`):
+    - `githubStatus` returns:
+      ```ts
+      {
+        configured: boolean;
+        installations: GitHubInstallationRecord[];
+        repositories: GitHubRepositoryGrantRecord[];
+      }
+      ```
+    - Handle `github_disconnect` operation: removes the installation and its repository grants, recording audit event `github.disconnected`.
+    - `github_setup_complete` and `github_reconcile` return updated `githubStatus`.
+  - API BFF (`apps/api/src/dashboard-response.ts`):
+    - Update `githubStatus` mapper to sanitize and pick fields for each item in `data.installations` as well as `data.repositories`.
+    - Maintain backwards compatibility for `data.installation` (e.g. `installations[0] ?? null`) if needed, while primary array is `installations`.
+    - Map `github_disconnect` operation responses.
+  - API Control Router (`apps/api/src/dashboard-control-router.ts`):
+    - `GET /api/v1/github` -> `github_status`
+    - `POST /api/v1/github/setup` -> `github_setup_begin`
+    - `POST /api/v1/github/complete` -> `github_setup_complete`
+    - `POST /api/v1/github/reconcile` -> `github_reconcile` (with optional `installationId` in body)
+    - `DELETE /api/v1/github/installations/:installationId` or `POST /api/v1/github/disconnect` -> `github_disconnect`
+- Non-functional:
+  - Input validation with Zod schemas.
+  - Consistent error responses and audit logging.
+
+## Related Code Files
+- Modify: `packages/contracts/src/internal-runner-api.ts`
+- Modify: `packages/contracts/test/internal-runner-api.test.ts`
+- Modify: `apps/runner/src/dashboard-control-service.ts`
+- Modify: `apps/runner/test/dashboard-control-service.test.ts`
+- Modify: `apps/api/src/dashboard-response.ts`
+- Modify: `apps/api/src/dashboard-control-router.ts`
+- Modify: `apps/api/test/dashboard-router.test.ts`
+
+## Implementation Steps (TDD)
+1. **Tests First:**
+   - In `packages/contracts/test/internal-runner-api.test.ts`: test schema parsing for `github_disconnect` and `github_reconcile`.
+   - In `apps/runner/test/dashboard-control-service.test.ts`: test `github_status` returns all installations; test `github_disconnect` removes specific installation and emits audit log; test `github_reconcile` iterates installations.
+   - In `apps/api/test/dashboard-router.test.ts`: test `/api/v1/github` response mapping; test disconnect route.
+2. **Implement Contracts:**
+   - Update `internal-runner-api.ts`.
+   - Run `npm run build -w @cloud-harness/contracts`.
+3. **Implement Runner Dashboard Control Service:**
+   - Update `apps/runner/src/dashboard-control-service.ts`.
+4. **Implement API Response Mapping & Routes:**
+   - Update `apps/api/src/dashboard-response.ts` and `apps/api/src/dashboard-control-router.ts`.
+5. **Run and Verify Tests:**
+   - `npx vitest run packages/contracts/test/internal-runner-api.test.ts apps/runner/test/dashboard-control-service.test.ts apps/api/test/dashboard-router.test.ts`
+
+## Success Criteria
+- [x] Contract schemas validate multi-installation status and disconnect operations.
+- [x] Runner control service returns full array of installations and handles disconnect.
+- [x] API routes map and sanitize response payloads properly.
+- [x] All tests in contracts, runner, and API pass.
+
+## Risk Assessment
+- *Risk:* Breaking API schema expectations if existing frontend code expects `installation` object instead of `installations` array.
+  *Signal:* Dashboard UI error or test assertion failure on `response.data.installation`.
+  *Mitigation:* Include both `installations` (canonical array) and `installation` (first item or null for backward compatibility) in the mapped response.

--- a/plans/260819-1853-support-multiple-github-app-installations-per-principal/phase-04-dashboard-ui-and-rendering.md
+++ b/plans/260819-1853-support-multiple-github-app-installations-per-principal/phase-04-dashboard-ui-and-rendering.md
@@ -1,0 +1,62 @@
+---
+phase: 4
+title: "Dashboard UI and Rendering"
+status: completed
+priority: P1
+effort: "1h"
+dependencies: [3]
+---
+
+# Phase 4: Dashboard UI and Rendering
+
+## Overview
+Update `apps/api/dashboard/dashboard-render.js`, `apps/api/dashboard/dashboard.js`, and styling to render multiple GitHub App installations, provide per-installation Reconcile and Disconnect buttons, render authorized repositories per installation/owner, and update overview stats.
+
+## Requirements
+- Functional:
+  - `renderGitHub` in `apps/api/dashboard/dashboard-render.js`:
+    - Renders an installation panel or list of cards when `status.installations` is non-empty.
+    - Each installation card displays:
+      - Account login (`accountLogin` or `accountId`)
+      - Installation status (`active`, `suspended`, `uninstalled`)
+      - Installation ID (mono)
+      - Last checked timestamp
+      - Action buttons: "Reconcile" and "Disconnect" (with data attributes `data-installation-id="..."`)
+    - When `status.installations` is empty: displays "No GitHub App installation is bound to this identity."
+    - "Connect GitHub App" panel with optional expected account ID input and "Connect GitHub App" button to connect additional accounts/orgs.
+    - "Authorized repositories" list displaying owner/repo, status, contents permissions, and associated installation ID.
+  - Event Handling in `apps/api/dashboard/dashboard.js`:
+    - Binds click listeners to per-installation Reconcile buttons (calls `POST /api/v1/github/reconcile` with `{ installationId }`).
+    - Binds click listeners to per-installation Disconnect buttons (prompts/confirms and calls `POST /api/v1/github/disconnect` or `DELETE /api/v1/github/installations/:id`).
+    - Overview tile displays count/summary of connected installations (e.g. `2 connected` or account names).
+  - Contract & UI Tests:
+    - `apps/api/test/dashboard-ui-contract.test.ts`
+    - `apps/api/test/dashboard-ui-behavior.test.ts`
+- Non-functional:
+  - Accessible HTML with proper ARIA attributes, semantic headings, and keyboard navigation.
+  - Zero external CDN dependencies, conforms to strict CSP.
+
+## Related Code Files
+- Modify: `apps/api/dashboard/dashboard-render.js`
+- Modify: `apps/api/dashboard/dashboard.js`
+- Modify: `apps/api/dashboard/dashboard.css` (if needed for styling installation cards)
+- Modify: `apps/api/test/dashboard-ui-contract.test.ts`
+- Modify: `apps/api/test/dashboard-ui-behavior.test.ts`
+
+## Implementation Steps (TDD)
+1. **Tests First:**
+   - In `apps/api/test/dashboard-ui-contract.test.ts`: test HTML structure when `installations` contains multiple records; test presence of per-installation action buttons and repository list.
+   - In `apps/api/test/dashboard-ui-behavior.test.ts`: test clicking reconcile and disconnect for a specific installation.
+2. **Implement `dashboard-render.js`:**
+   - Update `renderGitHub` to iterate over `status.installations`.
+3. **Implement `dashboard.js`:**
+   - Update `bindGitHubControls` to attach event listeners to all reconcile and disconnect buttons.
+   - Update overview panel logic.
+4. **Run and Verify Tests:**
+   - `npx vitest run apps/api/test/dashboard-ui-contract.test.ts apps/api/test/dashboard-ui-behavior.test.ts`
+
+## Success Criteria
+- [x] Operator dashboard lists each connected GitHub App installation.
+- [x] Operator can trigger reconcile or disconnect on an individual installation.
+- [x] Operator can initiate connection for additional organizations.
+- [x] UI contract and behavior tests pass.

--- a/plans/260819-1853-support-multiple-github-app-installations-per-principal/phase-05-documentation-and-regression-verification.md
+++ b/plans/260819-1853-support-multiple-github-app-installations-per-principal/phase-05-documentation-and-regression-verification.md
@@ -1,0 +1,40 @@
+---
+phase: 5
+title: "Documentation and Regression Verification"
+status: completed
+priority: P1
+effort: "1h"
+dependencies: [1, 2, 3, 4]
+---
+
+# Phase 5: Documentation and Regression Verification
+
+## Overview
+Update documentation to reflect multi-installation support and per-owner repository routing. Execute the full verification suite (`npm run verify` / `npm test`), ensuring zero regressions across all packages and components.
+
+## Requirements
+- Functional:
+  - Update `docs/github-app-private-repositories.md` to describe connecting multiple accounts/orgs, per-owner repository resolution, reconciliation, and disconnect workflows.
+  - Update `docs/mcp-api.md` if MCP API or metadata notes mention GitHub App behavior.
+  - Verify that all unit, integration, and security tests pass without warnings or errors.
+- Non-functional:
+  - Ensure documentation adheres to project standard: docs explain WHY and WHERE; code and contracts own WHAT and HOW.
+
+## Related Documentation Files
+- Modify: `docs/github-app-private-repositories.md`
+- Modify: `docs/mcp-api.md`
+
+## Implementation Steps
+1. **Update Documentation:**
+   - Update `docs/github-app-private-repositories.md` with multi-installation architecture and operator workflows.
+   - Update `docs/mcp-api.md` if applicable.
+2. **Execute Complete Test Suite:**
+   - Run `npm test` across all packages.
+   - Run `npm run verify` (lint, typecheck, build, test).
+3. **Verify Security Invariants:**
+   - Confirm zero credentials or tokens in logs, DB dumps, or MCP envelopes.
+
+## Success Criteria
+- [x] Documentation clearly describes multiple installations per principal.
+- [x] `npm run verify` passes completely.
+- [x] All security invariants are verified.

--- a/plans/260819-1853-support-multiple-github-app-installations-per-principal/plan.md
+++ b/plans/260819-1853-support-multiple-github-app-installations-per-principal/plan.md
@@ -1,0 +1,83 @@
+---
+title: "Support multiple GitHub App installations per principal"
+description: "Redesign the installation store, SQLite schema, token broker, binding service, dashboard BFF, and UI to support multiple concurrent GitHub App installations (personal account + multiple orgs) per principal."
+status: completed
+priority: P1
+effort: "6h"
+tags: ["github-app", "multi-installation", "sqlite-migration", "dashboard", "token-broker", "tdd"]
+created: 2026-08-19
+issue: 54
+---
+
+# Support multiple GitHub App installations per principal
+
+## Overview
+
+Cloud Harness MCP previously bound exactly one GitHub App installation per principal using `principal_id` as the primary key of `github_installations`. Connecting a second account or organization overwrote the previous installation and wiped existing repository grants during reconciliation.
+
+This implementation redesigns the GitHub App integration so that a single principal can hold multiple concurrent installations (e.g. personal account `mrgoonie` alongside organizations `bestagentkits` and `nextlevelbuilder`). The runner selectively mints installation tokens matching the owner of each requested repository, preserving single-principal isolation and least-privilege token minting.
+
+## Architecture and Key Invariants
+
+1. **Schema & Storage (`apps/runner/src/github-installation-sqlite-store.ts`):**
+   - `github_installations` primary key changed to `(principal_id, installation_id)`.
+   - `UNIQUE(principal_id, account_id)` prevents duplicate installations for the same account under one principal.
+   - Global `UNIQUE(installation_id)` ensures an installation cannot be bound across multiple principals (409 Conflict).
+   - In-place SQLite migration transforms existing single-installation tables without data loss.
+   - Grant reconciliation during `replaceVerified` is scoped strictly to matching `installation_id`.
+
+2. **Store Interface (`apps/runner/src/github-installation-store.ts`):**
+   - `replaceVerified`: Adds or updates a single installation and reconciles grants for that installation only.
+   - `markUninstalled`: Marks a specific installation (by `installationId`) as uninstalled and its grants removed.
+   - `removeInstallation`: Disconnects/removes an installation and removes associated grants.
+   - `getInstallation`: Retrieves installation by `principalId` and `installationId` (or single lookup helper).
+   - `listInstallations`: Returns all installations bound to a principal.
+   - `getRepositoryGrant`: Resolves the active grant for `(principalId, owner, repository)`.
+   - `listRepositoryGrants`: Returns repository grants for a principal (optionally filtered by `installationId`).
+
+3. **Token Broker (`apps/runner/src/github-app-broker.ts`):**
+   - `mintPrincipalRepositoryToken` resolves the grant for `(principalId, owner, repository)`, locates the specific installation via `grant.installationId`, verifies `status === 'active'` and matching `appId`, and mints the repository-scoped token.
+   - Decoupled from any single-installation assumption.
+
+4. **Binding & Reconciliation Service (`apps/runner/src/github-binding-service.ts`):**
+   - `completeSetup` verifies and adds/updates an individual installation without wiping other installations.
+   - `reconcile` iterates all active installations for the principal, verifying each against GitHub API, marking missing installations as uninstalled, and detecting identity conflicts per installation.
+   - `disconnect` removes an installation and its associated repository grants.
+
+5. **Dashboard BFF & UI (`apps/api/src/`, `apps/api/dashboard/`):**
+   - `github_status` returns `installations: [...]` and `repositories: [...]`.
+   - Dashboard renders cards for each connected installation with per-installation "Reconcile" and "Disconnect" actions.
+   - Supports connecting additional accounts/organizations via the setup flow.
+
+## Goals & Acceptance Criteria
+
+| # | Goal | Priority |
+|---|------|----------|
+| 1 | Multi-installation schema migration with backwards compatibility | P1 |
+| 2 | Scoped store methods and grant reconciliation without cross-installation wipes | P1 |
+| 3 | Owner-to-installation token broker resolution | P1 |
+| 4 | Multi-installation setup, reconciliation, and disconnect service | P1 |
+| 5 | Dashboard API contracts and responsive UI for multiple installations | P1 |
+| 6 | Comprehensive unit, integration, and security regression tests | P1 |
+
+## Phases
+
+| # | Phase | Status |
+|---|-------|--------|
+| 1 | [Phase 1: Contracts and Schema Migration](./phase-01-start.md) | Completed |
+| 2 | [Phase 2: Broker and Binding Service](./phase-02-broker-and-binding-service.md) | Completed |
+| 3 | [Phase 3: Dashboard BFF and Public Contracts](./phase-03-dashboard-bff-and-public-contracts.md) | Completed |
+| 4 | [Phase 4: Dashboard UI and Rendering](./phase-04-dashboard-ui-and-rendering.md) | Completed |
+| 5 | [Phase 5: Documentation and Regression Verification](./phase-05-documentation-and-regression-verification.md) | Completed |
+
+## Success Criteria
+
+- [x] Existing single-row SQLite databases migrate seamlessly to `(principal_id, installation_id)` PK without manual intervention.
+- [x] A principal can bind multiple active installations across different GitHub accounts/orgs simultaneously.
+- [x] Binding or reconciling one installation does not purge repository grants of other installations.
+- [x] `mintPrincipalRepositoryToken` successfully authorizes and mints tokens for repos belonging to any bound installation of the principal.
+- [x] Cross-principal binding attempts for the same `installation_id` fail with 409 Conflict.
+- [x] Dashboard displays all connected installations and allows connecting additional accounts, reconciling individual installations, and disconnecting specific installations.
+- [x] Full test suite (`npm test`) passes with 100% coverage on new and updated paths.
+- [x] All security invariants are preserved: no credentials leaked into state, remotes, logs, or MCP envelopes.
+<!-- slug: support-multiple-github-app-installations-per-principal -->


### PR DESCRIPTION
## Summary

Supports multiple concurrent GitHub App installations per principal across personal accounts and organizations with selective per-owner repository token minting.

Fixes #54.

## Key Changes

1. **Storage & SQLite Schema (`apps/runner/src/github-installation-sqlite-store.ts`, `apps/runner/src/github-installation-store.ts`):**
   - Compound primary key `(principal_id, installation_id)` on `github_installations`.
   - `UNIQUE(principal_id, account_id)` constraint ensures one installation per account per principal.
   - Global `UNIQUE(installation_id)` index preserves cross-principal conflict detection (409 Conflict).
   - In-place automatic SQLite migration from legacy single-row tables without data loss.
   - `replaceVerified` scopes grant removal strictly to `installation_id`, avoiding cross-installation grant wipes.
   - Added `listInstallations`, `removeInstallation`, `markUninstalled`, and filtered `listRepositoryGrants`.

2. **Token Broker (`apps/runner/src/github-app-broker.ts`):**
   - `mintPrincipalRepositoryToken` decouples from single-installation assumptions. It resolves the repository grant for `(principalId, owner, repo)`, verifies the specific installation by `grant.installationId` (`status === active` and matching `appId`), and mints the repository token.

3. **Binding Service (`apps/runner/src/github-binding-service.ts`):**
   - `completeSetup` adds/updates individual installations without purging others.
   - `reconcile` iterates all active installations for the principal, handling per-installation 404 NOT_FOUND (uninstall) and identity conflict checks.
   - Added `disconnect` to remove specific installations and their associated repository grants.

4. **Dashboard BFF & Operator UI (`apps/api/`, `apps/api/dashboard/`):**
   - Updated `github_status` metadata response to return `installations: [...]` and `repositories: [...]`.
   - Added `DELETE /api/v1/github/installations/:installationId` and `POST /api/v1/github/disconnect` endpoints.
   - Rendered installation cards with account logins, statuses, installation IDs, and per-installation **Reconcile** and **Disconnect** buttons.
   - Updated Overview metrics to reflect multi-installation account count.

5. **Documentation (`docs/github-app-private-repositories.md`, `docs/mcp-api.md`):**
   - Documented multi-installation setup, per-owner repository routing, reconciliation, and disconnect workflows.

## Verification Evidence

- `npm run verify` passes completely with 291/291 unit and integration tests passing.
- New unit tests in:
  - `apps/runner/test/github-installation-sqlite-store.test.ts` (multi-installation persistence, scoped reconciliation, removal, and legacy schema migration).
  - `apps/runner/test/github-binding-service.test.ts` (multi-installation setup and multi-installation reconciliation).
  - `apps/runner/test/github-app-broker.test.ts` (owner-to-installation token routing across multiple orgs).
  - `apps/runner/test/dashboard-control-service.test.ts` (multi-installation status, reconcile, and disconnect).
  - `packages/contracts/test/internal-runner-api.test.ts` (schema validation).
  - `apps/api/test/dashboard-router.test.ts` (BFF response mapping and routes).
  - `apps/api/test/dashboard-ui-contract.test.ts` & `apps/api/test/dashboard-ui-behavior.test.ts` (UI contract and rendering).

## Security Invariants

- Single-owner isolation strictly preserved: credentials remain runner-only; no tokens or private keys in checkouts, remotes, logs, DB state, or MCP tool results.