### PR TITLE
fix(github): inherit contents write permission from installation payload

### DIFF
--- a/apps/runner/src/github-api-installation-verifier.ts
+++ b/apps/runner/src/github-api-installation-verifier.ts
@@ -7,6 +7,7 @@ import type { VerifiedGitHubInstallation } from './github-installation-store.js'
 type InstallationPayload = {
   id?: number; app_id?: number; suspended_at?: string | null;
   account?: { id?: number; login?: string };
+  permissions?: { contents?: string; [key: string]: string | undefined };
 };
 type RepositoriesPayload = {
   total_count?: number;
@@ -80,6 +81,7 @@ export class GitHubApiInstallationVerifier implements GitHubInstallationVerifier
     if (!installation.id || !installation.app_id || !installation.account?.id || !installation.account.login) {
       throw new HarnessError('UNAVAILABLE', 'GitHub returned an invalid installation record', 502, true);
     }
+    const installationContents = installation.permissions?.contents;
     return {
       appId: installation.app_id,
       installationId: installation.id,
@@ -88,7 +90,9 @@ export class GitHubApiInstallationVerifier implements GitHubInstallationVerifier
       status: installation.suspended_at ? 'suspended' : 'active',
       repositories: repositories.map((repository) => {
         const permissions = repository.permissions;
-        const contents = permissions?.contents === 'write' || permissions?.push === true
+        const contents = installationContents === 'write' ||
+          permissions?.contents === 'write' ||
+          permissions?.push === true
           ? 'write'
           : 'read';
         return { owner: repository.owner!.login!, repository: repository.name!, contents } as const;

--- a/apps/runner/test/github-api-installation-verifier.test.ts
+++ b/apps/runner/test/github-api-installation-verifier.test.ts
@@ -85,4 +85,25 @@ describe('GitHub API installation verifier', () => {
     );
     await expect(verifier.verifyInstallation('456')).rejects.toMatchObject({ code: 'TIMEOUT' });
   });
+  it('inherits contents: write from installation-level permissions when repository permissions omit contents', async () => {
+    const writeInstallation = {
+      id: 456, app_id: 123, suspended_at: null,
+      account: { id: 789, login: 'acme' },
+      permissions: { contents: 'write', metadata: 'read', workflows: 'write' }
+    };
+    const realGithubRepo = {
+      name: 'cmai',
+      owner: { login: 'mrgoonie' },
+      permissions: { admin: false, maintain: false, push: false, triage: false, pull: true }
+    };
+    const request = vi.fn(async (input: URL | RequestInfo) => String(input).includes('/app/installations/')
+      ? Response.json(writeInstallation)
+      : Response.json({ total_count: 1, repositories: [realGithubRepo] })) as typeof fetch;
+
+    const verified = await new GitHubApiInstallationVerifier(githubApp, request).verifyInstallation('456');
+    expect(verified.repositories).toEqual([
+      { owner: 'mrgoonie', repository: 'cmai', contents: 'write' }
+    ]);
+  });
+
 });


### PR DESCRIPTION
## Summary

Inherit `contents: write` repository permission from the GitHub App `installation.permissions` payload in `GitHubApiInstallationVerifier`.

## Root Cause & Changes

- **Root Cause:** In GitHub REST API, repository objects returned by `GET /installation/repositories` (when called with an installation access token) do not contain `permissions.contents` (which is an app-level installation permission), and `permissions.push` is not computed for app installation tokens. `GitHubApiInstallationVerifier` only inspected `repository.permissions?.contents` and `repository.permissions?.push`, causing repository grants to always evaluate to `contents: 'read'`.
- **Fix:**
  - Update `InstallationPayload` type in `apps/runner/src/github-api-installation-verifier.ts` to include `permissions?: { contents?: string; [key: string]: string | undefined }`.
  - In `verifyInstallation`, check `installation.permissions?.contents === 'write'` and inherit `contents: 'write'` for all repositories in the installation.
  - Added unit test in `apps/runner/test/github-api-installation-verifier.test.ts` verifying `contents: 'write'` inheritance.

## Verification Evidence

- `npm run verify` passed cleanly (plugin check, lint, typecheck, all 293 tests, and build).

## Linked Issues
None

## Ship Mode
official