### PR TITLE
fix(site): prevent mobile header clipping on small screens and add drawer CTA

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -965,13 +965,10 @@
           <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
           </svg>
-          <span>GitHub</span>
-          <span class="github-star-badge" id="githubStarsCount">★ Star</span>
+          <span class="github-btn-text">GitHub</span><span class="github-star-badge" id="githubStarsCount">★ Star</span>
         </a>
 
-        <a href="#connect" class="hud-button hud-button-primary">
-          Connect Agent →
-        </a>
+        <a href="#connect" class="hud-button hud-button-primary nav-connect-btn">Connect Agent →</a>
 
         <!-- Mobile Menu Toggle Button -->
         <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle navigation menu">
@@ -985,6 +982,7 @@
 
       <!-- Mobile Navigation Drawer -->
       <nav class="mobile-drawer" id="mobileDrawer" aria-label="Mobile Navigation">
+        <a href="#connect" class="hud-button hud-button-primary" style="justify-content: center; text-align: center; margin-bottom: 0.5rem;" onclick="toggleMobileMenu()">Connect Agent →</a>
         <a href="#architecture" onclick="toggleMobileMenu()">Architecture</a>
         <a href="#workflows" onclick="toggleMobileMenu()">Workflows</a>
         <a href="#tools" onclick="toggleMobileMenu()">Tools Surface</a>

--- a/site/index.html
+++ b/site/index.html
@@ -892,6 +892,10 @@
       }
 
       /* Responsive Queries */
