### PR TITLE
fix(broker): allow unauthenticated public repository clone in Access mode without GitHub App grant

### DIFF
--- a/apps/runner/src/github-app-broker.ts
+++ b/apps/runner/src/github-app-broker.ts
@@ -20,11 +20,17 @@ export async function mintPrincipalRepositoryToken(input: {
   const { owner, repository } = parseGitHubRepository(input.repositoryUrl);
   const grant = input.installations.getRepositoryGrant(input.principalId, owner, repository);
   const requiredPermission = input.requiredPermission ?? 'read';
-  if (
-    !grant ||
-    grant.status !== 'granted' ||
-    (requiredPermission === 'write' && grant.contents !== 'write')
-  ) throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
+
+  if (!grant || grant.status !== 'granted') {
+    if (requiredPermission === 'write') {
+      throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
+    }
+    return undefined;
+  }
+
+  if (requiredPermission === 'write' && grant.contents !== 'write') {
+    throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
+  }
 
   const installation = input.installations.getInstallation(input.principalId, grant.installationId);
   if (

--- a/apps/runner/test/github-app-broker.test.ts
+++ b/apps/runner/test/github-app-broker.test.ts
@@ -61,19 +61,26 @@ describe('GitHub App broker', () => {
       installations
     };
 
-    await expect(mintPrincipalRepositoryToken({ ...request, principalId: 'principal-b' })).rejects.toThrow('not authorized');
+    await expect(mintPrincipalRepositoryToken({ ...request, principalId: 'principal-b' })).resolves.toBeUndefined();
+    await expect(mintPrincipalRepositoryToken({
+      ...request, principalId: 'principal-b', requiredPermission: 'write'
+    })).rejects.toThrow('not authorized');
     await expect(mintPrincipalRepositoryToken({
       ...request, principalId: 'principal-a', requiredPermission: 'write'
     })).rejects.toThrow('not authorized');
-
     installations.replaceVerified('principal-a', {
       appId: 123, installationId: 456, accountId: 789, accountLogin: 'example', status: 'active', repositories: []
     }, 2_000);
-    await expect(mintPrincipalRepositoryToken({ ...request, principalId: 'principal-a' })).rejects.toThrow('not authorized');
+    await expect(mintPrincipalRepositoryToken({
+      ...request, principalId: 'principal-a', requiredPermission: 'write'
+    })).rejects.toThrow('not authorized');
     installations.replaceVerified('principal-a', {
-      appId: 123, installationId: 456, accountId: 789, accountLogin: 'example', status: 'suspended', repositories: []
+      appId: 123, installationId: 456, accountId: 789, accountLogin: 'example', status: 'suspended',
+      repositories: []
     }, 3_000);
-    await expect(mintPrincipalRepositoryToken({ ...request, principalId: 'principal-a' })).rejects.toThrow('not authorized');
+    await expect(mintPrincipalRepositoryToken({
+      ...request, principalId: 'principal-a', requiredPermission: 'write'
+    })).rejects.toThrow('not authorized');
     expect(authMocks.createAppAuth).not.toHaveBeenCalled();
   });
 

--- a/apps/runner/test/github-binding-service.test.ts
+++ b/apps/runner/test/github-binding-service.test.ts
@@ -132,7 +132,8 @@ describe('GitHub installation binding', () => {
       config: { githubApp: { appId: 123, privateKey: '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----' } } as RunnerConfig,
       principalId: 'principal-a',
       repositoryUrl: new URL('https://github.com/example/private-repo.git'),
-      installations: store
+      installations: store,
+      requiredPermission: 'write'
     })).rejects.toThrow('not authorized');
   });
 


### PR DESCRIPTION
## Summary

In Cloudflare Access mode, `mintPrincipalRepositoryToken` was throwing a `403 FORBIDDEN` error whenever a repository had no grant in `github_repository_grants`. This broke public repository clones (such as `bestagentkits/cloud-harness-mcp.git` during deployment canary health checks).

This fix aligns the implementation with `docs/mcp-api.md`:
- When `permission === "read"` (clone/fetch/pull), a repository with no active grant returns `undefined`, allowing the clone helper to perform an anonymous public clone over HTTPS.
- When `permission === "write"` (push), it strictly enforces that an authorized grant with `contents: write` must be present, throwing `403 FORBIDDEN` otherwise.

Fixes production canary failure during `deploy.yml`.