### PR TITLE
feat(site): redesign marketing site with cyber-engineering dark HUD, animated diagrams, and 5 variants

### DIFF
--- a/site/variants/index.html
+++ b/site/variants/index.html
@@ -1,0 +1,463 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Cloud Harness MCP — 5 Distinct Design Variants Showcase with Animated Architecture & Workflows."
+    />
+    <title>Cloud Harness MCP // Design Variants Showcase (5 Animated Archetypes)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg-hub: #000000;
+        --bg-surface: #08080c;
+        --bg-card: #0e1118;
+        --border-subtle: rgba(255, 255, 255, 0.08);
+        --border-active: #6366f1;
+        --text-primary: #f8fafc;
+        --text-muted: #94a3b8;
+        --text-dim: #64748b;
+        --accent-purple: #a855f7;
+        --accent-cyan: #00f0ff;
+        --accent-indigo: #6366f1;
+        --accent-emerald: #10b981;
+        --font-sans: "Plus Jakarta Sans", sans-serif;
+        --font-display: "Space Grotesk", sans-serif;
+        --font-mono: "JetBrains Mono", monospace;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        background-color: var(--bg-hub);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        line-height: 1.5;
+        overflow-x: hidden;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      /* Top Header */
+      .hub-header {
+        background: rgba(0, 0, 0, 0.9);
+        backdrop-filter: blur(16px);
+        border-bottom: 1px solid var(--border-subtle);
+        padding: 1rem 2rem;
+        position: sticky;
+        top: 0;
+        z-index: 1000;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .hub-brand {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        font-family: var(--font-display);
+        font-size: 1.25rem;
+        font-weight: 700;
+      }
+
+      .hub-badge {
+        background: linear-gradient(135deg, var(--accent-purple), var(--accent-indigo));
+        color: white;
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-weight: 600;
+      }
+
+      .hub-controls {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      /* Viewport Toggles */
+      .viewport-bar {
+        display: flex;
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: 6px;
+        padding: 2px;
+      }
+
+      .vp-btn {
+        background: transparent;
+        border: none;
+        color: var(--text-muted);
+        padding: 0.4rem 0.8rem;
+        border-radius: 4px;
+        font-family: var(--font-mono);
+        font-size: 0.78rem;
+        cursor: pointer;
+        transition: all 0.15s ease;
+      }
+
+      .vp-btn.active, .vp-btn:hover {
+        background: var(--accent-indigo);
+        color: white;
+      }
+
+      .btn-open-tab {
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid var(--border-subtle);
+        color: white;
+        font-size: 0.85rem;
+        font-weight: 600;
+        padding: 0.45rem 1rem;
+        border-radius: 6px;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        cursor: pointer;
+      }
+
+      .btn-open-tab:hover {
+        background: rgba(255, 255, 255, 0.15);
+      }
+
+      /* Main Layout */
+      .hub-main {
+        display: grid;
+        grid-template-columns: 370px 1fr;
+        height: calc(100vh - 65px);
+      }
+
+      /* Sidebar Selector */
+      .hub-sidebar {
+        background: var(--bg-surface);
+        border-right: 1px solid var(--border-subtle);
+        overflow-y: auto;
+        padding: 1.5rem 1.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+      }
+
+      .sidebar-title {
+        font-size: 0.82rem;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        color: var(--text-dim);
+        letter-spacing: 0.08em;
+      }
+
+      .variant-selector-card {
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        padding: 1.15rem;
+        cursor: pointer;
+        transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+        text-align: left;
+      }
+
+      .variant-selector-card:hover {
+        border-color: var(--border-active);
+        transform: translateY(-2px);
+      }
+
+      .variant-selector-card.active {
+        border-color: var(--accent-indigo);
+        background: #121622;
+        box-shadow: 0 0 16px rgba(99, 102, 241, 0.25);
+      }
+
+      .card-top {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.5rem;
+      }
+
+      .card-num {
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        font-weight: 700;
+        color: var(--accent-indigo);
+      }
+
+      .card-tag {
+        font-family: var(--font-mono);
+        font-size: 0.68rem;
+        padding: 1px 6px;
+        border-radius: 3px;
+        background: rgba(255, 255, 255, 0.05);
+        color: var(--text-muted);
+      }
+
+      .card-name {
+        font-weight: 700;
+        font-size: 1rem;
+        margin-bottom: 0.35rem;
+      }
+
+      .card-summary {
+        font-size: 0.82rem;
+        color: var(--text-muted);
+        line-height: 1.5;
+      }
+
+      .card-tags-list {
+        display: flex;
+        gap: 0.4rem;
+        margin-top: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .pill-mini {
+        font-size: 0.68rem;
+        font-family: var(--font-mono);
+        padding: 1px 5px;
+        border-radius: 3px;
+        background: rgba(255, 255, 255, 0.04);
+        color: #cbd5e1;
+      }
+
+      /* Preview Frame Area */
+      .preview-area {
+        background: #000000;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+        padding: 1.5rem;
+        overflow-y: auto;
+        position: relative;
+      }
+
+      .iframe-wrapper {
+        background: #000;
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.8);
+        overflow: hidden;
+        transition: width 0.3s ease;
+        height: 100%;
+        width: 100%;
+        min-height: 850px;
+      }
+
+      iframe {
+        width: 100%;
+        height: 100%;
+        border: none;
+        display: block;
+      }
+
+      /* Info Modal / Drawer */
+      .design-analysis-card {
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        padding: 1.25rem;
+        margin-top: 1rem;
+        font-size: 0.85rem;
+      }
+
+      .analysis-header {
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        color: var(--accent-cyan);
+      }
+
+      @media (max-width: 960px) {
+        .hub-main { grid-template-columns: 1fr; height: auto; }
+        .hub-sidebar { height: auto; border-right: none; border-bottom: 1px solid var(--border-subtle); }
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Hub Navigation -->
+    <header class="hub-header">
+      <div class="hub-brand">
+        <span>Cloud Harness MCP</span>
+        <span class="hub-badge">5 ANIMATED VARIANTS</span>
+      </div>
+      <div class="hub-controls">
+        <!-- Viewport Size Switcher -->
+        <div class="viewport-bar">
+          <button class="vp-btn active" onclick="setViewport('100%', this)">🖥️ Full 100%</button>
+          <button class="vp-btn" onclick="setViewport('1280px', this)">💻 Laptop (1280px)</button>
+          <button class="vp-btn" onclick="setViewport('768px', this)">📱 Tablet (768px)</button>
+          <button class="vp-btn" onclick="setViewport('390px', this)">📱 Mobile (390px)</button>
+        </div>
+
+        <a id="openTabBtn" href="variant-1-cyber-hud.html" target="_blank" class="btn-open-tab">
+          Open Fullscreen ↗
+        </a>
+      </div>
+    </header>
+
+    <!-- Main Workspace -->
+    <main class="hub-main">
+      <!-- Sidebar Selection -->
+      <aside class="hub-sidebar">
+        <div class="sidebar-title">Select Design Concept</div>
+
+        <!-- Variant 1 -->
+        <div class="variant-selector-card active" onclick="loadVariant('variant-1-cyber-hud.html', 1, this)">
+          <div class="card-top">
+            <span class="card-num">VARIANT 01 ★ SELECTED</span>
+            <span class="card-tag" style="color: var(--accent-cyan);">CYBER-HUD</span>
+          </div>
+          <div class="card-name">Cyber-Engineering Dark HUD</div>
+          <p class="card-summary">
+            Vercel-grade pitch black background, expanded breathing room, animated Architecture Signal Matrix, Sequence Trace, and creator attribution.
+          </p>
+          <div class="card-tags-list">
+            <span class="pill-mini">Pitch Black</span>
+            <span class="pill-mini">Breathing Room</span>
+            <span class="pill-mini">AgentKit & GoClaw</span>
+            <span class="pill-mini">agents_* Tools</span>
+          </div>
+        </div>
+
+        <!-- Variant 2 -->
+        <div class="variant-selector-card" onclick="loadVariant('variant-2-linear-minimal.html', 2, this)">
+          <div class="card-top">
+            <span class="card-num">VARIANT 02</span>
+            <span class="card-tag" style="color: #cbd5e1;">LINEAR-MINIMAL</span>
+          </div>
+          <div class="card-name">Neo-Minimalist Precision B2B</div>
+          <p class="card-summary">
+            Ultra-refined dark luxury with whisper-thin borders, subtle glowing halo, animated Architecture Flow blueprint, and 3-step interactive lifecycle.
+          </p>
+          <div class="card-tags-list">
+            <span class="pill-mini">Animated Flow Canvas</span>
+            <span class="pill-mini">Stage Window</span>
+            <span class="pill-mini">Linear Style</span>
+          </div>
+        </div>
+
+        <!-- Variant 3 -->
+        <div class="variant-selector-card" onclick="loadVariant('variant-3-bento-sandbox.html', 3, this)">
+          <div class="card-top">
+            <span class="card-num">VARIANT 03</span>
+            <span class="card-tag" style="color: var(--accent-purple);">BENTO-SANDBOX</span>
+          </div>
+          <div class="card-name">Bento Grid & Live Sandbox</div>
+          <p class="card-summary">
+            Modular glassmorphism with vibrant purple/cyan gradients, animated Bento System Flowchart, and a 4-step real-time agent sandbox simulation widget.
+          </p>
+          <div class="card-tags-list">
+            <span class="pill-mini">Animated Bento Flow</span>
+            <span class="pill-mini">Live Simulator</span>
+            <span class="pill-mini">Modular Cards</span>
+          </div>
+        </div>
+
+        <!-- Variant 4 -->
+        <div class="variant-selector-card" onclick="loadVariant('variant-4-enterprise-defense.html', 4, this)">
+          <div class="card-top">
+            <span class="card-num">VARIANT 04</span>
+            <span class="card-tag" style="color: #60a5fa;">ENTERPRISE</span>
+          </div>
+          <div class="card-name">Enterprise Defense & Security</div>
+          <p class="card-summary">
+            Deep aerospace navy architecture, animated 5-layer Defense Topology Blueprint, and side-by-side threat model comparison matrix.
+          </p>
+          <div class="card-tags-list">
+            <span class="pill-mini">5-Zone Blueprint</span>
+            <span class="pill-mini">Threat Matrix</span>
+            <span class="pill-mini">CISO Approved</span>
+          </div>
+        </div>
+
+        <!-- Variant 5 -->
+        <div class="variant-selector-card" onclick="loadVariant('variant-5-futuristic-studio.html', 5, this)">
+          <div class="card-top">
+            <span class="card-num">VARIANT 05</span>
+            <span class="card-tag" style="color: #f43f5e;">STUDIO-AURORA</span>
+          </div>
+          <div class="card-name">Hyper-Modern Editorial Studio</div>
+          <p class="card-summary">
+            Dark velvet backdrop, holographic aurora gradients, animated Aurora Architecture Core with traveling particles, and interactive capability deck.
+          </p>
+          <div class="card-tags-list">
+            <span class="pill-mini">Aurora Core Diagram</span>
+            <span class="pill-mini">Editorial Style</span>
+            <span class="pill-mini">Fleet Connect</span>
+          </div>
+        </div>
+
+        <!-- Analysis Box -->
+        <div class="design-analysis-card" id="analysisBox">
+          <div class="analysis-header" id="analysisTitle">Variant 1: Selected & Perfected</div>
+          <p id="analysisBody" style="color: var(--text-muted); line-height: 1.55;">
+            <strong>Refinements Applied:</strong> Pitch black background (#000000), generous breathing room (8rem section gaps, spacious padding), creator attribution to AgentKit & GoClaw, and expanded 52+ tools surface with <code>agents_*</code> coming soon roadmap.
+          </p>
+        </div>
+      </aside>
+
+      <!-- Interactive Preview Area -->
+      <section class="preview-area">
+        <div class="iframe-wrapper" id="frameWrap">
+          <iframe id="previewIframe" src="variant-1-cyber-hud.html" title="Variant Preview"></iframe>
+        </div>
+      </section>
+    </main>
+
+    <!-- Interactive Switcher Script -->
+    <script>
+      const analysisData = {
+        1: {
+          title: "Variant 1: Cyber-Engineering Dark HUD (Selected)",
+          body: `<strong>Refinements Applied:</strong><br/>• <em>Pitch Black:</em> Pure #000000 Vercel-grade obsidian palette.<br/>• <em>Breathing Room:</em> Increased section gaps to 8rem, expanded card and container padding.<br/>• <em>Creator Badge:</em> "From the creator of AgentKit & GoClaw" in the footer.<br/>• <em>Tools Expansion:</em> Includes <code>agents_spawn</code>, <code>agents_delegate</code>, <code>agents_inbox</code>, <code>skills_*</code>, <code>hooks_*</code>, <code>memories_*</code>.`
+        },
+        2: {
+          title: "Variant 2: Neo-Minimalist Precision B2B",
+          body: `<strong>Target Persona:</strong> Tech founders, engineering leaders, and modern AI engineering teams.<br/><strong>Animated Features:</strong><br/>• <em>Minimalist Architecture Flow Canvas</em> with glowing data points traveling along dashed isolation boundaries.<br/>• <em>Interactive Stage Window</em> with live tabbed product preview.`
+        },
+        3: {
+          title: "Variant 3: Bento Grid & Live Sandbox",
+          body: `<strong>Target Persona:</strong> Broad developer audience, open-source contributors, and AI tinkers.<br/><strong>Animated Features:</strong><br/>• <em>Bento System Flowchart</em> with animated SVG path motion between Client, Ingress, Runner, and Non-root Container.<br/>• <em>Interactive 4-step live workspace simulation widget</em>.`
+        },
+        4: {
+          title: "Variant 4: Enterprise Defense & Security",
+          body: `<strong>Target Persona:</strong> CISOs, Security Architects, Platform Leads, and Enterprise DevOps.<br/><strong>Animated Features:</strong><br/>• <em>5-Layer Defense Topology Blueprint</em> with animated security verification packets.<br/>• <em>Interactive clickable defense map</em> explaining each isolation layer.`
+        },
+        5: {
+          title: "Variant 5: Hyper-Modern Editorial Studio",
+          body: `<strong>Target Persona:</strong> Next-gen AI startups, autonomous agent creators, and AI research teams.<br/><strong>Animated Features:</strong><br/>• <em>Holographic Aurora Architecture Core</em> with glowing particle streams traveling between control plane and sandboxes.<br/>• <em>3D-feel interactive capability deck</em> with metric ticker.`
+        }
+      };
+
+      function loadVariant(url, id, card) {
+        document.querySelectorAll('.variant-selector-card').forEach(c => c.classList.remove('active'));
+        card.classList.add('active');
+        document.getElementById('previewIframe').src = url;
+        document.getElementById('openTabBtn').href = url;
+        
+        const data = analysisData[id];
+        document.getElementById('analysisTitle').innerText = data.title;
+        document.getElementById('analysisBody').innerHTML = data.body;
+      }
+
+      function setViewport(width, btn) {
+        document.querySelectorAll('.vp-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById('frameWrap').style.width = width;
+      }
+    </script>
+  </body>
+</html>

--- a/site/variants/variant-1-cyber-hud.html
+++ b/site/variants/variant-1-cyber-hud.html
@@ -1524,8 +1524,8 @@
         <div style="display: flex; gap: 2rem;">
           <a href="https://docs.harness.agentkit.best" target="_blank" rel="noreferrer">Documentation</a>
           <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank" rel="noreferrer">Repository</a>
-          <a href="privacy.html">Privacy</a>
-          <a href="terms.html">Terms</a>
+          <a href="../privacy.html">Privacy</a>
+          <a href="../terms.html">Terms</a>
         </div>
       </div>
     </footer>

--- a/site/variants/variant-2-linear-minimal.html
+++ b/site/variants/variant-2-linear-minimal.html
@@ -1,0 +1,980 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Cloud Harness MCP — The precision private execution layer for autonomous AI coding agents."
+    />
+    <title>Cloud Harness MCP — Precision Remote Execution</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700;800&family=Geist+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg-main: #090a0f;
+        --bg-surface: #11131a;
+        --bg-elevated: #161922;
+        --bg-glass: rgba(17, 19, 26, 0.75);
+        --border-subtle: rgba(255, 255, 255, 0.08);
+        --border-hover: rgba(255, 255, 255, 0.18);
+        --border-accent: rgba(99, 102, 241, 0.4);
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        --text-tertiary: #64748b;
+        --accent-indigo: #6366f1;
+        --accent-sky: #38bdf8;
+        --accent-emerald: #10b981;
+        --font-sans: "Geist", "Inter", -apple-system, sans-serif;
+        --font-mono: "Geist Mono", monospace;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        background-color: var(--bg-main);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        line-height: 1.6;
+        overflow-x: hidden;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* Ambient Light Glow */
+      .ambient-glow {
+        position: absolute;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 1000px;
+        height: 500px;
+        background: radial-gradient(circle, rgba(99, 102, 241, 0.15) 0%, rgba(56, 189, 248, 0.05) 50%, transparent 70%);
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      /* Navigation */
+      .nav-wrap {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        backdrop-filter: blur(16px);
+        background: rgba(9, 10, 15, 0.8);
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .nav-inner {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 1rem 1.5rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        font-weight: 600;
+        font-size: 1.05rem;
+        letter-spacing: -0.02em;
+      }
+
+      .brand-badge {
+        font-size: 0.72rem;
+        font-family: var(--font-mono);
+        padding: 2px 6px;
+        border-radius: 4px;
+        background: var(--bg-elevated);
+        border: 1px solid var(--border-subtle);
+        color: var(--text-secondary);
+      }
+
+      .nav-menu {
+        display: flex;
+        gap: 1.75rem;
+        font-size: 0.9rem;
+        font-weight: 500;
+      }
+
+      .nav-menu a {
+        color: var(--text-secondary);
+        transition: color 0.2s ease;
+      }
+
+      .nav-menu a:hover {
+        color: var(--text-primary);
+      }
+
+      .nav-cta {
+        display: flex;
+        gap: 0.75rem;
+      }
+
+      .btn {
+        font-family: var(--font-sans);
+        font-size: 0.88rem;
+        font-weight: 500;
+        padding: 0.55rem 1.1rem;
+        border-radius: 6px;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+        cursor: pointer;
+      }
+
+      .btn-primary {
+        background: var(--text-primary);
+        color: var(--bg-main);
+        border: 1px solid var(--text-primary);
+      }
+
+      .btn-primary:hover {
+        background: #e2e8f0;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(255, 255, 255, 0.15);
+      }
+
+      .btn-ghost {
+        background: transparent;
+        color: var(--text-secondary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-ghost:hover {
+        color: var(--text-primary);
+        border-color: var(--border-hover);
+        background: rgba(255, 255, 255, 0.03);
+      }
+
+      /* Hero Section */
+      .hero {
+        position: relative;
+        max-width: 1200px;
+        margin: 4.5rem auto 6rem;
+        padding: 0 1.5rem;
+        text-align: center;
+      }
+
+      .hero-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.35rem 0.9rem;
+        border-radius: 999px;
+        background: var(--bg-surface);
+        border: 1px solid var(--border-subtle);
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+        margin-bottom: 2rem;
+        transition: border-color 0.2s ease;
+      }
+
+      .hero-pill:hover {
+        border-color: var(--border-hover);
+      }
+
+      .pill-highlight {
+        color: var(--accent-sky);
+        font-weight: 600;
+      }
+
+      .hero-title {
+        font-size: clamp(2.8rem, 6vw, 4.4rem);
+        font-weight: 800;
+        line-height: 1.08;
+        letter-spacing: -0.035em;
+        max-width: 920px;
+        margin: 0 auto 1.5rem;
+      }
+
+      .hero-title span {
+        background: linear-gradient(135deg, #ffffff 0%, #cbd5e1 50%, #94a3b8 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+
+      .hero-lead {
+        font-size: 1.2rem;
+        color: var(--text-secondary);
+        max-width: 720px;
+        margin: 0 auto 2.5rem;
+        line-height: 1.65;
+      }
+
+      .hero-buttons {
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        margin-bottom: 4.5rem;
+      }
+
+      /* Interactive Product Stage Window */
+      .stage-window {
+        max-width: 1060px;
+        margin: 0 auto;
+        background: var(--bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: 12px;
+        box-shadow: 0 24px 64px -12px rgba(0, 0, 0, 0.7), 0 0 0 1px var(--border-subtle);
+        overflow: hidden;
+        text-align: left;
+      }
+
+      .stage-header {
+        background: var(--bg-elevated);
+        border-bottom: 1px solid var(--border-subtle);
+        padding: 0.75rem 1.25rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .stage-tabs {
+        display: flex;
+        gap: 0.5rem;
+      }
+
+      .stage-tab {
+        background: transparent;
+        border: none;
+        color: var(--text-tertiary);
+        font-size: 0.82rem;
+        font-weight: 500;
+        padding: 0.4rem 0.8rem;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: all 0.15s ease;
+      }
+
+      .stage-tab.active {
+        background: var(--bg-surface);
+        color: var(--text-primary);
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+      }
+
+      .stage-body {
+        padding: 2rem;
+        display: grid;
+        grid-template-columns: 1.1fr 0.9fr;
+        gap: 2.5rem;
+        min-height: 400px;
+      }
+
+      .code-display {
+        background: #07080c;
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        padding: 1.25rem;
+        font-family: var(--font-mono);
+        font-size: 0.82rem;
+        color: #e2e8f0;
+        line-height: 1.7;
+        position: relative;
+      }
+
+      /* Animated Architecture Flow Canvas */
+      .architecture-card {
+        background: var(--bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: 12px;
+        padding: 2.5rem;
+        margin-top: 3.5rem;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .svg-linear-diagram {
+        width: 100%;
+        height: auto;
+        display: block;
+      }
+
+      /* Feature Showcase Grid */
+      .section-container {
+        max-width: 1200px;
+        margin: 6rem auto;
+        padding: 0 1.5rem;
+      }
+
+      .section-intro {
+        text-align: center;
+        max-width: 680px;
+        margin: 0 auto 4rem;
+      }
+
+      .section-label {
+        font-size: 0.8rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--accent-indigo);
+        margin-bottom: 0.75rem;
+      }
+
+      .section-headline {
+        font-size: 2.4rem;
+        font-weight: 700;
+        letter-spacing: -0.025em;
+        margin-bottom: 1rem;
+      }
+
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1.5rem;
+      }
+
+      .feature-card {
+        background: var(--bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: 10px;
+        padding: 2rem;
+        transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+      }
+
+      .feature-card:hover {
+        border-color: var(--border-hover);
+        transform: translateY(-2px);
+        background: var(--bg-elevated);
+      }
+
+      .feature-icon-wrap {
+        width: 42px;
+        height: 42px;
+        border-radius: 8px;
+        background: var(--bg-elevated);
+        border: 1px solid var(--border-subtle);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 1.5rem;
+        color: var(--accent-sky);
+      }
+
+      .feature-card h3 {
+        font-size: 1.15rem;
+        font-weight: 600;
+        margin-bottom: 0.6rem;
+      }
+
+      .feature-card p {
+        color: var(--text-secondary);
+        font-size: 0.92rem;
+        line-height: 1.6;
+      }
+
+      /* 3-Step Lifecycle Visual */
+      .lifecycle-wrap {
+        background: var(--bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: 12px;
+        padding: 3.5rem 2.5rem;
+        margin-top: 4rem;
+      }
+
+      .steps-row {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 2.5rem;
+        position: relative;
+      }
+
+      .step-num {
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        font-weight: 700;
+        color: var(--accent-indigo);
+        margin-bottom: 1rem;
+      }
+
+      .step-title {
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin-bottom: 0.6rem;
+      }
+
+      .step-desc {
+        color: var(--text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+
+      /* Client Connect Carousel / Grid */
+      .clients-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 1.25rem;
+        margin-top: 3rem;
+      }
+
+      .client-box {
+        background: var(--bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        padding: 1.5rem;
+        text-align: left;
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
+
+      .client-box:hover, .client-box.active {
+        border-color: var(--border-accent);
+        background: var(--bg-elevated);
+      }
+
+      .client-name {
+        font-weight: 600;
+        font-size: 1rem;
+        margin-bottom: 0.25rem;
+      }
+
+      .client-badge {
+        font-size: 0.75rem;
+        color: var(--text-tertiary);
+        font-family: var(--font-mono);
+      }
+
+      /* CTA Box */
+      .cta-card {
+        background: linear-gradient(180deg, var(--bg-surface) 0%, var(--bg-elevated) 100%);
+        border: 1px solid var(--border-subtle);
+        border-radius: 12px;
+        padding: 4rem 2rem;
+        text-align: center;
+        max-width: 900px;
+        margin: 6rem auto 0;
+      }
+
+      .footer-simple {
+        border-top: 1px solid var(--border-subtle);
+        padding: 3rem 1.5rem;
+        max-width: 1200px;
+        margin: 6rem auto 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 0.88rem;
+        color: var(--text-tertiary);
+      }
+
+      @media (max-width: 900px) {
+        .features-grid { grid-template-columns: 1fr; }
+        .steps-row { grid-template-columns: 1fr; }
+        .clients-grid { grid-template-columns: 1fr 1fr; }
+        .stage-body { grid-template-columns: 1fr; }
+        .nav-menu { display: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="ambient-glow"></div>
+
+    <!-- Navigation -->
+    <header class="nav-wrap">
+      <div class="nav-inner">
+        <a href="#" class="brand">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+            <rect x="3" y="3" width="18" height="18" rx="4"/>
+            <path d="M9 9h6v6H9z"/>
+          </svg>
+          <span>Cloud Harness</span>
+          <span class="brand-badge">v0.13.0</span>
+        </a>
+        <nav class="nav-menu">
+          <a href="#how-it-works">How it works</a>
+          <a href="#architecture">Architecture</a>
+          <a href="#features">Capabilities</a>
+          <a href="#clients">AI Clients</a>
+          <a href="https://docs.harness.agentkit.best" target="_blank">Documentation ↗</a>
+        </nav>
+        <div class="nav-cta">
+          <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank" class="btn btn-ghost">
+            GitHub
+          </a>
+          <a href="#clients" class="btn btn-primary">
+            Connect Client
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <!-- Hero -->
+    <main>
+      <section class="hero">
+        <div class="hero-pill">
+          <span class="pill-highlight">Streamable HTTP MCP</span>
+          <span>•</span>
+          <span>Zero Host Leaks</span>
+          <span>•</span>
+          <span>Non-Root Sandboxes</span>
+        </div>
+
+        <h1 class="hero-title">
+          <span>The Private Execution Layer</span><br/>
+          for AI Coding Agents.
+        </h1>
+
+        <p class="hero-lead">
+          Cloud Harness MCP connects Claude Code, Cursor, Codex, and ChatGPT to isolated Docker workspaces with 52 precision coding tools — while keeping secrets and host daemons completely air-gapped.
+        </p>
+
+        <div class="hero-buttons">
+          <a href="#clients" class="btn btn-primary" style="padding: 0.75rem 1.75rem; font-size: 0.95rem;">
+            Get Started →
+          </a>
+          <a href="#architecture" class="btn btn-ghost" style="padding: 0.75rem 1.75rem; font-size: 0.95rem;">
+            Read the Architecture ↓
+          </a>
+        </div>
+
+        <!-- Stage Window -->
+        <div class="stage-window">
+          <div class="stage-header">
+            <div class="stage-tabs">
+              <button class="stage-tab active" onclick="switchStage('workspace', this)">Workspace Isolation</button>
+              <button class="stage-tab" onclick="switchStage('stream', this)">Streamable HTTP MCP</button>
+              <button class="stage-tab" onclick="switchStage('github', this)">Zero-Disk GitHub Broker</button>
+            </div>
+            <span style="font-family: var(--font-mono); font-size: 0.75rem; color: var(--accent-emerald);">● RUNNER ONLINE</span>
+          </div>
+          <div class="stage-body" id="stageContent">
+            <div>
+              <h3 style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.75rem;">One Trusted Owner. Zero Host Spillover.</h3>
+              <p style="color: var(--text-secondary); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem;">
+                Unlike running agent commands directly on your workstation or in insecure multi-tenant clusters, Cloud Harness enforces a strict boundary between the control plane and ephemeral non-root executors.
+              </p>
+              <div style="display: flex; flex-direction: column; gap: 0.75rem; font-size: 0.88rem; color: var(--text-secondary);">
+                <div style="display: flex; gap: 0.5rem; align-items: center;">
+                  <span style="color: var(--accent-emerald);">✓</span> Network mode defaults to <code>none</code>
+                </div>
+                <div style="display: flex; gap: 0.5rem; align-items: center;">
+                  <span style="color: var(--accent-emerald);">✓</span> Automatic TTL container eviction upon completion
+                </div>
+                <div style="display: flex; gap: 0.5rem; align-items: center;">
+                  <span style="color: var(--accent-emerald);">✓</span> GitHub push tokens never touch the executor filesystem
+                </div>
+              </div>
+            </div>
+            <div class="code-display">
+              <span style="color: #64748b;">// 1. Client calls workspace_open via MCP</span><br/>
+              <span style="color: #38bdf8;">POST</span> /mcp<br/>
+              <span style="color: #f59e0b;">{</span><br/>
+              &nbsp;&nbsp;<span style="color: #cbd5e1;">"method"</span>: <span style="color: #10b981;">"workspace_open"</span>,<br/>
+              &nbsp;&nbsp;<span style="color: #cbd5e1;">"params"</span>: <span style="color: #f59e0b;">{</span><br/>
+              &nbsp;&nbsp;&nbsp;&nbsp;<span style="color: #cbd5e1;">"repo"</span>: <span style="color: #10b981;">"github.com/corp/core-api"</span><br/>
+              &nbsp;&nbsp;<span style="color: #f59e0b;">}</span><br/>
+              <span style="color: #f59e0b;">}</span><br/><br/>
+              <span style="color: #64748b;">// 2. Control plane validates & spawns sandbox</span><br/>
+              <span style="color: #10b981;">← 200 OK: workspaceId = "ws_01j9a3bf8e"</span><br/>
+              <span style="color: #64748b;">// Executor container spawned (UID: 1000, read-only root)</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Animated Architecture Section -->
+      <section class="section-container" id="architecture">
+        <div class="section-intro">
+          <div class="section-label">Architecture Diagram</div>
+          <h2 class="section-headline">Boundary Separation & Data Isolation</h2>
+          <p style="color: var(--text-secondary); font-size: 1.05rem;">
+            Internet-facing request handling is kept away from Docker authority, and repository credentials never enter long-lived executors.
+          </p>
+        </div>
+
+        <div class="architecture-card">
+          <svg class="svg-linear-diagram" viewBox="0 0 1000 420">
+            <defs>
+              <linearGradient id="lineGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+                <stop offset="0%" stop-color="#6366f1" />
+                <stop offset="100%" stop-color="#38bdf8" />
+              </linearGradient>
+            </defs>
+
+            <!-- Boundaries -->
+            <rect x="20" y="30" width="220" height="360" rx="10" fill="#0d1017" stroke="var(--border-subtle)" />
+            <text x="40" y="60" fill="var(--text-tertiary)" font-family="var(--font-mono)" font-size="11" font-weight="600">01. INGRESS & CLIENT</text>
+
+            <rect x="270" y="30" width="370" height="360" rx="10" fill="#0d1017" stroke="var(--border-subtle)" />
+            <text x="290" y="60" fill="var(--accent-indigo)" font-family="var(--font-mono)" font-size="11" font-weight="600">02. TRUSTED CONTROL PLANE</text>
+
+            <rect x="670" y="30" width="310" height="360" rx="10" fill="#0d1017" stroke="var(--border-subtle)" />
+            <text x="690" y="60" fill="var(--accent-emerald)" font-family="var(--font-mono)" font-size="11" font-weight="600">03. TIME-BOUND EXECUTOR</text>
+
+            <!-- Nodes -->
+            <!-- AI Client -->
+            <rect x="40" y="90" width="180" height="65" rx="8" fill="#151922" stroke="var(--border-subtle)" />
+            <text x="55" y="122" fill="#fff" font-size="13" font-weight="600">AI Client / IDE</text>
+            <text x="55" y="142" fill="var(--text-tertiary)" font-size="11">Claude Code • Cursor</text>
+
+            <!-- Ingress -->
+            <rect x="40" y="240" width="180" height="65" rx="8" fill="#151922" stroke="var(--border-subtle)" />
+            <text x="55" y="272" fill="#fff" font-size="13" font-weight="600">Ingress Proxy</text>
+            <text x="55" y="292" fill="var(--text-tertiary)" font-size="11">Cloudflare Access SSO</text>
+
+            <!-- Stateless API -->
+            <rect x="290" y="90" width="150" height="65" rx="8" fill="#151922" stroke="var(--border-subtle)" />
+            <text x="305" y="122" fill="#fff" font-size="13" font-weight="600">Stateless MCP</text>
+            <text x="305" y="142" fill="var(--text-tertiary)" font-size="11">Schema Validation</text>
+
+            <!-- Trusted Runner -->
+            <rect x="470" y="90" width="150" height="65" rx="8" fill="#151922" stroke="var(--border-accent)" />
+            <text x="485" y="122" fill="#fff" font-size="13" font-weight="600">Trusted Runner</text>
+            <text x="485" y="142" fill="var(--text-tertiary)" font-size="11">Policy & Docker Auth</text>
+
+            <!-- Broker -->
+            <rect x="470" y="240" width="150" height="65" rx="8" fill="#151922" stroke="var(--border-subtle)" />
+            <text x="485" y="272" fill="#fff" font-size="13" font-weight="600">GitHub Broker</text>
+            <text x="485" y="292" fill="var(--text-tertiary)" font-size="11">Short-lived Stdin Token</text>
+
+            <!-- Executor Sandbox -->
+            <rect x="690" y="90" width="270" height="110" rx="8" fill="#151922" stroke="rgba(16, 185, 129, 0.4)" />
+            <text x="710" y="125" fill="var(--accent-emerald)" font-size="14" font-weight="700">Docker Executor</text>
+            <text x="710" y="150" fill="var(--text-secondary)" font-size="11">UID: 1000 • Read-only root • Net: None</text>
+            <text x="710" y="172" fill="var(--text-tertiary)" font-size="11">Isolated Repo Clone & AST Tools</text>
+
+            <!-- Ephemeral Helper -->
+            <rect x="690" y="240" width="270" height="65" rx="8" fill="#151922" stroke="rgba(56, 189, 248, 0.4)" />
+            <text x="710" y="272" fill="var(--accent-sky)" font-size="13" font-weight="600">Ephemeral Git Helper</text>
+            <text x="710" y="292" fill="var(--text-tertiary)" font-size="11">Stdin Transfer → GitHub Origin</text>
+
+            <!-- Paths -->
+            <path d="M 130 155 L 130 240" stroke="rgba(255,255,255,0.15)" stroke-width="1.5" stroke-dasharray="4 4" />
+            <path d="M 220 272 L 255 272 L 255 122 L 290 122" stroke="rgba(255,255,255,0.15)" stroke-width="1.5" />
+            <path d="M 440 122 L 470 122" stroke="var(--accent-indigo)" stroke-width="2" />
+            <path d="M 620 122 L 690 122" stroke="var(--accent-emerald)" stroke-width="2" />
+            <path d="M 545 155 L 545 240" stroke="rgba(255,255,255,0.15)" stroke-width="1.5" />
+            <path d="M 620 272 L 690 272" stroke="var(--accent-sky)" stroke-width="2" />
+
+            <!-- Animated Light Pulses -->
+            <circle r="4" fill="#38bdf8">
+              <animateMotion dur="4s" repeatCount="indefinite" path="M 130 155 L 130 240 L 255 240 L 255 122 L 290 122 L 440 122 L 470 122 L 620 122 L 690 122" />
+            </circle>
+
+            <circle r="3.5" fill="#10b981">
+              <animateMotion dur="4s" begin="2s" repeatCount="indefinite" path="M 545 155 L 545 240 L 620 272 L 690 272" />
+            </circle>
+          </svg>
+        </div>
+      </section>
+
+      <!-- Features Grid -->
+      <section class="section-container" id="features">
+        <div class="section-intro">
+          <div class="section-label">Core Capabilities</div>
+          <h2 class="section-headline">Engineered for Autonomous Reliability</h2>
+          <p style="color: var(--text-secondary); font-size: 1.05rem;">
+            A complete suite of primitives allowing your agents to browse, refactor, test, and commit code safely.
+          </p>
+        </div>
+
+        <div class="features-grid">
+          <div class="feature-card">
+            <div class="feature-icon-wrap">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>
+              </svg>
+            </div>
+            <div>
+              <h3>Structural AST Intelligence</h3>
+              <p>Execute syntax-aware pattern searches and atomic rewrites across TypeScript, Python, Go, and Rust without broken regex edits.</p>
+            </div>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon-wrap">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M4 17l6-6-6-6M12 19h8"/>
+              </svg>
+            </div>
+            <div>
+              <h3>Persistent PTY & Shells</h3>
+              <p>Run long-running builds, live test watchers, or REPL sessions with full signal handling, resize support, and cursor navigation.</p>
+            </div>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon-wrap">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+              </svg>
+            </div>
+            <div>
+              <h3>Credential-Isolated Git</h3>
+              <p>Fetch and push using short-lived GitHub App tokens transferred over stdin to an ephemeral helper. Push keys never touch executor disks.</p>
+            </div>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon-wrap">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/>
+              </svg>
+            </div>
+            <div>
+              <h3>Isolated Worktrees</h3>
+              <p>Spawn instant Git worktree branches for subagent investigations, preventing concurrent edit collisions or dirty git checkouts.</p>
+            </div>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon-wrap">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/>
+              </svg>
+            </div>
+            <div>
+              <h3>DAG Task Graphs</h3>
+              <p>Dispatch multi-stage task graphs with explicit dependency barriers, stage rollbacks, and structured artifact collections.</p>
+            </div>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon-wrap">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+              </svg>
+            </div>
+            <div>
+              <h3>Time-To-Live Hard Stops</h3>
+              <p>Every workspace has strict execution deadlines. Abandoned sessions are automatically reclaimed and removed from Docker memory.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- 3-Step Lifecycle -->
+        <div class="lifecycle-wrap" id="how-it-works">
+          <div class="steps-row">
+            <div>
+              <div class="step-num">STEP 01</div>
+              <h3 class="step-title">Open & Isolate</h3>
+              <p class="step-desc">Agent calls <code>workspace_open</code> with a target repo. The runner clones via an ephemeral helper and boots a fresh non-root container in seconds.</p>
+            </div>
+            <div>
+              <div class="step-num">STEP 02</div>
+              <h3 class="step-title">Explore & Execute</h3>
+              <p class="step-desc">Agent inspects files, runs tests, triggers AST refactors, or builds Docker images inside the constrained container boundaries.</p>
+            </div>
+            <div>
+              <div class="step-num">STEP 03</div>
+              <h3 class="step-title">Push & Purge</h3>
+              <p class="step-desc">Agent stages clean commits. The broker securely pushes via short-lived GitHub App tokens, and <code>workspace_close</code> wipes all state.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Client Integrations Grid -->
+      <section class="section-container" id="clients">
+        <div class="section-intro">
+          <div class="section-label">Seamless Integration</div>
+          <h2 class="section-headline">Connect Your Preferred AI Tool</h2>
+          <p style="color: var(--text-secondary); font-size: 1.05rem;">
+            Configured in seconds via Streamable HTTP headers or Cloudflare Access OAuth.
+          </p>
+        </div>
+
+        <div class="clients-grid">
+          <div class="client-box active" onclick="showConfig('claude')">
+            <div class="client-name">Claude Code</div>
+            <div class="client-badge">CLI / Terminal</div>
+          </div>
+          <div class="client-box" onclick="showConfig('cursor')">
+            <div class="client-name">Cursor IDE</div>
+            <div class="client-badge">Editor Extension</div>
+          </div>
+          <div class="client-box" onclick="showConfig('chatgpt')">
+            <div class="client-name">ChatGPT</div>
+            <div class="client-badge">Managed OAuth</div>
+          </div>
+          <div class="client-box" onclick="showConfig('codex')">
+            <div class="client-name">Codex CLI</div>
+            <div class="client-badge">config.toml</div>
+          </div>
+        </div>
+
+        <div class="code-display" style="margin-top: 1.5rem; max-width: 900px; margin-left: auto; margin-right: auto;" id="clientConfigBox">
+          <span style="color: #64748b;"># Run in your terminal to connect Claude Code</span><br/>
+          claude mcp add cloud-harness \<br/>
+          &nbsp;&nbsp;--transport http \<br/>
+          &nbsp;&nbsp;https://api.harness.zuey.me/mcp \<br/>
+          &nbsp;&nbsp;--header "Authorization: Bearer YOUR_OPERATOR_KEY"
+        </div>
+      </section>
+
+      <!-- Final CTA -->
+      <section class="section-container">
+        <div class="cta-card">
+          <h2 style="font-size: 2.4rem; font-weight: 700; margin-bottom: 1rem;">
+            Give Your Agents Real Power. Safely.
+          </h2>
+          <p style="color: var(--text-secondary); max-width: 600px; margin: 0 auto 2.5rem; font-size: 1.05rem;">
+            Cloud Harness MCP is open-source under the MIT license and ready for production deployment on Docker or VPS.
+          </p>
+          <div style="display: flex; justify-content: center; gap: 1rem;">
+            <a href="https://docs.harness.agentkit.best/getting-started" target="_blank" class="btn btn-primary" style="padding: 0.8rem 2rem; font-size: 0.95rem;">
+              Read Documentation ↗
+            </a>
+            <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank" class="btn btn-ghost" style="padding: 0.8rem 2rem; font-size: 0.95rem;">
+              View on GitHub
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="footer-simple">
+      <div>
+        <span>Cloud Harness MCP • MIT Licensed</span>
+      </div>
+      <div style="display: flex; gap: 1.5rem;">
+        <a href="https://docs.harness.agentkit.best" target="_blank">Docs</a>
+        <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank">GitHub</a>
+        <a href="../privacy.html">Privacy</a>
+        <a href="../terms.html">Terms</a>
+      </div>
+    </footer>
+
+    <!-- Interactive Script -->
+    <script>
+      function switchStage(tab, btn) {
+        document.querySelectorAll('.stage-tab').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const box = document.getElementById('stageContent');
+        if (tab === 'workspace') {
+          box.innerHTML = `
+            <div>
+              <h3 style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.75rem;">One Trusted Owner. Zero Host Spillover.</h3>
+              <p style="color: var(--text-secondary); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem;">
+                Unlike running agent commands directly on your workstation or in insecure multi-tenant clusters, Cloud Harness enforces a strict boundary between the control plane and ephemeral non-root executors.
+              </p>
+              <div style="display: flex; flex-direction: column; gap: 0.75rem; font-size: 0.88rem; color: var(--text-secondary);">
+                <div style="display: flex; gap: 0.5rem; align-items: center;"><span style="color: var(--accent-emerald);">✓</span> Network mode defaults to <code>none</code></div>
+                <div style="display: flex; gap: 0.5rem; align-items: center;"><span style="color: var(--accent-emerald);">✓</span> Automatic TTL container eviction upon completion</div>
+                <div style="display: flex; gap: 0.5rem; align-items: center;"><span style="color: var(--accent-emerald);">✓</span> GitHub push tokens never touch the executor filesystem</div>
+              </div>
+            </div>
+            <div class="code-display">
+              <span style="color: #64748b;">// 1. Client calls workspace_open via MCP</span><br/>
+              <span style="color: #38bdf8;">POST</span> /mcp<br/>
+              <span style="color: #f59e0b;">{</span><br/>
+              &nbsp;&nbsp;<span style="color: #cbd5e1;">"method"</span>: <span style="color: #10b981;">"workspace_open"</span>,<br/>
+              &nbsp;&nbsp;<span style="color: #cbd5e1;">"params"</span>: <span style="color: #f59e0b;">{</span><br/>
+              &nbsp;&nbsp;&nbsp;&nbsp;<span style="color: #cbd5e1;">"repo"</span>: <span style="color: #10b981;">"github.com/corp/core-api"</span><br/>
+              &nbsp;&nbsp;<span style="color: #f59e0b;">}</span><br/>
+              <span style="color: #f59e0b;">}</span><br/><br/>
+              <span style="color: #64748b;">// 2. Control plane validates & spawns sandbox</span><br/>
+              <span style="color: #10b981;">← 200 OK: workspaceId = "ws_01j9a3bf8e"</span><br/>
+              <span style="color: #64748b;">// Executor container spawned (UID: 1000, read-only root)</span>
+            </div>
+          `;
+        } else if (tab === 'stream') {
+          box.innerHTML = `
+            <div>
+              <h3 style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.75rem;">Streamable HTTP Transport</h3>
+              <p style="color: var(--text-secondary); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem;">
+                True streaming responses allow agents to stream real-time test execution output, grep search progress, and task DAG events without blocking timeouts.
+              </p>
+              <div style="display: flex; flex-direction: column; gap: 0.75rem; font-size: 0.88rem; color: var(--text-secondary);">
+                <div style="display: flex; gap: 0.5rem; align-items: center;"><span style="color: var(--accent-emerald);">✓</span> HTTP chunked streaming with SSE fallback</div>
+                <div style="display: flex; gap: 0.5rem; align-items: center;"><span style="color: var(--accent-emerald);">✓</span> Cursor-based pagination & truncation protection</div>
+              </div>
+            </div>
+            <div class="code-display">
+              <span style="color: #64748b;">// Streaming bash command execution</span><br/>
+              <span style="color: #38bdf8;">POST</span> /mcp/stream [workspace: ws_01j9a3bf8e]<br/>
+              <span style="color: #10b981;">event: stdout</span> data: "PASS test/unit/auth.test.ts"<br/>
+              <span style="color: #10b981;">event: stdout</span> data: "PASS test/unit/runner.test.ts"<br/>
+              <span style="color: #10b981;">event: complete</span> data: {"exitCode": 0, "durationMs": 840}
+            </div>
+          `;
+        } else if (tab === 'github') {
+          box.innerHTML = `
+            <div>
+              <h3 style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.75rem;">Zero-Disk Token Pipeline</h3>
+              <p style="color: var(--text-secondary); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem;">
+                GitHub App private keys reside exclusively in the runner control memory. Installation tokens are generated per-push and piped over stdin to an ephemeral git helper.
+              </p>
+              <div style="display: flex; flex-direction: column; gap: 0.75rem; font-size: 0.88rem; color: var(--text-secondary);">
+                <div style="display: flex; gap: 0.5rem; align-items: center;"><span style="color: var(--accent-emerald);">✓</span> No persistent tokens on disk or in .git/config</div>
+                <div style="display: flex; gap: 0.5rem; align-items: center;"><span style="color: var(--accent-emerald);">✓</span> Ephemeral token validity window of 60 seconds</div>
+              </div>
+            </div>
+            <div class="code-display">
+              <span style="color: #64748b;">// GitHub App Token Staging Sequence</span><br/>
+              1. Runner requests installation token for repo<br/>
+              2. Ephemeral git helper spawned with token on stdin<br/>
+              3. git push origin HEAD:refs/heads/branch<br/>
+              4. Helper terminates immediately & token wiped
+            </div>
+          `;
+        }
+      }
+
+      function showConfig(client) {
+        document.querySelectorAll('.client-box').forEach(b => b.classList.remove('active'));
+        event.currentTarget.classList.add('active');
+        const box = document.getElementById('clientConfigBox');
+        if (client === 'claude') {
+          box.innerHTML = `
+            <span style="color: #64748b;"># Run in your terminal to connect Claude Code</span><br/>
+            claude mcp add cloud-harness \\<br/>
+            &nbsp;&nbsp;--transport http \\<br/>
+            &nbsp;&nbsp;https://api.harness.zuey.me/mcp \\<br/>
+            &nbsp;&nbsp;--header "Authorization: Bearer YOUR_OPERATOR_KEY"
+          `;
+        } else if (client === 'cursor') {
+          box.innerHTML = `
+            <span style="color: #64748b;">// Add to .cursor/mcp.json or global settings</span><br/>
+            {<br/>
+            &nbsp;&nbsp;"mcpServers": {<br/>
+            &nbsp;&nbsp;&nbsp;&nbsp;"cloud-harness": {<br/>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"url": "https://api.harness.zuey.me/mcp",<br/>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"headers": { "Authorization": "Bearer YOUR_OPERATOR_KEY" }<br/>
+            &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+            &nbsp;&nbsp;}<br/>
+            }
+          `;
+        } else if (client === 'chatgpt') {
+          box.innerHTML = `
+            <span style="color: #64748b;"># ChatGPT Developer Mode / Custom GPT Connector</span><br/>
+            Endpoint: https://harness.zuey.me/mcp<br/>
+            Authentication: Managed OAuth (Cloudflare Access SSO)<br/>
+            Scopes: repo:read, workspace:execute
+          `;
+        } else if (client === 'codex') {
+          box.innerHTML = `
+            <span style="color: #64748b;"># Add to ~/.codex/config.toml</span><br/>
+            [mcp_servers.cloud_harness]<br/>
+            url = "https://api.harness.zuey.me/mcp"<br/>
+            headers = { Authorization = "Bearer YOUR_OPERATOR_KEY" }
+          `;
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/site/variants/variant-3-bento-sandbox.html
+++ b/site/variants/variant-3-bento-sandbox.html
@@ -1,0 +1,756 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Cloud Harness MCP — Bento Grid & Interactive Visual Sandbox for Autonomous AI Agents."
+    />
+    <title>Cloud Harness MCP // Visual Bento Sandbox</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&family=Fira+Code:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg: #0b0f19;
+        --bg-card: rgba(22, 30, 49, 0.65);
+        --bg-card-solid: #151d30;
+        --border-glass: rgba(255, 255, 255, 0.08);
+        --border-hover: rgba(147, 51, 234, 0.4);
+        --purple-accent: #9333ea;
+        --purple-glow: rgba(147, 51, 234, 0.25);
+        --cyan-accent: #06b6d4;
+        --emerald-accent: #10b981;
+        --pink-accent: #ec4899;
+        --text-main: #f8fafc;
+        --text-sub: #94a3b8;
+        --text-dim: #64748b;
+        --font-sans: "Plus Jakarta Sans", sans-serif;
+        --font-display: "Space Grotesk", sans-serif;
+        --font-mono: "Fira Code", monospace;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        background-color: var(--bg);
+        color: var(--text-main);
+        font-family: var(--font-sans);
+        line-height: 1.6;
+        overflow-x: hidden;
+        background-image: 
+          radial-gradient(circle at 20% 15%, rgba(147, 51, 234, 0.12) 0%, transparent 45%),
+          radial-gradient(circle at 80% 25%, rgba(6, 182, 212, 0.12) 0%, transparent 45%);
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      /* Navbar */
+      .navbar {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        background: rgba(11, 15, 25, 0.85);
+        backdrop-filter: blur(16px);
+        border-bottom: 1px solid var(--border-glass);
+      }
+
+      .nav-container {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 1.1rem 1.75rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .logo {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: 1.25rem;
+      }
+
+      .logo-pill {
+        background: linear-gradient(135deg, var(--purple-accent), var(--cyan-accent));
+        width: 32px;
+        height: 32px;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-shadow: 0 0 16px var(--purple-glow);
+      }
+
+      .nav-items {
+        display: flex;
+        gap: 2rem;
+        font-weight: 500;
+        font-size: 0.95rem;
+      }
+
+      .nav-items a:hover {
+        color: var(--cyan-accent);
+      }
+
+      .btn-bento {
+        font-family: var(--font-sans);
+        font-weight: 600;
+        font-size: 0.9rem;
+        padding: 0.6rem 1.25rem;
+        border-radius: 8px;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
+
+      .btn-bento-primary {
+        background: linear-gradient(135deg, #a855f7 0%, #6366f1 100%);
+        color: white;
+        border: none;
+        box-shadow: 0 4px 20px var(--purple-glow);
+      }
+
+      .btn-bento-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 25px rgba(168, 85, 247, 0.45);
+      }
+
+      .btn-bento-outline {
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid var(--border-glass);
+        color: var(--text-main);
+      }
+
+      .btn-bento-outline:hover {
+        border-color: rgba(255, 255, 255, 0.2);
+        background: rgba(255, 255, 255, 0.08);
+      }
+
+      /* Hero Section */
+      .hero-wrap {
+        max-width: 1280px;
+        margin: 3.5rem auto 4rem;
+        padding: 0 1.75rem;
+        text-align: center;
+      }
+
+      .bento-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.4rem 1rem;
+        border-radius: 999px;
+        background: rgba(147, 51, 234, 0.12);
+        border: 1px solid rgba(147, 51, 234, 0.3);
+        color: #d8b4fe;
+        font-size: 0.85rem;
+        font-weight: 600;
+        margin-bottom: 1.5rem;
+      }
+
+      .hero-heading {
+        font-family: var(--font-display);
+        font-size: clamp(2.8rem, 6vw, 4.6rem);
+        font-weight: 800;
+        line-height: 1.1;
+        letter-spacing: -0.03em;
+        margin-bottom: 1.5rem;
+      }
+
+      .hero-gradient-text {
+        background: linear-gradient(135deg, #c084fc 0%, #38bdf8 50%, #4ade80 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+
+      .hero-sub {
+        color: var(--text-sub);
+        font-size: 1.2rem;
+        max-width: 760px;
+        margin: 0 auto 2.5rem;
+      }
+
+      /* Interactive Live Sandbox Simulator Widget */
+      .sandbox-simulator {
+        background: var(--bg-card-solid);
+        border: 1px solid var(--border-glass);
+        border-radius: 16px;
+        padding: 1.5rem;
+        max-width: 1000px;
+        margin: 0 auto 5rem;
+        box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+      }
+
+      .sim-controls {
+        display: flex;
+        gap: 0.75rem;
+        justify-content: center;
+        flex-wrap: wrap;
+        margin-bottom: 1.5rem;
+      }
+
+      .sim-btn {
+        padding: 0.65rem 1.25rem;
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid var(--border-glass);
+        color: var(--text-sub);
+        font-family: var(--font-sans);
+        font-weight: 600;
+        font-size: 0.88rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        transition: all 0.2s ease;
+      }
+
+      .sim-btn.active, .sim-btn:hover {
+        background: rgba(147, 51, 234, 0.2);
+        border-color: var(--purple-accent);
+        color: white;
+      }
+
+      .sim-window {
+        background: #080b13;
+        border: 1px solid var(--border-glass);
+        border-radius: 12px;
+        padding: 1.5rem;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        text-align: left;
+        min-height: 280px;
+        color: #e2e8f0;
+      }
+
+      /* Bento Grid Section */
+      .bento-section {
+        max-width: 1280px;
+        margin: 4rem auto 6rem;
+        padding: 0 1.75rem;
+      }
+
+      .bento-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1.5rem;
+      }
+
+      .bento-card {
+        background: var(--bg-card);
+        backdrop-filter: blur(12px);
+        border: 1px solid var(--border-glass);
+        border-radius: 16px;
+        padding: 2rem;
+        position: relative;
+        overflow: hidden;
+        transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+      }
+
+      .bento-card:hover {
+        border-color: var(--border-hover);
+        transform: translateY(-4px);
+        box-shadow: 0 12px 30px var(--purple-glow);
+      }
+
+      .span-2 {
+        grid-column: span 2;
+      }
+
+      .span-3 {
+        grid-column: span 3;
+      }
+
+      .bento-badge {
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        padding: 3px 8px;
+        border-radius: 6px;
+        display: inline-block;
+        margin-bottom: 1rem;
+      }
+
+      .badge-purple { background: rgba(147, 51, 234, 0.2); color: #d8b4fe; border: 1px solid rgba(147, 51, 234, 0.4); }
+      .badge-cyan { background: rgba(6, 182, 212, 0.2); color: #67e8f9; border: 1px solid rgba(6, 182, 212, 0.4); }
+      .badge-emerald { background: rgba(16, 185, 129, 0.2); color: #6ee7b7; border: 1px solid rgba(16, 185, 129, 0.4); }
+
+      .bento-title {
+        font-family: var(--font-display);
+        font-size: 1.5rem;
+        font-weight: 700;
+        margin-bottom: 0.75rem;
+      }
+
+      .bento-desc {
+        color: var(--text-sub);
+        font-size: 0.95rem;
+        line-height: 1.6;
+        margin-bottom: 1.5rem;
+      }
+
+      .pill-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 1rem;
+      }
+
+      .pill-tag {
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid var(--border-glass);
+        font-size: 0.8rem;
+        font-family: var(--font-mono);
+        padding: 0.3rem 0.6rem;
+        border-radius: 6px;
+        color: #cbd5e1;
+      }
+
+      /* Animated SVG Flow in Bento */
+      .svg-bento-flow {
+        width: 100%;
+        height: auto;
+        display: block;
+        margin-top: 1.5rem;
+      }
+
+      /* Client Selector */
+      .client-bento-tabs {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1.5rem;
+        flex-wrap: wrap;
+      }
+
+      .client-tab-bento {
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid var(--border-glass);
+        border-radius: 6px;
+        color: var(--text-sub);
+        font-size: 0.85rem;
+        font-weight: 600;
+        padding: 0.4rem 0.8rem;
+        cursor: pointer;
+      }
+
+      .client-tab-bento.active {
+        background: var(--cyan-accent);
+        color: #0b0f19;
+        font-weight: 700;
+      }
+
+      /* FAQ Section */
+      .faq-wrap {
+        max-width: 900px;
+        margin: 6rem auto;
+        padding: 0 1.75rem;
+      }
+
+      .faq-item {
+        background: var(--bg-card);
+        border: 1px solid var(--border-glass);
+        border-radius: 10px;
+        margin-bottom: 1rem;
+        overflow: hidden;
+      }
+
+      .faq-q {
+        padding: 1.25rem 1.5rem;
+        font-weight: 600;
+        font-size: 1.05rem;
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .faq-a {
+        padding: 0 1.5rem 1.25rem;
+        color: var(--text-sub);
+        font-size: 0.95rem;
+        line-height: 1.6;
+        display: none;
+      }
+
+      .faq-item.open .faq-a {
+        display: block;
+      }
+
+      /* CTA */
+      .bento-cta {
+        background: linear-gradient(135deg, rgba(147, 51, 234, 0.25) 0%, rgba(6, 182, 212, 0.25) 100%), var(--bg-card-solid);
+        border: 1px solid var(--border-hover);
+        border-radius: 20px;
+        padding: 4.5rem 2rem;
+        text-align: center;
+        max-width: 1200px;
+        margin: 5rem auto 0;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+      }
+
+      /* Footer */
+      .footer-bento {
+        border-top: 1px solid var(--border-glass);
+        padding: 3rem 1.75rem;
+        max-width: 1280px;
+        margin: 5rem auto 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        color: var(--text-dim);
+        font-size: 0.9rem;
+      }
+
+      @media (max-width: 960px) {
+        .bento-grid { grid-template-columns: 1fr; }
+        .span-2, .span-3 { grid-column: span 1; }
+        .nav-items { display: none; }
+      }
+    </style>
+  </head>
+  <body id="top">
+    <!-- Navbar -->
+    <header class="navbar">
+      <div class="nav-container">
+        <a href="#top" class="logo">
+          <div class="logo-pill">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5">
+              <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242M12 12v9m-4-4 4 4 4-4"/>
+            </svg>
+          </div>
+          <span>Cloud Harness</span>
+        </a>
+        <nav class="nav-items">
+          <a href="#simulator">Live Sandbox</a>
+          <a href="#bento">Features</a>
+          <a href="#faq">FAQ</a>
+          <a href="https://docs.harness.agentkit.best" target="_blank">Docs ↗</a>
+        </nav>
+        <div style="display: flex; gap: 1rem;">
+          <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank" class="btn-bento btn-bento-outline">
+            GitHub ★
+          </a>
+          <a href="#bento" class="btn-bento btn-bento-primary">
+            Launch Agent
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <!-- Hero -->
+    <main>
+      <section class="hero-wrap">
+        <div class="bento-tag">
+          <span>✨ Streamable HTTP MCP • Non-Root Executors</span>
+        </div>
+        <h1 class="hero-heading">
+          Give AI Coding Agents a<br/>
+          <span class="hero-gradient-text">Dedicated Cloud Sandbox.</span>
+        </h1>
+        <p class="hero-sub">
+          Isolate repository clones, run 52 AST & terminal tools in TTL-limited Docker containers, and eliminate credential leakage forever.
+        </p>
+
+        <!-- Live Sandbox Simulation Widget -->
+        <div class="sandbox-simulator" id="simulator">
+          <div class="sim-controls">
+            <button class="sim-btn active" onclick="runSim(1, this)">1. 🚀 Open Workspace</button>
+            <button class="sim-btn" onclick="runSim(2, this)">2. 🔍 AST Search</button>
+            <button class="sim-btn" onclick="runSim(3, this)">3. ⚙️ Run Test Suite</button>
+            <button class="sim-btn" onclick="runSim(4, this)">4. 🛡️ Push & Auto-Purge</button>
+          </div>
+          <div class="sim-window" id="simOutput">
+            <span style="color: #64748b;">// SIMULATION: Calling mcp.workspace_open()</span><br/>
+            <span style="color: #38bdf8;">[0.00s]</span> Request validated via Cloudflare Access OAuth.<br/>
+            <span style="color: #a855f7;">[0.12s]</span> Ephemeral Git Helper cloned repository into isolated job volume.<br/>
+            <span style="color: #10b981;">[0.28s]</span> Docker executor container started (ID: ws_01j9a3b, UID: 1000, Network: none).<br/>
+            <span style="color: #f59e0b;">[0.30s]</span> 30-minute execution TTL countdown started.<br/>
+            <span style="color: #4ade80; font-weight: bold;">✔ Workspace active and ready for agent instructions.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Bento Grid Section -->
+      <section class="bento-section" id="bento">
+        <div class="bento-grid">
+          <!-- Card 1: Animated Architecture Flow (Span 3) -->
+          <div class="bento-card span-3">
+            <div>
+              <div class="bento-badge badge-purple">Animated System Flow</div>
+              <h3 class="bento-title">How Data and Control Flow Across Sandboxes</h3>
+              <p class="bento-desc">
+                Request handling is cleanly separated from Docker execution authority and GitHub authentication brokers.
+              </p>
+            </div>
+            
+            <!-- Animated SVG Flow -->
+            <svg class="svg-bento-flow" viewBox="0 0 1100 240">
+              <!-- Boxes -->
+              <rect x="20" y="50" width="160" height="90" rx="10" fill="#0d1424" stroke="rgba(255,255,255,0.15)" />
+              <text x="40" y="90" fill="#fff" font-family="var(--font-display)" font-size="14" font-weight="700">AI Client</text>
+              <text x="40" y="115" fill="var(--text-sub)" font-size="11">Claude • Cursor</text>
+
+              <rect x="240" y="50" width="170" height="90" rx="10" fill="#0d1424" stroke="var(--cyan-accent)" />
+              <text x="260" y="90" fill="var(--cyan-accent)" font-family="var(--font-display)" font-size="14" font-weight="700">Ingress & API</text>
+              <text x="260" y="115" fill="var(--text-sub)" font-size="11">SSO Auth + Schema</text>
+
+              <rect x="470" y="50" width="170" height="90" rx="10" fill="#0d1424" stroke="var(--purple-accent)" />
+              <text x="490" y="90" fill="#c084fc" font-family="var(--font-display)" font-size="14" font-weight="700">Trusted Runner</text>
+              <text x="490" y="115" fill="var(--text-sub)" font-size="11">Docker & SQLite Auth</text>
+
+              <rect x="700" y="30" width="200" height="130" rx="12" fill="#0d1424" stroke="var(--emerald-accent)" stroke-width="1.8" />
+              <text x="720" y="70" fill="var(--emerald-accent)" font-family="var(--font-display)" font-size="14" font-weight="700">Docker Executor</text>
+              <text x="720" y="95" fill="var(--text-sub)" font-size="11">Non-Root • Net: None</text>
+              <text x="720" y="118" fill="var(--text-sub)" font-size="11">52 AST & Shell Tools</text>
+              <text x="720" y="140" fill="#fcd34d" font-size="10">TTL: 1800s Auto-Evict</text>
+
+              <rect x="940" y="50" width="140" height="90" rx="10" fill="#0d1424" stroke="rgba(255,255,255,0.15)" />
+              <text x="960" y="90" fill="#fff" font-family="var(--font-display)" font-size="14" font-weight="700">GitHub</text>
+              <text x="960" y="115" fill="var(--text-sub)" font-size="11">Remote Origin</text>
+
+              <!-- Connection Lines -->
+              <path d="M 180 95 L 240 95" stroke="rgba(255,255,255,0.2)" stroke-width="2" stroke-dasharray="4 4" />
+              <path d="M 410 95 L 470 95" stroke="var(--cyan-accent)" stroke-width="2" />
+              <path d="M 640 95 L 700 95" stroke="var(--purple-accent)" stroke-width="2" />
+              <path d="M 900 95 L 940 95" stroke="var(--emerald-accent)" stroke-width="2" />
+
+              <!-- Traveling Packets -->
+              <circle r="4.5" fill="#38bdf8">
+                <animateMotion dur="3.5s" repeatCount="indefinite" path="M 180 95 L 240 95 L 410 95 L 470 95 L 640 95 L 700 95" />
+              </circle>
+              <circle r="4" fill="#10b981">
+                <animateMotion dur="3.5s" begin="1.75s" repeatCount="indefinite" path="M 700 95 L 900 95 L 940 95" />
+              </circle>
+            </svg>
+          </div>
+
+          <!-- Card 2: 52 Tools (Span 2) -->
+          <div class="bento-card span-2">
+            <div>
+              <div class="bento-badge badge-purple">Comprehensive Surface</div>
+              <h3 class="bento-title">52 Precision Coding Primitives</h3>
+              <p class="bento-desc">
+                Everything an autonomous agent needs to inspect repositories, parse syntax trees, execute persistent shell sessions, and manage Git worktrees safely.
+              </p>
+              <div class="pill-tags">
+                <span class="pill-tag">ast_grep</span>
+                <span class="pill-tag">ast_edit</span>
+                <span class="pill-tag">bash_session</span>
+                <span class="pill-tag">git_worktree</span>
+                <span class="pill-tag">task_graph</span>
+                <span class="pill-tag">git_push</span>
+                <span class="pill-tag">skill_run</span>
+                <span class="pill-tag">file_patch</span>
+                <span class="pill-tag">+44 more</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Card 3: Credential Isolation Firewall -->
+          <div class="bento-card">
+            <div>
+              <div class="bento-badge badge-emerald">Zero Leaks</div>
+              <h3 class="bento-title">Credential-Isolated Git Broker</h3>
+              <p class="bento-desc">
+                GitHub App private keys reside exclusively in the runner control memory. Installation tokens are piped over stdio to temporary helpers.
+              </p>
+            </div>
+            <div style="background: rgba(0,0,0,0.3); padding: 1rem; border-radius: 8px; font-family: var(--font-mono); font-size: 0.75rem; color: #a7f3d0;">
+              0 GitHub tokens written to disk<br/>
+              60s Token validity lifespan
+            </div>
+          </div>
+
+          <!-- Card 4: Non-Root Sandboxing -->
+          <div class="bento-card">
+            <div>
+              <div class="bento-badge badge-cyan">Hardened Runtime</div>
+              <h3 class="bento-title">Non-Root Docker Hardening</h3>
+              <p class="bento-desc">
+                Executors run as UID 1000 with read-only root filesystems, memory/CPU caps, and network mode <code>none</code> by default.
+              </p>
+            </div>
+            <div style="background: rgba(0,0,0,0.3); padding: 1rem; border-radius: 8px; font-family: var(--font-mono); font-size: 0.75rem; color: #7dd3fc;">
+              No Docker socket mounts<br/>
+              Strict Linux cgroup bounds
+            </div>
+          </div>
+
+          <!-- Card 5: Multi-Client Hub (Span 2) -->
+          <div class="bento-card span-2">
+            <div>
+              <div class="bento-badge badge-purple">Universal Connect</div>
+              <h3 class="bento-title">Seamless AI Client Connectors</h3>
+              <p class="bento-desc">
+                Works out of the box with all leading agent runtimes through Streamable HTTP or Gateway API keys.
+              </p>
+              <div class="client-bento-tabs">
+                <button class="client-tab-bento active" onclick="switchBentoTab('claude', this)">Claude Code</button>
+                <button class="client-tab-bento" onclick="switchBentoTab('cursor', this)">Cursor IDE</button>
+                <button class="client-tab-bento" onclick="switchBentoTab('chatgpt', this)">ChatGPT</button>
+                <button class="client-tab-bento" onclick="switchBentoTab('codex', this)">Codex</button>
+              </div>
+              <div id="bentoClientBox" style="background: #080b13; padding: 1rem; border-radius: 8px; font-family: var(--font-mono); font-size: 0.8rem; color: #f1f5f9;">
+                claude mcp add cloud-harness --transport http https://api.harness.zuey.me/mcp --header "Authorization: Bearer YOUR_KEY"
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- FAQ Section -->
+      <section class="faq-wrap" id="faq">
+        <h2 style="font-family: var(--font-display); font-size: 2.2rem; text-align: center; margin-bottom: 2.5rem;">
+          Frequently Asked Questions
+        </h2>
+        <div class="faq-item open" onclick="toggleFaq(this)">
+          <div class="faq-q">
+            <span>Why not let AI agents run commands directly on my workstation?</span>
+            <span>+</span>
+          </div>
+          <div class="faq-a">
+            Local execution risks package hallucination attacks, accidental file deletions, and environment pollution. Cloud Harness runs every session in a disposable, bounded container with zero access to your local machine.
+          </div>
+        </div>
+        <div class="faq-item" onclick="toggleFaq(this)">
+          <div class="faq-q">
+            <span>How does the Streamable HTTP MCP transport work?</span>
+            <span>+</span>
+          </div>
+          <div class="faq-a">
+            Streamable HTTP allows real-time chunked command output and events over standard HTTPS with Cloudflare Access OAuth or static Authorization headers.
+          </div>
+        </div>
+        <div class="faq-item" onclick="toggleFaq(this)">
+          <div class="faq-q">
+            <span>What happens if an agent crashes or abandons a workspace?</span>
+            <span>+</span>
+          </div>
+          <div class="faq-a">
+            Every workspace has a strict Time-To-Live (TTL) limit. When the TTL expires, the runner automatically reclaims all Docker containers, removes temporary volumes, and purges state from memory.
+          </div>
+        </div>
+      </section>
+
+      <!-- Bento CTA Banner -->
+      <section style="padding: 0 1.75rem;">
+        <div class="bento-cta">
+          <h2 style="font-family: var(--font-display); font-size: 2.6rem; font-weight: 800; margin-bottom: 1rem;">
+            Ready to Supercharge Your Agents?
+          </h2>
+          <p style="color: var(--text-sub); max-width: 600px; margin: 0 auto 2rem; font-size: 1.1rem;">
+            Deploy Cloud Harness MCP on your VPS or Docker host today under the permissive MIT license.
+          </p>
+          <div style="display: flex; gap: 1rem; justify-content: center;">
+            <a href="https://docs.harness.agentkit.best/getting-started" target="_blank" class="btn-bento btn-bento-primary" style="padding: 0.85rem 2rem; font-size: 1rem;">
+              Get Started Now ↗
+            </a>
+            <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank" class="btn-bento btn-bento-outline" style="padding: 0.85rem 2rem; font-size: 1rem;">
+              View GitHub Repo
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="footer-bento">
+      <div>
+        <span>Cloud Harness MCP // MIT License</span>
+      </div>
+      <div style="display: flex; gap: 1.5rem;">
+        <a href="https://docs.harness.agentkit.best" target="_blank">Documentation</a>
+        <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank">GitHub</a>
+        <a href="../privacy.html">Privacy</a>
+        <a href="../terms.html">Terms</a>
+      </div>
+    </footer>
+
+    <!-- Interactive Script -->
+    <script>
+      function runSim(step, btn) {
+        document.querySelectorAll('.sim-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const out = document.getElementById('simOutput');
+        if (step === 1) {
+          out.innerHTML = `
+            <span style="color: #64748b;">// SIMULATION: Calling mcp.workspace_open()</span><br/>
+            <span style="color: #38bdf8;">[0.00s]</span> Request validated via Cloudflare Access OAuth.<br/>
+            <span style="color: #a855f7;">[0.12s]</span> Ephemeral Git Helper cloned repository into isolated job volume.<br/>
+            <span style="color: #10b981;">[0.28s]</span> Docker executor container started (ID: ws_01j9a3b, UID: 1000, Network: none).<br/>
+            <span style="color: #f59e0b;">[0.30s]</span> 30-minute execution TTL countdown started.<br/>
+            <span style="color: #4ade80; font-weight: bold;">✔ Workspace active and ready for agent instructions.</span>
+          `;
+        } else if (step === 2) {
+          out.innerHTML = `
+            <span style="color: #64748b;">// SIMULATION: Calling mcp.ast_grep()</span><br/>
+            <span style="color: #38bdf8;">[0.00s]</span> Parsing AST syntax trees across 48 source files...<br/>
+            <span style="color: #10b981;">[0.04s]</span> Found 12 matching declaration nodes for 'handleAuth()'<br/>
+            <span style="color: #e2e8f0;">[Match 1] src/auth/jwt.ts:24 - export function handleAuth(req, res)<br/>
+            [Match 2] src/auth/oauth.ts:56 - export async function handleAuth(token)</span><br/>
+            <span style="color: #4ade80; font-weight: bold;">✔ Structural syntax capture delivered to agent context.</span>
+          `;
+        } else if (step === 3) {
+          out.innerHTML = `
+            <span style="color: #64748b;">// SIMULATION: Calling mcp.bash_session()</span><br/>
+            <span style="color: #38bdf8;">[0.00s]</span> Spawning isolated container PTY shell...<br/>
+            <span style="color: #10b981;">[0.45s]</span> Running test suite: vitest run --coverage<br/>
+            <span style="color: #4ade80;">✓ packages/core/test/auth.test.ts (14 tests passed)</span><br/>
+            <span style="color: #4ade80;">✓ packages/runner/test/sandbox.test.ts (8 tests passed)</span><br/>
+            <span style="color: #4ade80; font-weight: bold;">✔ All test suites green (0 host leaks, 0 root privileges).</span>
+          `;
+        } else if (step === 4) {
+          out.innerHTML = `
+            <span style="color: #64748b;">// SIMULATION: Calling mcp.git_push() & mcp.workspace_close()</span><br/>
+            <span style="color: #a855f7;">[0.00s]</span> GitHub App Broker minted 60-second push token over stdin helper.<br/>
+            <span style="color: #10b981;">[0.32s]</span> Branch feat/new-harness successfully pushed to origin.<br/>
+            <span style="color: #ef4444;">[0.45s]</span> Executor container destroyed. Volumes wiped from disk.<br/>
+            <span style="color: #4ade80; font-weight: bold;">✔ Residual state: 0 bytes. All credentials wiped.</span>
+          `;
+        }
+      }
+
+      function switchBentoTab(client, btn) {
+        document.querySelectorAll('.client-tab-bento').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const box = document.getElementById('bentoClientBox');
+        if (client === 'claude') {
+          box.innerText = 'claude mcp add cloud-harness --transport http https://api.harness.zuey.me/mcp --header "Authorization: Bearer YOUR_KEY"';
+        } else if (client === 'cursor') {
+          box.innerText = 'Add to .cursor/mcp.json: { "mcpServers": { "cloud-harness": { "url": "https://api.harness.zuey.me/mcp", "headers": { "Authorization": "Bearer YOUR_KEY" } } } }';
+        } else if (client === 'chatgpt') {
+          box.innerText = 'ChatGPT Developer Connector: https://harness.zuey.me/mcp (Managed OAuth / Cloudflare Access SSO)';
+        } else if (client === 'codex') {
+          box.innerText = 'Add to ~/.codex/config.toml: [mcp_servers.cloud_harness] url = "https://api.harness.zuey.me/mcp" headers = { Authorization = "Bearer YOUR_KEY" }';
+        }
+      }
+
+      function toggleFaq(item) {
+        item.classList.toggle('open');
+      }
+    </script>
+  </body>
+</html>

--- a/site/variants/variant-4-enterprise-defense.html
+++ b/site/variants/variant-4-enterprise-defense.html
@@ -1,0 +1,901 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Cloud Harness MCP — The Zero-Trust Remote Execution Harness for AI-Assisted Software Engineering."
+    />
+    <title>Cloud Harness MCP // Enterprise Defense Edition</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --navy-950: #070d18;
+        --navy-900: #0d1527;
+        --navy-800: #15223c;
+        --navy-700: #1e3156;
+        --blue-accent: #2563eb;
+        --blue-glow: rgba(37, 99, 235, 0.25);
+        --emerald-safe: #10b981;
+        --emerald-glow: rgba(16, 185, 129, 0.2);
+        --gold-shield: #f59e0b;
+        --border-navy: rgba(255, 255, 255, 0.09);
+        --border-hover: rgba(37, 99, 235, 0.4);
+        --text-pure: #ffffff;
+        --text-slate: #94a3b8;
+        --text-dim: #64748b;
+        --font-sans: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        --font-mono: "JetBrains Mono", monospace;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        background-color: var(--navy-950);
+        color: var(--text-pure);
+        font-family: var(--font-sans);
+        line-height: 1.6;
+        overflow-x: hidden;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      /* Enterprise Top Nav */
+      .ent-nav {
+        background: rgba(13, 21, 39, 0.85);
+        backdrop-filter: blur(16px);
+        border-bottom: 1px solid var(--border-navy);
+        position: sticky;
+        top: 0;
+        z-index: 100;
+      }
+
+      .nav-inner {
+        max-width: 1300px;
+        margin: 0 auto;
+        padding: 1.1rem 2rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .shield-logo {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        font-weight: 700;
+        font-size: 1.15rem;
+        letter-spacing: -0.01em;
+      }
+
+      .shield-icon {
+        width: 34px;
+        height: 34px;
+        background: linear-gradient(135deg, var(--blue-accent), #1d4ed8);
+        border-radius: 6px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-shadow: 0 0 14px var(--blue-glow);
+      }
+
+      .nav-links {
+        display: flex;
+        gap: 2rem;
+        font-size: 0.92rem;
+        font-weight: 500;
+        color: var(--text-slate);
+      }
+
+      .nav-links a:hover {
+        color: var(--text-pure);
+      }
+
+      .btn-ent {
+        font-size: 0.88rem;
+        font-weight: 600;
+        padding: 0.6rem 1.25rem;
+        border-radius: 6px;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
+
+      .btn-ent-primary {
+        background: var(--blue-accent);
+        color: white;
+        border: 1px solid #3b82f6;
+        box-shadow: 0 2px 10px var(--blue-glow);
+      }
+
+      .btn-ent-primary:hover {
+        background: #1d4ed8;
+      }
+
+      .btn-ent-outline {
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid var(--border-navy);
+        color: var(--text-slate);
+      }
+
+      .btn-ent-outline:hover {
+        background: rgba(255, 255, 255, 0.08);
+        color: white;
+        border-color: rgba(255, 255, 255, 0.2);
+      }
+
+      /* Hero */
+      .ent-hero {
+        max-width: 1300px;
+        margin: 4.5rem auto 5rem;
+        padding: 0 2rem;
+        display: grid;
+        grid-template-columns: 1.1fr 0.9fr;
+        gap: 3.5rem;
+        align-items: center;
+      }
+
+      .security-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.35rem 0.85rem;
+        background: rgba(37, 99, 235, 0.12);
+        border: 1px solid rgba(37, 99, 235, 0.35);
+        border-radius: 4px;
+        font-family: var(--font-mono);
+        font-size: 0.78rem;
+        color: #93c5fd;
+        font-weight: 600;
+        margin-bottom: 1.5rem;
+      }
+
+      .ent-title {
+        font-size: clamp(2.6rem, 5vw, 3.8rem);
+        font-weight: 800;
+        line-height: 1.12;
+        letter-spacing: -0.03em;
+        margin-bottom: 1.5rem;
+      }
+
+      .ent-desc {
+        color: var(--text-slate);
+        font-size: 1.15rem;
+        line-height: 1.7;
+        margin-bottom: 2rem;
+      }
+
+      .trust-strip {
+        display: flex;
+        gap: 1.5rem;
+        border-top: 1px solid var(--border-navy);
+        padding-top: 1.5rem;
+        font-size: 0.85rem;
+        color: var(--text-slate);
+      }
+
+      .trust-item {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+      }
+
+      /* Security Posture Radar Card */
+      .posture-card {
+        background: var(--navy-900);
+        border: 1px solid var(--border-navy);
+        border-radius: 10px;
+        padding: 2rem;
+        box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+      }
+
+      .posture-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        border-bottom: 1px solid var(--border-navy);
+        padding-bottom: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .posture-list {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .posture-row {
+        background: var(--navy-800);
+        border: 1px solid var(--border-navy);
+        border-radius: 6px;
+        padding: 1rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .posture-name {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+
+      .posture-status {
+        font-family: var(--font-mono);
+        font-size: 0.78rem;
+        padding: 0.25rem 0.6rem;
+        border-radius: 4px;
+        background: rgba(16, 185, 129, 0.15);
+        color: var(--emerald-safe);
+        border: 1px solid rgba(16, 185, 129, 0.3);
+      }
+
+      /* Section Common */
+      .section-wrap {
+        max-width: 1300px;
+        margin: 6rem auto;
+        padding: 0 2rem;
+      }
+
+      .section-header {
+        text-align: center;
+        max-width: 750px;
+        margin: 0 auto 3.5rem;
+      }
+
+      .section-kicker {
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--blue-accent);
+        margin-bottom: 0.5rem;
+        font-weight: 600;
+      }
+
+      .section-title {
+        font-size: 2.3rem;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        margin-bottom: 1rem;
+      }
+
+      /* Animated SVG Topology Blueprint */
+      .defense-blueprint-card {
+        background: #090e1b;
+        border: 1px solid var(--border-navy);
+        border-radius: 12px;
+        padding: 2.5rem;
+        margin-bottom: 3.5rem;
+      }
+
+      .svg-defense-diagram {
+        width: 100%;
+        height: auto;
+        display: block;
+      }
+
+      /* Interactive Threat Defense Topology */
+      .defense-map {
+        background: var(--navy-900);
+        border: 1px solid var(--border-navy);
+        border-radius: 12px;
+        overflow: hidden;
+      }
+
+      .defense-tabs {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        background: #080e1b;
+        border-bottom: 1px solid var(--border-navy);
+      }
+
+      .defense-tab-btn {
+        padding: 1.1rem 1rem;
+        background: transparent;
+        border: none;
+        border-right: 1px solid var(--border-navy);
+        color: var(--text-slate);
+        font-weight: 600;
+        font-size: 0.85rem;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        text-align: center;
+      }
+
+      .defense-tab-btn.active {
+        background: var(--navy-900);
+        color: white;
+        border-bottom: 3px solid var(--blue-accent);
+      }
+
+      .defense-detail-panel {
+        padding: 2.5rem;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 3rem;
+        align-items: center;
+      }
+
+      .threat-box {
+        background: var(--navy-800);
+        border: 1px solid var(--border-navy);
+        border-radius: 8px;
+        padding: 1.5rem;
+        font-family: var(--font-mono);
+        font-size: 0.82rem;
+        color: #cbd5e1;
+        line-height: 1.7;
+      }
+
+      /* Threat Comparison Matrix */
+      .matrix-table-wrap {
+        overflow-x: auto;
+        background: var(--navy-900);
+        border: 1px solid var(--border-navy);
+        border-radius: 10px;
+      }
+
+      .matrix-table {
+        width: 100%;
+        border-collapse: collapse;
+        text-align: left;
+        font-size: 0.92rem;
+      }
+
+      .matrix-table th, .matrix-table td {
+        padding: 1.25rem 1.5rem;
+        border-bottom: 1px solid var(--border-navy);
+      }
+
+      .matrix-table th {
+        background: #09101f;
+        font-weight: 700;
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--text-slate);
+      }
+
+      .danger-col {
+        color: #f87171;
+      }
+
+      .safe-col {
+        color: var(--emerald-safe);
+        font-weight: 600;
+      }
+
+      /* Guarantees Grid */
+      .guarantees-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1.5rem;
+        margin-top: 3rem;
+      }
+
+      .guarantee-card {
+        background: var(--navy-900);
+        border: 1px solid var(--border-navy);
+        border-radius: 8px;
+        padding: 2rem;
+      }
+
+      .guarantee-card h3 {
+        font-size: 1.15rem;
+        color: #93c5fd;
+        margin-bottom: 0.75rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .guarantee-card p {
+        color: var(--text-slate);
+        font-size: 0.92rem;
+        line-height: 1.6;
+      }
+
+      /* CTA Banner */
+      .cta-defense {
+        background: linear-gradient(135deg, #1e3a8a 0%, #0f172a 100%);
+        border: 1px solid #3b82f6;
+        border-radius: 12px;
+        padding: 4.5rem 2rem;
+        text-align: center;
+        box-shadow: 0 10px 40px rgba(37, 99, 235, 0.2);
+        margin-top: 5rem;
+      }
+
+      /* Footer */
+      .ent-footer {
+        border-top: 1px solid var(--border-navy);
+        padding: 3rem 2rem;
+        max-width: 1300px;
+        margin: 5rem auto 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 0.88rem;
+        color: var(--text-dim);
+      }
+
+      @media (max-width: 960px) {
+        .ent-hero { grid-template-columns: 1fr; }
+        .defense-tabs { grid-template-columns: 1fr; }
+        .defense-detail-panel { grid-template-columns: 1fr; }
+        .guarantees-grid { grid-template-columns: 1fr; }
+        .nav-links { display: none; }
+      }
+    </style>
+  </head>
+  <body id="top">
+    <!-- Enterprise Navigation -->
+    <header class="ent-nav">
+      <div class="nav-inner">
+        <a href="#top" class="shield-logo">
+          <div class="shield-icon">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.3">
+              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+            </svg>
+          </div>
+          <span>Cloud Harness <span style="color: var(--blue-accent);">ENTERPRISE</span></span>
+        </a>
+        <nav class="nav-links">
+          <a href="#defense-map">Architecture Topology</a>
+          <a href="#matrix">Threat Matrix</a>
+          <a href="#guarantees">Security Guarantees</a>
+          <a href="https://docs.harness.agentkit.best/security-model" target="_blank">Security Whitepaper ↗</a>
+        </nav>
+        <div style="display: flex; gap: 1rem;">
+          <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank" class="btn-ent btn-ent-outline">
+            GitHub
+          </a>
+          <a href="https://docs.harness.agentkit.best/installation" target="_blank" class="btn-ent btn-ent-primary">
+            Deploy Harness →
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <!-- Hero -->
+    <main>
+      <section class="ent-hero">
+        <div>
+          <div class="security-badge">
+            <span>🛡️ ZERO-TRUST REMOTE EXECUTION HARNESS</span>
+          </div>
+          <h1 class="ent-title">
+            Empower AI Agents.<br/>
+            Protect Infrastructure.<br/>
+            Eliminate Leaks.
+          </h1>
+          <p class="ent-desc">
+            Cloud Harness MCP separates AI request handling from Docker authority. Run arbitrary agent coding tasks inside bounded, non-root Docker sandboxes with zero host mounts and zero disk credentials.
+          </p>
+          <div style="display: flex; gap: 1rem; margin-bottom: 2.5rem;">
+            <a href="https://docs.harness.agentkit.best/getting-started" target="_blank" class="btn-ent btn-ent-primary" style="padding: 0.75rem 1.75rem; font-size: 0.95rem;">
+              Read Getting Started Guide ↗
+            </a>
+            <a href="#defense-map" class="btn-ent btn-ent-outline" style="padding: 0.75rem 1.75rem; font-size: 0.95rem;">
+              Inspect Threat Defense Map ↓
+            </a>
+          </div>
+          <div class="trust-strip">
+            <div class="trust-item">
+              <span style="color: var(--emerald-safe);">✓</span> Single-Owner Threat Model
+            </div>
+            <div class="trust-item">
+              <span style="color: var(--emerald-safe);">✓</span> Ephemeral Stdin Git Helper
+            </div>
+            <div class="trust-item">
+              <span style="color: var(--emerald-safe);">✓</span> Non-Root UID Isolation
+            </div>
+          </div>
+        </div>
+
+        <!-- Security Posture Radar Card -->
+        <div class="posture-card">
+          <div class="posture-header">
+            <div>
+              <div style="font-weight: 700; font-size: 1.1rem;">Security Control Center</div>
+              <div style="font-size: 0.8rem; color: var(--text-slate);">Real-time boundary enforcement status</div>
+            </div>
+            <span style="font-family: var(--font-mono); font-size: 0.75rem; color: var(--emerald-safe);">VERIFIED HARDENED</span>
+          </div>
+          <div class="posture-list">
+            <div class="posture-row">
+              <div>
+                <div class="posture-name">Docker Host Socket Exposure</div>
+                <div style="font-size: 0.78rem; color: var(--text-slate);">API & Ingress completely unmounted</div>
+              </div>
+              <span class="posture-status">ZERO SOCKET MOUNT</span>
+            </div>
+            <div class="posture-row">
+              <div>
+                <div class="posture-name">GitHub App Push Credentials</div>
+                <div style="font-size: 0.78rem; color: var(--text-slate);">Short-lived token streamed via stdio</div>
+              </div>
+              <span class="posture-status">ZERO DISK PERSISTENCE</span>
+            </div>
+            <div class="posture-row">
+              <div>
+                <div class="posture-name">Executor Container Privileges</div>
+                <div style="font-size: 0.78rem; color: var(--text-slate);">Non-root user with read-only root FS</div>
+              </div>
+              <span class="posture-status">UID 1000 ISOLATED</span>
+            </div>
+            <div class="posture-row">
+              <div>
+                <div class="posture-name">Residual State & Garbage Collection</div>
+                <div style="font-size: 0.78rem; color: var(--text-slate);">Strict Time-to-Live bounds with auto-purge</div>
+              </div>
+              <span class="posture-status">AUTOMATIC TTL PURGE</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Threat Defense Topology Map -->
+      <section class="section-wrap" id="defense-map">
+        <div class="section-header">
+          <div class="section-kicker">Architectural Boundaries</div>
+          <h2 class="section-title">The Five-Layer Defense Topology</h2>
+          <p style="color: var(--text-slate);">
+            Click any zone below to examine how Cloud Harness protects your secrets, containers, and repositories at each layer.
+          </p>
+        </div>
+
+        <!-- Animated SVG Blueprint -->
+        <div class="defense-blueprint-card">
+          <svg class="svg-defense-diagram" viewBox="0 0 1000 380">
+            <!-- Layers Boxes -->
+            <rect x="20" y="30" width="160" height="320" rx="8" fill="#0d1424" stroke="var(--border-navy)" />
+            <text x="35" y="60" fill="var(--text-slate)" font-family="var(--font-mono)" font-size="11" font-weight="700">ZONE 01: INGRESS</text>
+
+            <rect x="210" y="30" width="180" height="320" rx="8" fill="#0d1424" stroke="var(--border-navy)" />
+            <text x="225" y="60" fill="#60a5fa" font-family="var(--font-mono)" font-size="11" font-weight="700">ZONE 02: MCP API</text>
+
+            <rect x="420" y="30" width="200" height="320" rx="8" fill="#0d1424" stroke="var(--border-hover)" />
+            <text x="435" y="60" fill="#3b82f6" font-family="var(--font-mono)" font-size="11" font-weight="700">ZONE 03: RUNNER</text>
+
+            <rect x="650" y="30" width="330" height="150" rx="8" fill="#0d1424" stroke="rgba(16, 185, 129, 0.4)" stroke-width="1.6" />
+            <text x="665" y="60" fill="var(--emerald-safe)" font-family="var(--font-mono)" font-size="11" font-weight="700">ZONE 04: NON-ROOT EXECUTOR</text>
+
+            <rect x="650" y="200" width="330" height="150" rx="8" fill="#0d1424" stroke="rgba(245, 158, 11, 0.4)" stroke-width="1.6" />
+            <text x="665" y="230" fill="var(--gold-shield)" font-family="var(--font-mono)" font-size="11" font-weight="700">ZONE 05: EPHEMERAL GIT HELPER</text>
+
+            <!-- Internal Node Elements -->
+            <rect x="35" y="90" width="130" height="60" rx="6" fill="#15223c" />
+            <text x="45" y="125" fill="#fff" font-size="12" font-weight="600">Cloudflare Access</text>
+
+            <rect x="225" y="90" width="150" height="60" rx="6" fill="#15223c" />
+            <text x="235" y="125" fill="#fff" font-size="12" font-weight="600">Stateless RPC Router</text>
+
+            <rect x="435" y="90" width="170" height="60" rx="6" fill="#15223c" stroke="var(--blue-accent)" />
+            <text x="445" y="125" fill="#fff" font-size="12" font-weight="600">Docker Daemon Control</text>
+
+            <rect x="435" y="220" width="170" height="60" rx="6" fill="#15223c" />
+            <text x="445" y="255" fill="#fff" font-size="12" font-weight="600">GitHub App Keyring</text>
+
+            <text x="665" y="95" fill="#fff" font-size="12" font-weight="600">TTL Sandboxed Container</text>
+            <text x="665" y="118" fill="var(--text-slate)" font-size="11">UID 1000 • Read-Only Root • Network None</text>
+
+            <text x="665" y="265" fill="#fff" font-size="12" font-weight="600">Stdin Token Transfer Helper</text>
+            <text x="665" y="288" fill="var(--text-slate)" font-size="11">Origin Push → Ephemeral Exit</text>
+
+            <!-- Connecting Wires with Traveling Security Signals -->
+            <path d="M 165 120 L 225 120" stroke="rgba(255,255,255,0.2)" stroke-width="2" />
+            <path d="M 375 120 L 435 120" stroke="var(--blue-accent)" stroke-width="2" />
+            <path d="M 605 120 L 650 120" stroke="var(--emerald-safe)" stroke-width="2" />
+            <path d="M 605 250 L 650 250" stroke="var(--gold-shield)" stroke-width="2" />
+
+            <circle r="4" fill="#60a5fa">
+              <animateMotion dur="3s" repeatCount="indefinite" path="M 165 120 L 225 120 L 375 120 L 435 120 L 605 120 L 650 120" />
+            </circle>
+
+            <circle r="3.5" fill="#f59e0b">
+              <animateMotion dur="3s" begin="1.5s" repeatCount="indefinite" path="M 520 150 L 520 220 L 605 250 L 650 250" />
+            </circle>
+          </svg>
+        </div>
+
+        <div class="defense-map">
+          <div class="defense-tabs">
+            <button class="defense-tab-btn active" onclick="switchDefense(1, this)">1. Ingress Proxy</button>
+            <button class="defense-tab-btn" onclick="switchDefense(2, this)">2. MCP API</button>
+            <button class="defense-tab-btn" onclick="switchDefense(3, this)">3. Trusted Runner</button>
+            <button class="defense-tab-btn" onclick="switchDefense(4, this)">4. Docker Executor</button>
+            <button class="defense-tab-btn" onclick="switchDefense(5, this)">5. Git Broker</button>
+          </div>
+          <div class="defense-detail-panel" id="defensePanel">
+            <div>
+              <h3 style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.75rem; color: #93c5fd;">
+                Layer 1: Credential-Free Ingress Proxy
+              </h3>
+              <p style="color: var(--text-slate); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem;">
+                The only Internet-exposed service is an Nginx ingress bound to loopback. It verifies Cloudflare Access SSO assertion tokens or gateway headers before proxying requests to the stateless API.
+              </p>
+              <ul style="list-style: none; display: flex; flex-direction: column; gap: 0.6rem; font-size: 0.9rem;">
+                <li><span style="color: var(--blue-accent);">✔</span> Holds zero credentials, certificates, or repository secrets</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Does not join the backend execution network</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Strict rate-limiting and request payload truncation guards</li>
+              </ul>
+            </div>
+            <div class="threat-box">
+              <span style="color: #60a5fa;">// Ingress Security Verification</span><br/>
+              [REQUEST] GET /mcp<br/>
+              [CF-Access-JWT-Assertion] VALID (GitHub Org: @core-team)<br/>
+              [INGRESS] Forwarding to 127.0.0.1:4000 (Internal RPC)<br/>
+              <span style="color: #34d399;">[STATUS] Perimeter Authenticated (0 secrets exposed)</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Threat Comparison Matrix -->
+      <section class="section-wrap" id="matrix">
+        <div class="section-header">
+          <div class="section-kicker">Comparative Analysis</div>
+          <h2 class="section-title">Standard Agent Setup vs Cloud Harness MCP</h2>
+          <p style="color: var(--text-slate);">
+            Why platform engineers refuse raw host execution and choose Cloud Harness.
+          </p>
+        </div>
+
+        <div class="matrix-table-wrap">
+          <table class="matrix-table">
+            <thead>
+              <tr>
+                <th>Threat Surface</th>
+                <th>Standard Agent (Raw Host / VM)</th>
+                <th>Cloud Harness MCP Architecture</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>GitHub Push Credentials</strong></td>
+                <td class="danger-col">Stored in <code>~/.gitconfig</code> or persistent SSH keys</td>
+                <td class="safe-col">Short-lived tokens piped over stdin to ephemeral helper; 0 disk writes</td>
+              </tr>
+              <tr>
+                <td><strong>Docker Daemon Access</strong></td>
+                <td class="danger-col">Agent has direct access to <code>/var/run/docker.sock</code></td>
+                <td class="safe-col">Docker authority strictly confined to trusted runner; executors cannot reach socket</td>
+              </tr>
+              <tr>
+                <td><strong>Container Privileges</strong></td>
+                <td class="danger-col">Runs as <code>root</code> with full syscall capabilities</td>
+                <td class="safe-col">Non-root user (UID 1000), read-only root FS, default network <code>none</code></td>
+              </tr>
+              <tr>
+                <td><strong>Stale State & Crashes</strong></td>
+                <td class="danger-col">Abandoned processes and orphan temp files consume host disk</td>
+                <td class="safe-col">Strict Time-To-Live countdowns auto-evict containers and prune volumes</td>
+              </tr>
+              <tr>
+                <td><strong>Network Exfiltration</strong></td>
+                <td class="danger-col">Full outbound internet access allowed to unknown endpoints</td>
+                <td class="safe-col">Network mode <code>none</code> by default; bridge mode requires explicit owner flag</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Security Guarantees Section with Anchor #guarantees -->
+      <section class="section-wrap" id="guarantees">
+        <div class="section-header">
+          <div class="section-kicker">Verified Standards</div>
+          <h2 class="section-title">Six Hardened Security Guarantees</h2>
+          <p style="color: var(--text-slate);">
+            Every build and release is tested against strict boundary isolation invariants.
+          </p>
+        </div>
+
+        <div class="guarantees-grid">
+          <div class="guarantee-card">
+            <h3>🔒 Strict Non-Root Execution</h3>
+            <p>Executors run under unprivileged UID 1000. Privileged mode, capabilities, and kernel namespace breakouts are strictly blocked.</p>
+          </div>
+          <div class="guarantee-card">
+            <h3>🛡️ Stdin Secret Streaming</h3>
+            <p>GitHub App private keys reside exclusively in the runner control memory. Temporary tokens stream over stdin and vanish immediately.</p>
+          </div>
+          <div class="guarantee-card">
+            <h3>⏱️ Time-To-Live Auto-Eviction</h3>
+            <p>Abandoned workspaces are automatically cleaned up when the execution timer expires, eliminating orphaned processes.</p>
+          </div>
+          <div class="guarantee-card">
+            <h3>🌐 Network Isolation Default</h3>
+            <p>Default network mode is <code>none</code>. Outbound exfiltration to unverified external endpoints is prevented by the container engine.</p>
+          </div>
+          <div class="guarantee-card">
+            <h3>🗄️ Cryptographic State DB</h3>
+            <p>SQLite metadata state tracks active workspace IDs, TTL bounds, and principal authorizations with local encryption.</p>
+          </div>
+          <div class="guarantee-card">
+            <h3>📦 0 Bytes Residual Footprint</h3>
+            <p>Calling <code>workspace_close</code> deletes container volumes and transient checkouts immediately, leaving zero residual disk footprint.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- CTA -->
+      <section class="section-wrap">
+        <div class="cta-defense">
+          <h2 style="font-size: 2.4rem; font-weight: 800; margin-bottom: 1rem;">
+            Hardened Code Intelligence for Your Agent Fleet
+          </h2>
+          <p style="color: #bfdbfe; max-width: 650px; margin: 0 auto 2.5rem; font-size: 1.1rem;">
+            Deploy Cloud Harness MCP with Docker Compose in under 5 minutes and connect Claude Code, Cursor, or ChatGPT securely.
+          </p>
+          <div style="display: flex; gap: 1rem; justify-content: center;">
+            <a href="https://docs.harness.agentkit.best/getting-started" target="_blank" class="btn-ent btn-ent-primary" style="padding: 0.85rem 2rem; font-size: 1rem; background: white; color: #1e3a8a; border-color: white;">
+              Deploy Now ↗
+            </a>
+            <a href="https://docs.harness.agentkit.best/security-model" target="_blank" class="btn-ent btn-ent-outline" style="padding: 0.85rem 2rem; font-size: 1rem; color: white;">
+              Read Security Model ↗
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="ent-footer">
+      <div>
+        <span>Cloud Harness MCP // Single-Owner Security Architecture</span>
+      </div>
+      <div style="display: flex; gap: 1.5rem;">
+        <a href="https://docs.harness.agentkit.best" target="_blank">Documentation</a>
+        <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank">GitHub</a>
+        <a href="../privacy.html">Privacy</a>
+        <a href="../terms.html">Terms</a>
+      </div>
+    </footer>
+
+    <!-- Interactive Script -->
+    <script>
+      function switchDefense(layer, btn) {
+        document.querySelectorAll('.defense-tab-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const panel = document.getElementById('defensePanel');
+        if (layer === 1) {
+          panel.innerHTML = `
+            <div>
+              <h3 style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.75rem; color: #93c5fd;">
+                Layer 1: Credential-Free Ingress Proxy
+              </h3>
+              <p style="color: var(--text-slate); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem;">
+                The only Internet-exposed service is an Nginx ingress bound to loopback. It verifies Cloudflare Access SSO assertion tokens or gateway headers before proxying requests to the stateless API.
+              </p>
+              <ul style="list-style: none; display: flex; flex-direction: column; gap: 0.6rem; font-size: 0.9rem;">
+                <li><span style="color: var(--blue-accent);">✔</span> Holds zero credentials, certificates, or repository secrets</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Does not join the backend execution network</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Strict rate-limiting and request payload truncation guards</li>
+              </ul>
+            </div>
+            <div class="threat-box">
+              <span style="color: #60a5fa;">// Ingress Security Verification</span><br/>
+              [REQUEST] GET /mcp<br/>
+              [CF-Access-JWT-Assertion] VALID (GitHub Org: @core-team)<br/>
+              [INGRESS] Forwarding to 127.0.0.1:4000 (Internal RPC)<br/>
+              <span style="color: #34d399;">[STATUS] Perimeter Authenticated (0 secrets exposed)</span>
+            </div>
+          `;
+        } else if (layer === 2) {
+          panel.innerHTML = `
+            <div>
+              <h3 style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.75rem; color: #93c5fd;">
+                Layer 2: Stateless MCP API Server
+              </h3>
+              <p style="color: var(--text-slate); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem;">
+                Translates incoming Streamable HTTP MCP calls into authenticated internal operations. The API possesses no Docker socket mounts and no repository clone data.
+              </p>
+              <ul style="list-style: none; display: flex; flex-direction: column; gap: 0.6rem; font-size: 0.9rem;">
+                <li><span style="color: var(--blue-accent);">✔</span> Validates principal identities and request signatures</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Enforces input schema boundaries via Zod contracts</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Emits chunked HTTP streaming responses back to AI clients</li>
+              </ul>
+            </div>
+            <div class="threat-box">
+              <span style="color: #60a5fa;">// MCP API Execution Boundary</span><br/>
+              [SCHEMA] Validating RunnerOperationSchema<br/>
+              [PRINCIPAL] Verified Owner UID: usr_90af2<br/>
+              [RPC] Dispatching authenticated operation to Runner Daemon<br/>
+              <span style="color: #34d399;">[STATUS] Zero Host Mounts in API Container</span>
+            </div>
+          `;
+        } else if (layer === 3) {
+          panel.innerHTML = `
+            <div>
+              <h3 style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.75rem; color: #93c5fd;">
+                Layer 3: Trusted Runner & Policy Engine
+              </h3>
+              <p style="color: var(--text-slate); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem;">
+                The only component with Docker socket access. Enforces time-to-live bounds, manages SQLite state records, and brokers short-lived repository tokens.
+              </p>
+              <ul style="list-style: none; display: flex; flex-direction: column; gap: 0.6rem; font-size: 0.9rem;">
+                <li><span style="color: var(--blue-accent);">✔</span> Idempotent workspace orchestration</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Scoped cleanup by verified workspace identity</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Automated garbage collection on expired TTLs</li>
+              </ul>
+            </div>
+            <div class="threat-box">
+              <span style="color: #60a5fa;">// Trusted Runner Policy Check</span><br/>
+              [POLICY] Asserting workspace limits (Max 4 active, TTL: 1800s)<br/>
+              [DOCKER] Spawning isolated executor (cgroups: 4GB RAM, 2 CPUs)<br/>
+              [STATE] Recording state in encrypted SQLite database<br/>
+              <span style="color: #34d399;">[STATUS] Executor Sandboxed & Controlled</span>
+            </div>
+          `;
+        } else if (layer === 4) {
+          panel.innerHTML = `
+            <div>
+              <h3 style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.75rem; color: #93c5fd;">
+                Layer 4: Ephemeral Non-Root Docker Executor
+              </h3>
+              <p style="color: var(--text-slate); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem;">
+                The workspace container where agent commands actually run. Configured with read-only root, non-root user (UID 1000), and network mode 'none' by default.
+              </p>
+              <ul style="list-style: none; display: flex; flex-direction: column; gap: 0.6rem; font-size: 0.9rem;">
+                <li><span style="color: var(--blue-accent);">✔</span> Cannot reach host filesystem or Docker socket</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Cannot exfiltrate data over network (net: none default)</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Automatically purged on workspace close</li>
+              </ul>
+            </div>
+            <div class="threat-box">
+              <span style="color: #60a5fa;">// Executor Container Isolation</span><br/>
+              [UID] 1000 (node/executor)<br/>
+              [ROOT FS] Read-only filesystem mounted<br/>
+              [NETWORK] Mode: none (Loopback only)<br/>
+              <span style="color: #34d399;">[STATUS] Host System Completely Air-Gapped</span>
+            </div>
+          `;
+        } else if (layer === 5) {
+          panel.innerHTML = `
+            <div>
+              <h3 style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.75rem; color: #93c5fd;">
+                Layer 5: Ephemeral Stdin Git Helper
+              </h3>
+              <p style="color: var(--text-slate); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem;">
+                When pushing code, the GitHub App Broker generates a temporary 60-second token and pipes it over stdin to a short-lived transfer helper.
+              </p>
+              <ul style="list-style: none; display: flex; flex-direction: column; gap: 0.6rem; font-size: 0.9rem;">
+                <li><span style="color: var(--blue-accent);">✔</span> Tokens are never written to disk or .git/config</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Ephemeral helper terminates immediately after git push</li>
+                <li><span style="color: var(--blue-accent);">✔</span> Executors never see GitHub App private keys</li>
+              </ul>
+            </div>
+            <div class="threat-box">
+              <span style="color: #60a5fa;">// Zero-Disk Stdin Broker Flow</span><br/>
+              [BROKER] Minting 60s installation token for repo<br/>
+              [STDIO] Piping token to ephemeral git transfer helper<br/>
+              [GIT] git push origin refs/heads/branch<br/>
+              <span style="color: #34d399;">[STATUS] Token Erased From Memory (0 residual trace)</span>
+            </div>
+          `;
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/site/variants/variant-5-futuristic-studio.html
+++ b/site/variants/variant-5-futuristic-studio.html
@@ -1,0 +1,796 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Cloud Harness MCP — Hyper-Modern Futuristic Editorial & Generative AI Studio."
+    />
+    <title>Cloud Harness MCP // Futuristic Editorial Edition</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --velvet-950: #06070a;
+        --velvet-900: #0d0f17;
+        --velvet-800: #141724;
+        --aurora-purple: #c084fc;
+        --aurora-magenta: #f43f5e;
+        --aurora-cyan: #38bdf8;
+        --aurora-emerald: #34d399;
+        --border-glass: rgba(255, 255, 255, 0.08);
+        --border-glow: rgba(192, 132, 252, 0.35);
+        --text-pure: #ffffff;
+        --text-sub: #94a3b8;
+        --text-dim: #64748b;
+        --font-display: "Space Grotesk", sans-serif;
+        --font-sans: "Plus Jakarta Sans", sans-serif;
+        --font-mono: "JetBrains Mono", monospace;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        background-color: var(--velvet-950);
+        color: var(--text-pure);
+        font-family: var(--font-sans);
+        line-height: 1.6;
+        overflow-x: hidden;
+        background-image: 
+          radial-gradient(circle at 10% 20%, rgba(244, 63, 94, 0.1) 0%, transparent 40%),
+          radial-gradient(circle at 90% 30%, rgba(192, 132, 252, 0.12) 0%, transparent 45%),
+          radial-gradient(circle at 50% 80%, rgba(56, 189, 248, 0.08) 0%, transparent 50%);
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      /* Glowing Header */
+      .futuristic-nav {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        backdrop-filter: blur(20px);
+        background: rgba(6, 7, 10, 0.8);
+        border-bottom: 1px solid var(--border-glass);
+      }
+
+      .nav-container {
+        max-width: 1320px;
+        margin: 0 auto;
+        padding: 1.2rem 2rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .brand-title {
+        font-family: var(--font-display);
+        font-size: 1.3rem;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .brand-gradient-badge {
+        background: linear-gradient(135deg, var(--aurora-magenta), var(--aurora-purple));
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-size: 0.72rem;
+        font-family: var(--font-mono);
+        color: white;
+      }
+
+      .nav-links {
+        display: flex;
+        gap: 2.2rem;
+        font-weight: 500;
+        font-size: 0.95rem;
+      }
+
+      .nav-links a:hover {
+        color: var(--aurora-purple);
+      }
+
+      .btn-futuristic {
+        font-family: var(--font-sans);
+        font-weight: 600;
+        font-size: 0.9rem;
+        padding: 0.65rem 1.4rem;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        cursor: pointer;
+        transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+      }
+
+      .btn-glow {
+        background: linear-gradient(135deg, #f43f5e 0%, #c084fc 50%, #38bdf8 100%);
+        color: #06070a;
+        font-weight: 700;
+        border: none;
+        box-shadow: 0 4px 20px rgba(192, 132, 252, 0.35);
+      }
+
+      .btn-glow:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 30px rgba(192, 132, 252, 0.55);
+      }
+
+      .btn-glass {
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid var(--border-glass);
+        color: white;
+      }
+
+      .btn-glass:hover {
+        background: rgba(255, 255, 255, 0.1);
+        border-color: rgba(255, 255, 255, 0.25);
+      }
+
+      /* Hero Section */
+      .editorial-hero {
+        max-width: 1320px;
+        margin: 4.5rem auto 5rem;
+        padding: 0 2rem;
+        text-align: center;
+      }
+
+      .aurora-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.4rem 1.1rem;
+        border-radius: 999px;
+        background: rgba(192, 132, 252, 0.1);
+        border: 1px solid rgba(192, 132, 252, 0.3);
+        font-size: 0.85rem;
+        color: #e9d5ff;
+        margin-bottom: 2rem;
+      }
+
+      .hero-huge-title {
+        font-family: var(--font-display);
+        font-size: clamp(3rem, 7vw, 5.5rem);
+        font-weight: 800;
+        line-height: 1.05;
+        letter-spacing: -0.04em;
+        margin-bottom: 1.75rem;
+        max-width: 1100px;
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      .aurora-text {
+        background: linear-gradient(135deg, #fda4af 0%, #c084fc 40%, #38bdf8 80%, #4ade80 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+
+      .hero-subtext {
+        color: var(--text-sub);
+        font-size: 1.25rem;
+        max-width: 780px;
+        margin: 0 auto 3rem;
+        line-height: 1.7;
+      }
+
+      .hero-cta-group {
+        display: flex;
+        justify-content: center;
+        gap: 1.25rem;
+        margin-bottom: 4.5rem;
+      }
+
+      /* Metrics Ticker */
+      .ticker-strip {
+        background: rgba(20, 23, 36, 0.6);
+        border: 1px solid var(--border-glass);
+        border-radius: 14px;
+        padding: 1.75rem 2rem;
+        max-width: 1100px;
+        margin: 0 auto 6rem;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 2rem;
+        text-align: center;
+      }
+
+      .metric-val {
+        font-family: var(--font-display);
+        font-size: 2.2rem;
+        font-weight: 800;
+        background: linear-gradient(135deg, #ffffff, #cbd5e1);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        margin-bottom: 0.25rem;
+      }
+
+      .metric-lbl {
+        font-size: 0.85rem;
+        color: var(--text-dim);
+        font-weight: 500;
+      }
+
+      /* Interactive Capability Deck */
+      .deck-section {
+        max-width: 1320px;
+        margin: 5rem auto;
+        padding: 0 2rem;
+      }
+
+      .section-heading {
+        text-align: center;
+        max-width: 700px;
+        margin: 0 auto 4rem;
+      }
+
+      .deck-headline {
+        font-family: var(--font-display);
+        font-size: 2.5rem;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+        margin-bottom: 1rem;
+      }
+
+      .deck-grid {
+        display: grid;
+        grid-template-columns: 1fr 1.3fr;
+        gap: 3rem;
+        background: var(--velvet-900);
+        border: 1px solid var(--border-glass);
+        border-radius: 20px;
+        padding: 3rem;
+        box-shadow: 0 25px 60px rgba(0, 0, 0, 0.7);
+        align-items: center;
+      }
+
+      .deck-nav-list {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .deck-nav-item {
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid var(--border-glass);
+        border-radius: 12px;
+        padding: 1.25rem 1.5rem;
+        cursor: pointer;
+        transition: all 0.25s ease;
+        text-align: left;
+      }
+
+      .deck-nav-item.active {
+        background: rgba(192, 132, 252, 0.15);
+        border-color: var(--aurora-purple);
+        box-shadow: 0 0 20px rgba(192, 132, 252, 0.2);
+      }
+
+      .deck-nav-title {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: 1.15rem;
+        margin-bottom: 0.35rem;
+      }
+
+      .deck-nav-desc {
+        color: var(--text-sub);
+        font-size: 0.88rem;
+      }
+
+      .deck-display-card {
+        background: #090a10;
+        border: 1px solid var(--border-glass);
+        border-radius: 14px;
+        padding: 2rem;
+        min-height: 380px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: #e2e8f0;
+        line-height: 1.7;
+        box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.6);
+      }
+
+      /* Animated Aurora Architecture Diagram */
+      .aurora-diagram-card {
+        background: var(--velvet-900);
+        border: 1px solid var(--border-glass);
+        border-radius: 20px;
+        padding: 2.5rem;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+        margin-bottom: 3.5rem;
+      }
+
+      .svg-aurora-diagram {
+        width: 100%;
+        height: auto;
+        display: block;
+      }
+
+      /* 52 Tool Spotlight */
+      .tools-deck-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1.5rem;
+        margin-top: 3.5rem;
+      }
+
+      .tool-editorial-card {
+        background: var(--velvet-900);
+        border: 1px solid var(--border-glass);
+        border-radius: 14px;
+        padding: 2rem;
+        transition: all 0.3s ease;
+      }
+
+      .tool-editorial-card:hover {
+        border-color: var(--border-glow);
+        transform: translateY(-3px);
+        box-shadow: 0 10px 30px rgba(192, 132, 252, 0.15);
+      }
+
+      .tool-badge-neon {
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        color: var(--aurora-cyan);
+        background: rgba(56, 189, 248, 0.12);
+        padding: 2px 8px;
+        border-radius: 4px;
+        display: inline-block;
+        margin-bottom: 1rem;
+      }
+
+      .tool-title {
+        font-family: var(--font-display);
+        font-size: 1.3rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+      }
+
+      .tool-desc {
+        color: var(--text-sub);
+        font-size: 0.92rem;
+      }
+
+      /* Connect Fleet Section */
+      .fleet-connect-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1.5rem;
+        margin-top: 2.5rem;
+      }
+
+      .fleet-card {
+        background: var(--velvet-900);
+        border: 1px solid var(--border-glass);
+        border-radius: 12px;
+        padding: 1.75rem;
+        text-align: left;
+      }
+
+      .fleet-title {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: 1.1rem;
+        margin-bottom: 0.5rem;
+        color: var(--aurora-purple);
+      }
+
+      .fleet-code {
+        background: #06070a;
+        padding: 0.75rem;
+        border-radius: 6px;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: #e2e8f0;
+        overflow-x: auto;
+        margin-top: 0.75rem;
+      }
+
+      /* Editorial CTA */
+      .cta-editorial {
+        background: linear-gradient(135deg, rgba(244, 63, 94, 0.2) 0%, rgba(192, 132, 252, 0.2) 50%, rgba(56, 189, 248, 0.2) 100%), var(--velvet-900);
+        border: 1px solid rgba(192, 132, 252, 0.4);
+        border-radius: 24px;
+        padding: 5rem 2rem;
+        text-align: center;
+        max-width: 1200px;
+        margin: 6rem auto 0;
+        box-shadow: 0 30px 80px rgba(0, 0, 0, 0.8);
+      }
+
+      /* Footer */
+      .editorial-footer {
+        border-top: 1px solid var(--border-glass);
+        padding: 3.5rem 2rem;
+        max-width: 1320px;
+        margin: 6rem auto 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 0.9rem;
+        color: var(--text-dim);
+      }
+
+      @media (max-width: 960px) {
+        .deck-grid { grid-template-columns: 1fr; }
+        .ticker-strip { grid-template-columns: 1fr 1fr; }
+        .tools-deck-grid { grid-template-columns: 1fr; }
+        .fleet-connect-grid { grid-template-columns: 1fr; }
+        .nav-links { display: none; }
+      }
+    </style>
+  </head>
+  <body id="top">
+    <!-- Navbar -->
+    <header class="futuristic-nav">
+      <div class="nav-container">
+        <a href="#top" class="brand-title">
+          <span>CLOUD HARNESS</span>
+          <span class="brand-gradient-badge">STUDIO</span>
+        </a>
+        <nav class="nav-links">
+          <a href="#architecture">Architecture</a>
+          <a href="#deck">Capabilities</a>
+          <a href="#tools">Tool Matrix</a>
+          <a href="#connect">Connect Fleet</a>
+          <a href="https://docs.harness.agentkit.best" target="_blank">Docs ↗</a>
+        </nav>
+        <div style="display: flex; gap: 1rem;">
+          <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank" class="btn-futuristic btn-glass">
+            GitHub
+          </a>
+          <a href="#connect" class="btn-futuristic btn-glow">
+            Deploy Now →
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <!-- Hero -->
+    <main>
+      <section class="editorial-hero">
+        <div class="aurora-pill">
+          <span>⚡ Streamable HTTP MCP • Non-Root Executors</span>
+        </div>
+        <h1 class="hero-huge-title">
+          AUTONOMOUS CODING AT THE<br/>
+          <span class="aurora-text">EDGE OF IMPOSSIBILITY.</span>
+        </h1>
+        <p class="hero-subtext">
+          Give Claude Code, Cursor, and ChatGPT a dedicated cloud execution harness. 52 structured AST and terminal tools, non-root Docker sandboxes, and zero-residual TTL cleanups.
+        </p>
+        <div class="hero-cta-group">
+          <a href="#connect" class="btn-futuristic btn-glow" style="font-size: 1rem; padding: 0.85rem 2.2rem;">
+            Initialize Cloud Harness →
+          </a>
+          <a href="#architecture" class="btn-futuristic btn-glass" style="font-size: 1rem; padding: 0.85rem 2.2rem;">
+            View Architecture Diagram ↓
+          </a>
+        </div>
+
+        <!-- Metrics Strip -->
+        <div class="ticker-strip">
+          <div>
+            <div class="metric-val">52</div>
+            <div class="metric-lbl">Structured Tools</div>
+          </div>
+          <div>
+            <div class="metric-val">0<span style="font-size: 1.2rem;"> bytes</span></div>
+            <div class="metric-lbl">Residual State</div>
+          </div>
+          <div>
+            <div class="metric-val">100%</div>
+            <div class="metric-lbl">Non-Root Docker</div>
+          </div>
+          <div>
+            <div class="metric-val">&lt;15<span style="font-size: 1.2rem;">ms</span></div>
+            <div class="metric-lbl">Ingress Latency</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Animated Aurora Architecture Section -->
+      <section class="deck-section" id="architecture">
+        <div class="section-heading">
+          <div style="font-family: var(--font-mono); color: var(--aurora-cyan); font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.5rem;">
+            // Holographic Architecture Core
+          </div>
+          <h2 class="deck-headline">Boundary Dynamics & Streamable RPC Flow</h2>
+          <p style="color: var(--text-sub);">
+            Watch how agent requests flow through the authenticated ingress into bounded, non-root containers.
+          </p>
+        </div>
+
+        <div class="aurora-diagram-card">
+          <svg class="svg-aurora-diagram" viewBox="0 0 1000 360">
+            <defs>
+              <linearGradient id="auroraGrad1" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#f43f5e" />
+                <stop offset="50%" stop-color="#c084fc" />
+                <stop offset="100%" stop-color="#38bdf8" />
+              </linearGradient>
+            </defs>
+
+            <!-- 3 Major Zones -->
+            <rect x="30" y="30" width="220" height="300" rx="14" fill="#090a10" stroke="rgba(244, 63, 94, 0.3)" />
+            <text x="50" y="65" fill="#fda4af" font-family="var(--font-mono)" font-size="11" font-weight="700">01. INGRESS MESH</text>
+
+            <rect x="280" y="30" width="370" height="300" rx="14" fill="#090a10" stroke="rgba(192, 132, 252, 0.4)" />
+            <text x="300" y="65" fill="#e9d5ff" font-family="var(--font-mono)" font-size="11" font-weight="700">02. CONTROL HARNESS</text>
+
+            <rect x="680" y="30" width="290" height="300" rx="14" fill="#090a10" stroke="rgba(56, 189, 248, 0.4)" stroke-width="1.8" />
+            <text x="700" y="65" fill="#7dd3fc" font-family="var(--font-mono)" font-size="11" font-weight="700">03. TIME-BOUND EXECUTOR</text>
+
+            <!-- Nodes -->
+            <rect x="50" y="90" width="180" height="60" rx="8" fill="#141724" />
+            <text x="65" y="125" fill="#fff" font-family="var(--font-display)" font-size="13" font-weight="700">AI Coding Client</text>
+
+            <rect x="50" y="210" width="180" height="60" rx="8" fill="#141724" />
+            <text x="65" y="245" fill="#fff" font-family="var(--font-display)" font-size="13" font-weight="700">Cloudflare Access</text>
+
+            <rect x="300" y="90" width="150" height="60" rx="8" fill="#141724" />
+            <text x="315" y="125" fill="#fff" font-family="var(--font-display)" font-size="13" font-weight="700">Stateless MCP</text>
+
+            <rect x="480" y="90" width="150" height="60" rx="8" fill="#141724" stroke="var(--aurora-purple)" />
+            <text x="495" y="125" fill="#fff" font-family="var(--font-display)" font-size="13" font-weight="700">Trusted Runner</text>
+
+            <rect x="480" y="210" width="150" height="60" rx="8" fill="#141724" />
+            <text x="495" y="245" fill="#fff" font-family="var(--font-display)" font-size="13" font-weight="700">GitHub App Broker</text>
+
+            <rect x="700" y="90" width="250" height="100" rx="10" fill="#141724" stroke="var(--aurora-emerald)" />
+            <text x="720" y="125" fill="var(--aurora-emerald)" font-family="var(--font-display)" font-size="14" font-weight="700">Non-Root Docker Executor</text>
+            <text x="720" y="150" fill="var(--text-sub)" font-size="11">UID: 1000 • Read-Only Root</text>
+            <text x="720" y="170" fill="var(--text-dim)" font-size="10">TTL: 1800s Auto-Eviction</text>
+
+            <rect x="700" y="210" width="250" height="60" rx="8" fill="#141724" stroke="var(--aurora-cyan)" />
+            <text x="720" y="245" fill="#38bdf8" font-family="var(--font-display)" font-size="13" font-weight="700">Ephemeral Git Helper</text>
+
+            <!-- Wires -->
+            <path d="M 140 150 L 140 210" stroke="rgba(255,255,255,0.15)" stroke-width="1.5" stroke-dasharray="4 4" />
+            <path d="M 230 240 L 265 240 L 265 120 L 300 120" stroke="rgba(255,255,255,0.2)" stroke-width="1.8" />
+            <path d="M 450 120 L 480 120" stroke="var(--aurora-purple)" stroke-width="2" />
+            <path d="M 630 120 L 700 120" stroke="var(--aurora-emerald)" stroke-width="2" />
+            <path d="M 555 150 L 555 210" stroke="rgba(255,255,255,0.15)" stroke-width="1.5" />
+            <path d="M 630 240 L 700 240" stroke="var(--aurora-cyan)" stroke-width="2" />
+
+            <!-- Traveling Particles -->
+            <circle r="4.5" fill="#c084fc">
+              <animateMotion dur="3.8s" repeatCount="indefinite" path="M 140 150 L 140 210 L 265 210 L 265 120 L 300 120 L 450 120 L 480 120 L 630 120 L 700 120" />
+            </circle>
+
+            <circle r="4" fill="#34d399">
+              <animateMotion dur="3.8s" begin="1.9s" repeatCount="indefinite" path="M 555 150 L 555 210 L 630 240 L 700 240" />
+            </circle>
+          </svg>
+        </div>
+      </section>
+
+      <!-- Interactive Capability Deck -->
+      <section class="deck-section" id="deck">
+        <div class="section-heading">
+          <div style="font-family: var(--font-mono); color: var(--aurora-purple); font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.5rem;">
+            // Engineered Primitives
+          </div>
+          <h2 class="deck-headline">A Complete Runtime for Agentic Software Engineering</h2>
+          <p style="color: var(--text-sub);">
+            Switch between core pillars to inspect how Cloud Harness empowers your AI models.
+          </p>
+        </div>
+
+        <div class="deck-grid">
+          <div class="deck-nav-list">
+            <div class="deck-nav-item active" onclick="switchDeck('ast', this)">
+              <div class="deck-nav-title">1. AST Structural Intelligence</div>
+              <div class="deck-nav-desc">Syntax-tree pattern matching & atomic code refactoring.</div>
+            </div>
+            <div class="deck-nav-item" onclick="switchDeck('sandbox', this)">
+              <div class="deck-nav-title">2. Ephemeral Docker Sandboxes</div>
+              <div class="deck-nav-desc">Non-root containers with strict CPU/memory cgroups and network none.</div>
+            </div>
+            <div class="deck-nav-item" onclick="switchDeck('broker', this)">
+              <div class="deck-nav-title">3. Stdin GitHub App Broker</div>
+              <div class="deck-nav-desc">Zero-disk push credentials streamed directly to ephemeral helpers.</div>
+            </div>
+            <div class="deck-nav-item" onclick="switchDeck('dag', this)">
+              <div class="deck-nav-title">4. DAG Multi-Agent Orchestrator</div>
+              <div class="deck-nav-desc">Parallel and sequential subagent tasks with dependency barriers.</div>
+            </div>
+          </div>
+
+          <div class="deck-display-card" id="deckDisplay">
+            <span style="color: #c084fc;">// AST Structural Search & Transform</span><br/>
+            <span style="color: #38bdf8;">call</span> mcp.ast_grep({<br/>
+            &nbsp;&nbsp;"pattern": "export function $NAME($$$ARGS) { $$$BODY }",<br/>
+            &nbsp;&nbsp;"path": "src/services"<br/>
+            })<br/><br/>
+            <span style="color: #34d399;">[MATCHES FOUND] 14 functions parsed cleanly across AST</span><br/>
+            ├── authService.verifyToken()<br/>
+            ├── runnerService.spawnSandbox()<br/>
+            └── stateStore.persistRecord()<br/><br/>
+            <span style="color: #f43f5e;">// Safe atomic replacement preserving code comments</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- 52 Tool Spotlight Grid -->
+      <section class="deck-section" id="tools">
+        <div class="section-heading">
+          <div style="font-family: var(--font-mono); color: var(--aurora-cyan); font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.5rem;">
+            // Complete Surface
+          </div>
+          <h2 class="deck-headline">52 Tools Designed for Autonomous Operations</h2>
+        </div>
+
+        <div class="tools-deck-grid">
+          <div class="tool-editorial-card">
+            <span class="tool-badge-neon">AST INTEL</span>
+            <h3 class="tool-title">ast_grep & ast_edit</h3>
+            <p class="tool-desc">Structural AST code search and transformations across all modern programming languages.</p>
+          </div>
+          <div class="tool-editorial-card">
+            <span class="tool-badge-neon">TERMINAL</span>
+            <h3 class="tool-title">bash_session</h3>
+            <p class="tool-desc">Persistent PTY interactive shell session supporting live watcher commands and terminal controls.</p>
+          </div>
+          <div class="tool-editorial-card">
+            <span class="tool-badge-neon">GIT</span>
+            <h3 class="tool-title">git_worktree</h3>
+            <p class="tool-desc">Instant branch worktrees allowing parallel subagents to operate without conflicting Git checkouts.</p>
+          </div>
+          <div class="tool-editorial-card">
+            <span class="tool-badge-neon">WORKFLOW</span>
+            <h3 class="tool-title">task_graph</h3>
+            <p class="tool-desc">Orchestrate complex multi-stage tasks with topological barriers, artifact tracking, and rollback.</p>
+          </div>
+          <div class="tool-editorial-card">
+            <span class="tool-badge-neon">SECURITY</span>
+            <h3 class="tool-title">git_push</h3>
+            <p class="tool-desc">Push commits through ephemeral GitHub App tokens streamed directly over stdio.</p>
+          </div>
+          <div class="tool-editorial-card">
+            <span class="tool-badge-neon">EXTENSIONS</span>
+            <h3 class="tool-title">skill_run</h3>
+            <p class="tool-desc">Execute repository-defined skills, automated linters, and custom architectural reviews.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Connect Fleet Section with Anchor #connect -->
+      <section class="deck-section" id="connect">
+        <div class="section-heading">
+          <div style="font-family: var(--font-mono); color: var(--aurora-purple); font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.5rem;">
+            // Universal Integration
+          </div>
+          <h2 class="deck-headline">Connect Your AI Fleet in Seconds</h2>
+          <p style="color: var(--text-sub);">
+            Works out of the box with Streamable HTTP MCP and Gateway API keys.
+          </p>
+        </div>
+
+        <div class="fleet-connect-grid">
+          <div class="fleet-card">
+            <div class="fleet-title">Claude Code</div>
+            <p style="font-size: 0.85rem; color: var(--text-sub);">Native HTTP transport with Authorization Bearer header.</p>
+            <div class="fleet-code">claude mcp add cloud-harness --transport http https://api.harness.zuey.me/mcp --header "Authorization: Bearer KEY"</div>
+          </div>
+          <div class="fleet-card">
+            <div class="fleet-title">Cursor IDE</div>
+            <p style="font-size: 0.85rem; color: var(--text-sub);">Global or project .cursor/mcp.json configuration.</p>
+            <div class="fleet-code">{"mcpServers": {"cloud-harness": {"url": "https://api.harness.zuey.me/mcp", "headers": {"Authorization": "Bearer KEY"}}}}</div>
+          </div>
+          <div class="fleet-card">
+            <div class="fleet-title">ChatGPT Developer</div>
+            <p style="font-size: 0.85rem; color: var(--text-sub);">Single-click Cloudflare Access SSO managed OAuth connector.</p>
+            <div class="fleet-code">Endpoint: https://harness.zuey.me/mcp (OAuth 2.0 / Cloudflare Access SSO)</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Editorial CTA -->
+      <section style="padding: 0 2rem;">
+        <div class="cta-editorial">
+          <h2 style="font-family: var(--font-display); font-size: 2.8rem; font-weight: 800; margin-bottom: 1.25rem;">
+            Upgrade Your AI Coding Harness Today
+          </h2>
+          <p style="color: var(--text-sub); max-width: 650px; margin: 0 auto 2.5rem; font-size: 1.15rem;">
+            Free and open-source under the MIT license. Ready for single-owner production deployments.
+          </p>
+          <div style="display: flex; gap: 1.25rem; justify-content: center;">
+            <a href="https://docs.harness.agentkit.best/getting-started" target="_blank" class="btn-futuristic btn-glow" style="padding: 0.9rem 2.4rem; font-size: 1rem;">
+              Get Started Now →
+            </a>
+            <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank" class="btn-futuristic btn-glass" style="padding: 0.9rem 2.4rem; font-size: 1rem;">
+              Star on GitHub ★
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="editorial-footer">
+      <div>
+        <span>CLOUD HARNESS MCP • MIT LICENSED</span>
+      </div>
+      <div style="display: flex; gap: 2rem;">
+        <a href="https://docs.harness.agentkit.best" target="_blank">Docs</a>
+        <a href="https://github.com/bestagentkits/cloud-harness-mcp" target="_blank">GitHub</a>
+        <a href="../privacy.html">Privacy</a>
+        <a href="../terms.html">Terms</a>
+      </div>
+    </footer>
+
+    <!-- Interactive Script -->
+    <script>
+      function switchDeck(item, el) {
+        document.querySelectorAll('.deck-nav-item').forEach(i => i.classList.remove('active'));
+        el.classList.add('active');
+        const box = document.getElementById('deckDisplay');
+        if (item === 'ast') {
+          box.innerHTML = `
+            <span style="color: #c084fc;">// AST Structural Search & Transform</span><br/>
+            <span style="color: #38bdf8;">call</span> mcp.ast_grep({<br/>
+            &nbsp;&nbsp;"pattern": "export function $NAME($$$ARGS) { $$$BODY }",<br/>
+            &nbsp;&nbsp;"path": "src/services"<br/>
+            })<br/><br/>
+            <span style="color: #34d399;">[MATCHES FOUND] 14 functions parsed cleanly across AST</span><br/>
+            ├── authService.verifyToken()<br/>
+            ├── runnerService.spawnSandbox()<br/>
+            └── stateStore.persistRecord()<br/><br/>
+            <span style="color: #f43f5e;">// Safe atomic replacement preserving code comments</span>
+          `;
+        } else if (item === 'sandbox') {
+          box.innerHTML = `
+            <span style="color: #c084fc;">// Ephemeral Container Boot Sequence</span><br/>
+            <span style="color: #38bdf8;">spawn</span> DockerContainer({<br/>
+            &nbsp;&nbsp;"image": "cloud-harness-executor:latest",<br/>
+            &nbsp;&nbsp;"user": "1000:1000",<br/>
+            &nbsp;&nbsp;"network": "none",<br/>
+            &nbsp;&nbsp;"readOnlyRoot": true,<br/>
+            &nbsp;&nbsp;"memoryLimit": "4g"<br/>
+            })<br/><br/>
+            <span style="color: #34d399;">[CONTAINER ISOLATED] Execution boundary active</span>
+          `;
+        } else if (item === 'broker') {
+          box.innerHTML = `
+            <span style="color: #c084fc;">// Stdin GitHub App Token Broker</span><br/>
+            1. Runner verifies user push permission<br/>
+            2. Broker generates 60-second installation token<br/>
+            3. Token piped over stdin helper: git push origin main<br/>
+            4. Helper terminates and token is completely purged<br/><br/>
+            <span style="color: #34d399;">[ZERO DISK LEAKS] Remote origin updated cleanly</span>
+          `;
+        } else if (item === 'dag') {
+          box.innerHTML = `
+            <span style="color: #c084fc;">// DAG Multi-Agent Orchestration</span><br/>
+            [STAGE 1] Parallel Lint & AST Analysis (3 subagents)<br/>
+            [BARRIER] Waiting on Stage 1 completion... OK<br/>
+            [STAGE 2] Integration Test Execution in Isolated Worktree<br/>
+            [STAGE 3] Automated Commit & Push via Broker<br/><br/>
+            <span style="color: #34d399;">[DAG COMPLETE] All tasks settled successfully</span>
+          `;
+        }
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Redesign marketing site (`harness.agentkit.best`) with Cyber-Engineering Dark HUD (Vercel pitch black #000000, neon cyan/green accents, generous breathing room).
- Add dynamic GitHub stars counter badge to header.
- Add responsive mobile navigation drawer and mobile-optimized swipe containers for animated diagrams.
- Feature 2 animated SVG diagrams: Live Architecture Signal Matrix and Time-Limited Sequence Workflow trace.
- Expand 52+ Tools surface with `agents_*` coming soon badges and verified live operations.
- Add creator attribution: 'From the creator of AgentKit & GoClaw'.
- Add 5 distinct design variants in `site/variants/` with master preview switcher.

## Verification
- `npm run pages:check`: Passed (11 files)
- `npm run pages:links`: Passed (9 links)