+      @media (max-width: 1120px) {
+        .nav-links { display: none; }
+        .mobile-menu-btn { display: inline-flex; }
+      }
       @media (max-width: 960px) {
         .hero-section { grid-template-columns: 1fr; }
         .arch-grid { grid-template-columns: 1fr; }
@@ -1236,6 +1240,20 @@
 
           <div class="diagram-scroll-wrapper">
             <svg class="svg-hud-diagram" viewBox="0 0 1000 440" aria-label="Sequence Workflow">
+              <defs>
+                <marker id="seq-arrow-cyan" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+                  <path d="M0,0 L8,4 L0,8 z" fill="var(--cyan-glow)" />
+                </marker>
+                <marker id="seq-arrow-purple" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+                  <path d="M0,0 L8,4 L0,8 z" fill="var(--purple-laser)" />
+                </marker>
+                <marker id="seq-arrow-green" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+                  <path d="M0,0 L8,4 L0,8 z" fill="var(--green-neon)" />
+                </marker>
+                <marker id="seq-arrow-amber" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+                  <path d="M0,0 L8,4 L0,8 z" fill="var(--amber-warn)" />
+                </marker>
+              </defs>
               <!-- Column Lifelines -->
               <line x1="120" y1="60" x2="120" y2="400" stroke="rgba(255,255,255,0.08)" stroke-width="1.5" stroke-dasharray="4 4" />
               <line x1="380" y1="60" x2="380" y2="400" stroke="rgba(255,255,255,0.08)" stroke-width="1.5" stroke-dasharray="4 4" />
@@ -1256,33 +1274,33 @@
               <text x="830" y="43" fill="#fff" font-family="var(--font-mono)" font-size="12" font-weight="700">GitHub Origin</text>
 
               <!-- Step 1: workspace_open -->
-              <path d="M 120 100 L 380 100" stroke="var(--cyan-glow)" stroke-width="2" marker-end="url(#arrow-cyan)" />
+              <path d="M 120 100 L 380 100" stroke="var(--cyan-glow)" stroke-width="2" marker-end="url(#seq-arrow-cyan)" />
               <text x="140" y="92" fill="var(--cyan-glow)" font-family="var(--font-mono)" font-size="11">1. workspace_open(repoUrl, idempotencyKey)</text>
 
-              <path d="M 380 130 L 880 130" stroke="var(--purple-laser)" stroke-width="1.8" stroke-dasharray="4 4" />
+              <path d="M 380 130 L 880 130" stroke="var(--purple-laser)" stroke-width="1.8" stroke-dasharray="4 4" marker-end="url(#seq-arrow-purple)" />
               <text x="420" y="122" fill="var(--purple-laser)" font-family="var(--font-mono)" font-size="11">2. Ephemeral Git Clone (Token over stdin)</text>
 
-              <path d="M 380 165 L 650 165" stroke="var(--green-neon)" stroke-width="2" />
+              <path d="M 380 165 L 650 165" stroke="var(--green-neon)" stroke-width="2" marker-end="url(#seq-arrow-green)" />
               <text x="400" y="157" fill="var(--green-neon)" font-family="var(--font-mono)" font-size="11">3. Spawn Non-Root Container (TTL: 30m, Net: None)</text>
 
-              <path d="M 380 195 L 120 195" stroke="var(--cyan-glow)" stroke-width="1.8" stroke-dasharray="4 4" />
+              <path d="M 380 195 L 120 195" stroke="var(--cyan-glow)" stroke-width="1.8" stroke-dasharray="4 4" marker-end="url(#seq-arrow-cyan)" />
               <text x="160" y="187" fill="var(--text-muted)" font-family="var(--font-mono)" font-size="11">4. Returns opaque workspaceId</text>
 
               <!-- Step 2: Agent Work -->
-              <path d="M 120 240 L 650 240" stroke="var(--cyan-glow)" stroke-width="2" />
+              <path d="M 120 240 L 650 240" stroke="var(--cyan-glow)" stroke-width="2" marker-end="url(#seq-arrow-cyan)" />
               <text x="180" y="232" fill="var(--cyan-glow)" font-family="var(--font-mono)" font-size="11">5. grep_search / files_apply_patch / shell_open / tasks_run</text>
 
-              <path d="M 650 270 L 120 270" stroke="var(--green-neon)" stroke-width="1.8" stroke-dasharray="4 4" />
+              <path d="M 650 270 L 120 270" stroke="var(--green-neon)" stroke-width="1.8" stroke-dasharray="4 4" marker-end="url(#seq-arrow-green)" />
               <text x="240" y="262" fill="var(--green-neon)" font-family="var(--font-mono)" font-size="11">6. Real-time stream results (Zero host leaks)</text>
 
               <!-- Step 3: Git Push & Purge -->
               <path d="M 120 320 L 380 320" stroke="var(--cyan-glow)" stroke-width="2" />
               <text x="150" y="312" fill="var(--cyan-glow)" font-family="var(--font-mono)" font-size="11">7. git_push(refspec, forceWithLease)</text>
 
-              <path d="M 380 345 L 880 345" stroke="var(--purple-laser)" stroke-width="2" />
+              <path d="M 380 345 L 880 345" stroke="var(--purple-laser)" stroke-width="2" marker-end="url(#seq-arrow-purple)" />
               <text x="450" y="337" fill="var(--purple-laser)" font-family="var(--font-mono)" font-size="11">8. Broker push via short-lived stdin helper</text>
 
-              <path d="M 120 380 L 380 380" stroke="#f59e0b" stroke-width="2" />
+              <path d="M 120 380 L 380 380" stroke="#f59e0b" stroke-width="2" marker-end="url(#seq-arrow-amber)" />
               <text x="150" y="372" fill="#f59e0b" font-family="var(--font-mono)" font-size="11">9. workspace_close → Container & volumes destroyed (0 residual state)</text>
             </svg>
           </div>

--- a/site/index.html
+++ b/site/index.html
@@ -1225,7 +1225,7 @@
       <section class="section-wrap" id="workflows">
         <div class="section-header">
           <div class="section-tag">// Lifecycle Dynamics</div>
-          <h2 class="section-title">End-to-End Agent Coding Workflow</h2>
+          <h2 class="section-title">Bounded Coding Workflow</h2>
           <p style="color: var(--text-muted);">
             A high-velocity, deterministic sequence from workspace boot to safe git push and automatic sandbox purging.
           </p>

--- a/site/variants/variant-1-cyber-hud.html
+++ b/site/variants/variant-1-cyber-hud.html
@@ -965,13 +965,10 @@
           <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
           </svg>
-          <span>GitHub</span>
-          <span class="github-star-badge" id="githubStarsCount">★ Star</span>
+          <span class="github-btn-text">GitHub</span><span class="github-star-badge" id="githubStarsCount">★ Star</span>
         </a>
 
-        <a href="#connect" class="hud-button hud-button-primary">
-          Connect Agent →
-        </a>
+        <a href="#connect" class="hud-button hud-button-primary nav-connect-btn">Connect Agent →</a>
 
         <!-- Mobile Menu Toggle Button -->
         <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle navigation menu">
@@ -985,6 +982,7 @@
 
       <!-- Mobile Navigation Drawer -->
       <nav class="mobile-drawer" id="mobileDrawer" aria-label="Mobile Navigation">
+        <a href="#connect" class="hud-button hud-button-primary" style="justify-content: center; text-align: center; margin-bottom: 0.5rem;" onclick="toggleMobileMenu()">Connect Agent →</a>
         <a href="#architecture" onclick="toggleMobileMenu()">Architecture</a>
         <a href="#workflows" onclick="toggleMobileMenu()">Workflows</a>
         <a href="#tools" onclick="toggleMobileMenu()">Tools Surface</a>

--- a/site/variants/variant-1-cyber-hud.html
+++ b/site/variants/variant-1-cyber-hud.html
@@ -892,6 +892,10 @@
       }
 
       /* Responsive Queries */
+      @media (max-width: 1120px) {
+        .nav-links { display: none; }
+        .mobile-menu-btn { display: inline-flex; }
+      }
       @media (max-width: 960px) {
         .hero-section { grid-template-columns: 1fr; }
         .arch-grid { grid-template-columns: 1fr; }
@@ -1236,6 +1240,20 @@
 
           <div class="diagram-scroll-wrapper">
             <svg class="svg-hud-diagram" viewBox="0 0 1000 440" aria-label="Sequence Workflow">
+              <defs>
+                <marker id="seq-arrow-cyan" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+                  <path d="M0,0 L8,4 L0,8 z" fill="var(--cyan-glow)" />
+                </marker>
+                <marker id="seq-arrow-purple" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+                  <path d="M0,0 L8,4 L0,8 z" fill="var(--purple-laser)" />
+                </marker>
+                <marker id="seq-arrow-green" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+                  <path d="M0,0 L8,4 L0,8 z" fill="var(--green-neon)" />
+                </marker>
+                <marker id="seq-arrow-amber" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+                  <path d="M0,0 L8,4 L0,8 z" fill="var(--amber-warn)" />
+                </marker>
+              </defs>
               <!-- Column Lifelines -->
               <line x1="120" y1="60" x2="120" y2="400" stroke="rgba(255,255,255,0.08)" stroke-width="1.5" stroke-dasharray="4 4" />
               <line x1="380" y1="60" x2="380" y2="400" stroke="rgba(255,255,255,0.08)" stroke-width="1.5" stroke-dasharray="4 4" />
@@ -1256,33 +1274,33 @@
               <text x="830" y="43" fill="#fff" font-family="var(--font-mono)" font-size="12" font-weight="700">GitHub Origin</text>
 
               <!-- Step 1: workspace_open -->
-              <path d="M 120 100 L 380 100" stroke="var(--cyan-glow)" stroke-width="2" marker-end="url(#arrow-cyan)" />
+              <path d="M 120 100 L 380 100" stroke="var(--cyan-glow)" stroke-width="2" marker-end="url(#seq-arrow-cyan)" />
               <text x="140" y="92" fill="var(--cyan-glow)" font-family="var(--font-mono)" font-size="11">1. workspace_open(repoUrl, idempotencyKey)</text>
 
-              <path d="M 380 130 L 880 130" stroke="var(--purple-laser)" stroke-width="1.8" stroke-dasharray="4 4" />
+              <path d="M 380 130 L 880 130" stroke="var(--purple-laser)" stroke-width="1.8" stroke-dasharray="4 4" marker-end="url(#seq-arrow-purple)" />
               <text x="420" y="122" fill="var(--purple-laser)" font-family="var(--font-mono)" font-size="11">2. Ephemeral Git Clone (Token over stdin)</text>
 
-              <path d="M 380 165 L 650 165" stroke="var(--green-neon)" stroke-width="2" />
+              <path d="M 380 165 L 650 165" stroke="var(--green-neon)" stroke-width="2" marker-end="url(#seq-arrow-green)" />
               <text x="400" y="157" fill="var(--green-neon)" font-family="var(--font-mono)" font-size="11">3. Spawn Non-Root Container (TTL: 30m, Net: None)</text>
 
-              <path d="M 380 195 L 120 195" stroke="var(--cyan-glow)" stroke-width="1.8" stroke-dasharray="4 4" />
+              <path d="M 380 195 L 120 195" stroke="var(--cyan-glow)" stroke-width="1.8" stroke-dasharray="4 4" marker-end="url(#seq-arrow-cyan)" />
               <text x="160" y="187" fill="var(--text-muted)" font-family="var(--font-mono)" font-size="11">4. Returns opaque workspaceId</text>
 
               <!-- Step 2: Agent Work -->
-              <path d="M 120 240 L 650 240" stroke="var(--cyan-glow)" stroke-width="2" />
+              <path d="M 120 240 L 650 240" stroke="var(--cyan-glow)" stroke-width="2" marker-end="url(#seq-arrow-cyan)" />
               <text x="180" y="232" fill="var(--cyan-glow)" font-family="var(--font-mono)" font-size="11">5. grep_search / files_apply_patch / shell_open / tasks_run</text>
 
-              <path d="M 650 270 L 120 270" stroke="var(--green-neon)" stroke-width="1.8" stroke-dasharray="4 4" />
+              <path d="M 650 270 L 120 270" stroke="var(--green-neon)" stroke-width="1.8" stroke-dasharray="4 4" marker-end="url(#seq-arrow-green)" />
               <text x="240" y="262" fill="var(--green-neon)" font-family="var(--font-mono)" font-size="11">6. Real-time stream results (Zero host leaks)</text>
 
               <!-- Step 3: Git Push & Purge -->
               <path d="M 120 320 L 380 320" stroke="var(--cyan-glow)" stroke-width="2" />
               <text x="150" y="312" fill="var(--cyan-glow)" font-family="var(--font-mono)" font-size="11">7. git_push(refspec, forceWithLease)</text>
 
-              <path d="M 380 345 L 880 345" stroke="var(--purple-laser)" stroke-width="2" />
+              <path d="M 380 345 L 880 345" stroke="var(--purple-laser)" stroke-width="2" marker-end="url(#seq-arrow-purple)" />
               <text x="450" y="337" fill="var(--purple-laser)" font-family="var(--font-mono)" font-size="11">8. Broker push via short-lived stdin helper</text>
 
-              <path d="M 120 380 L 380 380" stroke="#f59e0b" stroke-width="2" />
+              <path d="M 120 380 L 380 380" stroke="#f59e0b" stroke-width="2" marker-end="url(#seq-arrow-amber)" />
               <text x="150" y="372" fill="#f59e0b" font-family="var(--font-mono)" font-size="11">9. workspace_close → Container & volumes destroyed (0 residual state)</text>
             </svg>
           </div>

--- a/site/variants/variant-1-cyber-hud.html
+++ b/site/variants/variant-1-cyber-hud.html
@@ -1225,7 +1225,7 @@
       <section class="section-wrap" id="workflows">
         <div class="section-header">
           <div class="section-tag">// Lifecycle Dynamics</div>
-          <h2 class="section-title">End-to-End Agent Coding Workflow</h2>
+          <h2 class="section-title">Bounded Coding Workflow</h2>
           <p style="color: var(--text-muted);">
             A high-velocity, deterministic sequence from workspace boot to safe git push and automatic sandbox purging.
           </p>

--- a/test/site-diagram-geometry.test.ts
+++ b/test/site-diagram-geometry.test.ts
@@ -45,6 +45,8 @@ describe('marketing site diagram and structure verification', () => {
     expect(page).toContain('https://agentkit.best');
     expect(page).toContain('https://goclaw.sh');
     expect(page).toContain('githubStarsCount');
+    expect(page).toContain('Bounded Coding Workflow');
+    expect(page).toContain('seq-arrow-cyan');
     expect(page).toContain('agents_spawn');
     expect(page).toContain('symbols_search');
     expect(page).toContain('workspace_open');


### PR DESCRIPTION
## Summary
- Prevents header overflow on mobile screens (<= 768px) by showing compact logo, GitHub stars pill, and hamburger menu.
- Adds prominent Connect Agent CTA to top of mobile drawer.
- Ensures all elements fit comfortably within 320px-430px mobile viewports without horizontal clipping.