### PR TITLE
feat(mailbox): add ChatGPT capability probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ AUTH_MODE=owner-bearer
 # API_KEY_GATEWAY_SERVICE_SUBJECT=cf-service:base64url-cloudflare-service-token-client-id
 # API_KEY_GATEWAY_PUBLIC_URL=https://api.harness.zuey.me/mcp
 # Worker-only secrets CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET are configured with Wrangler, never here.
+# Internal spike endpoint; exposes /mcp-mailbox-probe when true.
+# MAILBOX_PROBE_ENABLED=false
 # Exact one-time legacy owner binding for the first Access rollout:
 # ACCESS_LEGACY_OWNER_ID=owner
 # ACCESS_LEGACY_ISSUER=https://your-team.cloudflareaccess.com

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import { accessAssertionAuth, apiKeyGatewayAuth, bearerAuth } from './auth.js';
 import { createDashboardAssetsRouter } from './dashboard-assets.js';
 import { createDashboardRouter } from './dashboard-router.js';
 import { createCloudHarnessServerFactory } from './mcp-server.js';
+import { createMailboxProbeServerFactory } from './mailbox-probe-server.js';
 import { preAuthRequestLimits, principalRequestLimits, requestSecurity } from './request-security.js';
 import { RunnerClient } from './runner-client.js';
 
@@ -16,6 +17,8 @@ export function createApiApp(config: ApiConfig): ApiRuntime {
   const runnerClient = new RunnerClient(config);
   const handler = createMcpHandler(createCloudHarnessServerFactory(runnerClient), { legacy: 'stateless', responseMode: 'auto' });
   const nodeHandler = toNodeHandler(handler);
+  const probeHandler = config.mailboxProbeEnabled ? createMcpHandler(createMailboxProbeServerFactory(runnerClient), { legacy: 'stateless', responseMode: 'auto' }) : undefined;
+  const probeNodeHandler = probeHandler ? toNodeHandler(probeHandler) : undefined;
   app.disable('x-powered-by');
   app.get('/healthz', (_request, response) => response.json({ status: 'ok' }));
   app.get('/readyz', async (_request, response) => {
@@ -31,6 +34,17 @@ export function createApiApp(config: ApiConfig): ApiRuntime {
     }
     await nodeHandler(request, response, request.body);
   });
+  if (probeNodeHandler) {
+    app.use('/mcp-mailbox-probe', requestSecurity(config), preAuthRequestLimits(), bearerAuth(config), principalRequestLimits());
+    app.use('/mcp-mailbox-probe', express.json({ limit: config.maxBodyBytes, strict: true }));
+    app.all('/mcp-mailbox-probe', async (request: Request, response: Response) => {
+      if (request.method === 'POST' && !request.is('application/json')) {
+        response.status(415).json({ error: 'unsupported_media_type' });
+        return;
+      }
+      await probeNodeHandler(request, response, request.body);
+    });
+  }
   if (config.authMode === 'cloudflare-access' && config.apiKeyAuthEnabled) {
     app.use('/mcp-api-key', requestSecurity(config), preAuthRequestLimits(), apiKeyGatewayAuth(config, runnerClient), principalRequestLimits());
     app.use('/mcp-api-key', express.json({ limit: config.maxBodyBytes, strict: true }));
@@ -47,5 +61,5 @@ export function createApiApp(config: ApiConfig): ApiRuntime {
     app.use('/dashboard', createDashboardRouter(config, runnerClient));
     app.use('/dashboard', createDashboardAssetsRouter());
   }
-  return { app, close: () => handler.close(), runnerClient };
+  return { app, close: async () => { await handler.close(); await probeHandler?.close(); }, runnerClient };
 }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -31,5 +31,6 @@ export function loadApiConfig(): ApiConfig {
     apiKeyGatewayAccessAudience: environment('API_KEY_GATEWAY_ACCESS_AUDIENCE'),
     apiKeyGatewayServiceSubject: environment('API_KEY_GATEWAY_SERVICE_SUBJECT'),
     apiKeyGatewayPublicUrl: environment('API_KEY_GATEWAY_PUBLIC_URL')
+    ,mailboxProbeEnabled: environment('MAILBOX_PROBE_ENABLED')
   });
 }

--- a/apps/api/src/mailbox-probe-server.ts
+++ b/apps/api/src/mailbox-probe-server.ts
@@ -1,0 +1,314 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
+import { McpServer, type CallToolResult, type McpRequestContext } from '@modelcontextprotocol/server';
+import { ToolResultSchema, type RunnerPrincipalSelector, type ToolResult } from '@cloud-harness/contracts';
+import { z } from 'zod';
+import { principalFromAuthInfo } from './auth.js';
+import { MAILBOX_PROBE_RESOURCE_URI, MCP_APP_RESOURCE_MIME_TYPE, mailboxProbeWidgetHtml } from './mailbox-probe-widget-resource.js';
+import type { RunnerClient } from './runner-client.js';
+type MailboxProbeRunnerClient = Pick<RunnerClient, 'call'>;
+
+
+const capabilityHash = (capability: string) => createHash('sha256').update(capability).digest();
+const secret = () => randomBytes(32).toString('base64url');
+const sessionId = () => `mbp_${randomBytes(18).toString('base64url')}`;
+const requestId = () => `mpr_${randomBytes(18).toString('base64url')}`;
+const RESOURCE_META = {
+  ui: {
+    prefersBorder: true,
+    csp: { connectDomains: [], resourceDomains: [] }
+  },
+  'openai/widgetDescription': 'A Cloud Harness mailbox probe that checks widget-private metadata, app-only polling, PiP continuity, and autonomous follow-up turns.',
+  'openai/widgetPrefersBorder': true,
+  'openai/widgetCSP': { connect_domains: [], resource_domains: [] }
+} as const;
+
+type ProbeRequest = { id: string; prompt: string; availableAt: number; deliveredAt?: number; completedAt?: number };
+type ProbeSession = {
+  id: string;
+  principalKey: string;
+  capabilityHash: Buffer;
+  requests: ProbeRequest[];
+  nextRequest: number;
+  firstSubmitAt?: number;
+};
+
+const ProbeSubmitInputSchema = z.object({
+  version: z.literal(1),
+  requestId: z.string().regex(/^mpr_[A-Za-z0-9_-]{20,}$/),
+  status: z.literal('completed'),
+  message: z.object({
+    role: z.literal('assistant'),
+    content: z.array(z.object({ type: z.literal('output_text'), text: z.string().min(1).max(4_000) }).strict()).min(1).max(8)
+  }).strict(),
+  finishReason: z.literal('stop'),
+  data: z.null(),
+  error: z.null()
+}).strict();
+
+type ProbeSubmitInput = z.infer<typeof ProbeSubmitInputSchema>;
+
+const ReceiveInputSchema = z.object({
+  sessionId: z.string().regex(/^mbp_[A-Za-z0-9_-]{20,}$/),
+  capability: z.string().min(32).max(128),
+  waitMs: z.number().int().min(0).max(20_000).default(0)
+}).strict();
+
+type ReceiveInput = z.infer<typeof ReceiveInputSchema>;
+const WorkspaceListInputSchema = z.object({ cursor: z.string().max(256).optional(), limit: z.number().int().min(1).max(500).default(100) }).strict();
+
+
+function principalKey(principal: RunnerPrincipalSelector): string {
+  return principal.kind === 'owner'
+    ? `owner:${principal.ownerId}`
+    : `external:${principal.issuer}:${principal.subject}`;
+}
+
+function resultToMcp(result: ToolResult): CallToolResult {
+  return {
+    content: [{ type: 'text', text: result.message }],
+    structuredContent: result,
+    isError: !result.ok
+  };
+}
+
+function authError(): CallToolResult {
+  return resultToMcp({
+    ok: false,
+    message: 'Authentication context unavailable',
+    error: { code: 'AUTHENTICATION_FAILED', message: 'Authentication context unavailable', retryable: false },
+    truncated: false
+  });
+}
+
+function makeSession(principal: RunnerPrincipalSelector): { session: ProbeSession; capability: string } {
+  const capability = secret();
+  const now = Date.now();
+  const session: ProbeSession = {
+    id: sessionId(),
+    principalKey: principalKey(principal),
+    capabilityHash: capabilityHash(capability),
+    nextRequest: 0,
+    requests: [{
+      id: requestId(),
+      prompt: 'Probe turn 1: call agent_probe_submit with a strict ProbeResponseV1 object and no native-text-only completion.',
+      availableAt: now + 25
+    }]
+  };
+  return { session, capability };
+}
+
+function verifySession(sessions: Map<string, ProbeSession>, input: ReceiveInput, principal: RunnerPrincipalSelector): ProbeSession | undefined {
+  const session = sessions.get(input.sessionId);
+  if (!session || session.principalKey !== principalKey(principal)) return undefined;
+  const presented = capabilityHash(input.capability);
+  if (presented.length !== session.capabilityHash.length || !timingSafeEqual(presented, session.capabilityHash)) return undefined;
+  return session;
+}
+
+function nextAvailableRequest(session: ProbeSession): ProbeRequest | undefined {
+  const candidate = session.requests[session.nextRequest];
+  if (!candidate || candidate.availableAt > Date.now()) return undefined;
+  candidate.deliveredAt ??= Date.now();
+  return candidate;
+}
+
+async function receiveProbe(session: ProbeSession, waitMs: number, signal?: AbortSignal): Promise<CallToolResult> {
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    const request = nextAvailableRequest(session);
+    if (request) {
+      return {
+        content: [{ type: 'text', text: `Mailbox probe request ${request.id} received.` }],
+        structuredContent: {
+          received: true,
+          sessionId: session.id,
+          request: { id: request.id, prompt: request.prompt }
+        }
+      };
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      return {
+        content: [{ type: 'text', text: 'No mailbox probe request is ready.' }],
+        structuredContent: { received: false, sessionId: session.id }
+      };
+    }
+    await delay(Math.min(remaining, 50), undefined, { signal });
+  }
+}
+
+function submitProbe(sessions: Map<string, ProbeSession>, input: ProbeSubmitInput, principal: RunnerPrincipalSelector): CallToolResult {
+  for (const session of sessions.values()) {
+    if (session.principalKey !== principalKey(principal)) continue;
+    const request = session.requests.find((candidate) => candidate.id === input.requestId);
+    if (!request || request.completedAt) continue;
+    request.completedAt = Date.now();
+    if (session.nextRequest === 0) {
+      session.nextRequest = 1;
+      session.firstSubmitAt = request.completedAt;
+      session.requests.push({
+        id: requestId(),
+        prompt: 'Probe turn 2: call agent_probe_submit again, proving the widget resumed polling after the first autonomous turn settled.',
+        availableAt: request.completedAt + 25
+      });
+    } else {
+      session.nextRequest += 1;
+    }
+    return {
+      content: [{ type: 'text', text: `Probe response accepted for ${input.requestId}.` }],
+      structuredContent: {
+        accepted: true,
+        requestId: input.requestId,
+        nextRequestReady: session.nextRequest < session.requests.length,
+        firstSubmitAt: session.firstSubmitAt
+      }
+    };
+  }
+  return {
+    content: [{ type: 'text', text: `Probe request ${input.requestId} is unavailable or already completed.` }],
+    structuredContent: { accepted: false, requestId: input.requestId },
+    isError: true
+  };
+}
+
+export function createMailboxProbeServer(client: MailboxProbeRunnerClient, sessions: Map<string, ProbeSession>, principal?: RunnerPrincipalSelector): McpServer {
+  const server = new McpServer(
+    { name: 'cloud-harness-mailbox-probe', version: '0.17.0' },
+    { instructions: 'Mailbox probe profile only: open the probe widget, let it poll, and answer probe requests only through agent_probe_submit.' }
+  );
+
+  server.registerResource(
+    'Cloud Harness Mailbox Probe Widget',
+    MAILBOX_PROBE_RESOURCE_URI,
+    {
+      title: 'Cloud Harness Mailbox Probe',
+      description: 'Interactive mailbox capability probe widget.',
+      mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+      _meta: RESOURCE_META
+    },
+    async () => ({
+      contents: [{
+        uri: MAILBOX_PROBE_RESOURCE_URI,
+        mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+        text: mailboxProbeWidgetHtml(),
+        _meta: RESOURCE_META
+      }]
+    })
+  );
+
+  server.registerTool(
+    'mailbox_probe_open',
+    {
+      title: 'Open Mailbox Probe',
+      description: 'Mounts the Cloud Harness mailbox capability probe widget.',
+      inputSchema: z.object({}).strict(),
+      outputSchema: z.object({ sessionId: z.string(), resourceUri: z.string(), privateMetadataVisibleToWidget: z.literal(true) }).strict(),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      _meta: {
+        ui: { resourceUri: MAILBOX_PROBE_RESOURCE_URI, visibility: ['model', 'app'] },
+        'ui/resourceUri': MAILBOX_PROBE_RESOURCE_URI,
+        'openai/outputTemplate': MAILBOX_PROBE_RESOURCE_URI,
+        'openai/toolInvocation/invoking': 'Opening probe',
+        'openai/toolInvocation/invoked': 'Probe opened'
+      }
+    },
+    async () => {
+      if (!principal) return authError();
+      const created = makeSession(principal);
+      sessions.set(created.session.id, created.session);
+      return {
+        content: [{
+          type: 'resource_link',
+          uri: MAILBOX_PROBE_RESOURCE_URI,
+          name: 'Cloud Harness Mailbox Probe',
+          mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+          description: 'Mailbox probe widget'
+        }],
+        structuredContent: {
+          sessionId: created.session.id,
+          resourceUri: MAILBOX_PROBE_RESOURCE_URI,
+          privateMetadataVisibleToWidget: true
+        },
+        _meta: {
+          mailboxProbeSessionId: created.session.id,
+          mailboxProbeCapability: created.capability,
+          mailboxProbePrivateMarker: 'widget-only'
+        }
+      } satisfies CallToolResult;
+    }
+  );
+
+  server.registerTool(
+    'mailbox_probe_receive',
+    {
+      title: 'Receive Mailbox Probe Request',
+      description: 'App-only bounded long poll for one in-memory mailbox probe request.',
+      inputSchema: ReceiveInputSchema,
+      outputSchema: z.object({
+        received: z.boolean(),
+        sessionId: z.string(),
+        request: z.object({ id: z.string(), prompt: z.string() }).strict().optional()
+      }).strict(),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      _meta: {
+        ui: { resourceUri: MAILBOX_PROBE_RESOURCE_URI, visibility: ['app'] },
+        'ui/resourceUri': MAILBOX_PROBE_RESOURCE_URI,
+        'openai/widgetAccessible': true,
+        'openai/visibility': 'private'
+      }
+    },
+    async (input, context) => {
+      if (!principal) return authError();
+      const parsed = ReceiveInputSchema.parse(input);
+      const session = verifySession(sessions, parsed, principal);
+      if (!session) {
+        return {
+          content: [{ type: 'text', text: 'Mailbox probe capability rejected.' }],
+          structuredContent: { received: false, sessionId: parsed.sessionId },
+          isError: true
+        };
+      }
+      return await receiveProbe(session, parsed.waitMs, context.mcpReq.signal);
+    }
+  );
+
+  server.registerTool(
+    'agent_probe_submit',
+    {
+      title: 'Submit Probe Response',
+      description: 'Submit the strict ProbeResponseV1 required by the mailbox capability probe.',
+      inputSchema: ProbeSubmitInputSchema,
+      outputSchema: z.object({ accepted: z.boolean(), requestId: z.string(), nextRequestReady: z.boolean().optional(), firstSubmitAt: z.number().optional() }).strict(),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: false }
+    },
+    async (input) => {
+      if (!principal) return authError();
+      return submitProbe(sessions, ProbeSubmitInputSchema.parse(input), principal);
+    }
+  );
+
+  server.registerTool(
+    'workspace_list',
+    {
+      title: 'List Workspaces',
+      description: 'Harmless read-only Cloud Harness capability included for probe discovery boundary checks.',
+      inputSchema: WorkspaceListInputSchema,
+      outputSchema: ToolResultSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }
+    },
+    async (input, context) => {
+      if (!principal) return authError();
+      const parsed = WorkspaceListInputSchema.parse(input);
+      const runnerInput: Record<string, unknown> = { ...parsed };
+      return resultToMcp(await client.call('workspace_list', runnerInput, principal, context.mcpReq.signal));
+    }
+  );
+
+  return server;
+}
+
+export function createMailboxProbeServerFactory(client: MailboxProbeRunnerClient): (context: McpRequestContext) => McpServer {
+  const sessions = new Map<string, ProbeSession>();
+  return (context) => createMailboxProbeServer(client, sessions, principalFromAuthInfo(context.authInfo));
+}

--- a/apps/api/src/mailbox-probe-widget-resource.ts
+++ b/apps/api/src/mailbox-probe-widget-resource.ts
@@ -1,0 +1,76 @@
+export const MAILBOX_PROBE_RESOURCE_URI = 'ui://cloud-harness/mailbox-probe.html';
+export const MCP_APP_RESOURCE_MIME_TYPE = 'text/html;profile=mcp-app';
+
+export function mailboxProbeWidgetHtml(): string {
+  return String.raw`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Cloud Harness Mailbox Probe</title>
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; }
+    body { margin: 0; padding: 16px; background: Canvas; color: CanvasText; }
+    main { display: grid; gap: 12px; }
+    code { overflow-wrap: anywhere; }
+    .status { padding: 10px 12px; border: 1px solid color-mix(in oklab, CanvasText 20%, transparent); border-radius: 10px; }
+  </style>
+</head>
+<body>
+  <main>
+    <strong>Cloud Harness mailbox capability probe</strong>
+    <div id="status" class="status">booting</div>
+    <code id="request"></code>
+  </main>
+  <script>
+    const statusEl = document.getElementById('status');
+    const requestEl = document.getElementById('request');
+    const log = (message) => { statusEl.textContent = message; };
+    const openai = window.openai;
+    const metadata = openai?.toolResponseMetadata?.mcp_tool_result?._meta
+      ?? openai?.toolResponseMetadata?.call_tool_result?._meta
+      ?? openai?.toolResponseMetadata?._meta
+      ?? {};
+    const sessionId = metadata.mailboxProbeSessionId;
+    const capability = metadata.mailboxProbeCapability;
+    const dispatchedRequestIds = new Set(Array.isArray(openai?.widgetState?.dispatchedRequestIds) ? openai.widgetState.dispatchedRequestIds : []);
+    let displayModeRequested = false;
+
+    async function receiveOnce() {
+      if (!openai?.callTool) throw new Error('ChatGPT bridge missing callTool');
+      const result = await openai.callTool('mailbox_probe_receive', { sessionId, capability, waitMs: 20000 });
+      const payload = result?.structuredContent ?? {};
+      if (!payload.received) return false;
+      requestEl.textContent = JSON.stringify(payload.request, null, 2);
+      if (!dispatchedRequestIds.has(payload.request.id)) {
+        dispatchedRequestIds.add(payload.request.id);
+        openai.setWidgetState?.({ dispatchedRequestIds: Array.from(dispatchedRequestIds) });
+        if (!displayModeRequested) {
+          displayModeRequested = true;
+          await openai.requestDisplayMode?.({ mode: 'picture-in-picture' });
+        }
+        if (!openai.sendFollowUpMessage) throw new Error('ChatGPT bridge missing sendFollowUpMessage');
+        await openai.sendFollowUpMessage({ prompt: payload.request.prompt + '\\n\\nUse requestId ' + payload.request.id + ' in the required agent_probe_submit call. Do not include or ask for any widget capability.', scrollToBottom: false });
+        log('follow-up sent for ' + payload.request.id + '; waiting for strict submit');
+      } else {
+        log('request already dispatched; waiting for strict submit');
+      }
+      return true;
+    }
+
+    async function loop() {
+      if (!sessionId || !capability) throw new Error('missing widget-private probe capability');
+      log('polling');
+      for (;;) {
+        await receiveOnce();
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+    }
+
+    loop().catch((error) => {
+      log(error instanceof Error ? error.message : String(error));
+    });
+  </script>
+</body>
+</html>`;
+}

--- a/apps/api/test/access-auth.test.ts
+++ b/apps/api/test/access-auth.test.ts
@@ -141,7 +141,8 @@ describe('Access authentication middleware', () => {
     host: '127.0.0.1', port: 3000, authMode: 'cloudflare-access', ownerId: 'owner',
     accessIssuer: issuer, accessAudience: audience, accessJwksUrl: jwksUrl,
     runnerUrl: 'http://runner:3001', runnerToken: 'runner-token-that-is-longer-than-32-characters',
-    publicHosts: ['localhost'], allowedOrigins: [], requestTimeoutMs: 2_000, maxBodyBytes: 65_536
+    publicHosts: ['localhost'], allowedOrigins: [], requestTimeoutMs: 2_000, maxBodyBytes: 65_536,
+    apiKeyAuthEnabled: false, mailboxProbeEnabled: false
   };
 
   function response() {

--- a/apps/api/test/api-key-gateway-auth.test.ts
+++ b/apps/api/test/api-key-gateway-auth.test.ts
@@ -30,7 +30,8 @@ const config: ApiConfig = {
   apiKeyAuthEnabled: true, apiKeyGatewayAccessAudience: gatewayAudience,
   apiKeyGatewayServiceSubject: gatewaySubject, apiKeyGatewayPublicUrl: 'https://api.harness.example/mcp',
   runnerUrl: 'http://runner:3001', runnerToken: 'runner-token-that-is-longer-than-32-characters',
-  publicHosts: ['localhost'], allowedOrigins: [], requestTimeoutMs: 2_000, maxBodyBytes: 65_536
+  publicHosts: ['localhost'], allowedOrigins: [], requestTimeoutMs: 2_000, maxBodyBytes: 65_536,
+  mailboxProbeEnabled: false
 };
 
 const verifier = {

--- a/apps/api/test/dashboard-router.test.ts
+++ b/apps/api/test/dashboard-router.test.ts
@@ -16,7 +16,8 @@ const config: ApiConfig = {
   apiKeyAuthEnabled: true, apiKeyGatewayAccessAudience: 'api-key-audience',
   apiKeyGatewayServiceSubject: 'cf-service:d29ya2Vy', apiKeyGatewayPublicUrl: 'https://api.example/mcp',
   runnerToken: 'runner-token-that-is-longer-than-32-characters', publicHosts: ['dashboard.example'],
-  allowedOrigins: ['https://dashboard.example'], requestTimeoutMs: 2_000, maxBodyBytes: 65_536
+  allowedOrigins: ['https://dashboard.example'], requestTimeoutMs: 2_000, maxBodyBytes: 65_536,
+  mailboxProbeEnabled: false
 };
 
 type Reply = { status: number; headers: Record<string, string | string[] | undefined>; text: string; json: any };

--- a/apps/api/test/http-security.test.ts
+++ b/apps/api/test/http-security.test.ts
@@ -9,7 +9,7 @@ let runtime: ApiRuntime;
 let url: string;
 
 beforeEach(async () => {
-  const config: ApiConfig = { host: '127.0.0.1', port: 0, ownerId: 'owner', bearerToken: token, runnerUrl: 'http://127.0.0.1:9', runnerToken: 'runner-token-that-is-longer-than-32-characters', publicHosts: ['127.0.0.1'], allowedOrigins: ['https://allowed.example'], requestTimeoutMs: 2_000, maxBodyBytes: 65_536 };
+  const config: ApiConfig = { host: '127.0.0.1', port: 0, ownerId: 'owner', bearerToken: token, runnerUrl: 'http://127.0.0.1:9', runnerToken: 'runner-token-that-is-longer-than-32-characters', publicHosts: ['127.0.0.1'], allowedOrigins: ['https://allowed.example'], requestTimeoutMs: 2_000, maxBodyBytes: 65_536, apiKeyAuthEnabled: false, mailboxProbeEnabled: false };
   runtime = createApiApp(config);
   server = createServer(runtime.app);
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));

--- a/apps/api/test/mailbox-probe-contract.test.ts
+++ b/apps/api/test/mailbox-probe-contract.test.ts
@@ -1,0 +1,173 @@
+import { createServer, type Server } from 'node:http';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { InMemoryTransport, type AuthInfo } from '@modelcontextprotocol/server';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ApiConfig, RunnerPrincipalSelector } from '@cloud-harness/contracts';
+import { createApiApp, type ApiRuntime } from '../src/app.js';
+import { createMailboxProbeServerFactory } from '../src/mailbox-probe-server.js';
+import { MAILBOX_PROBE_RESOURCE_URI, MCP_APP_RESOURCE_MIME_TYPE } from '../src/mailbox-probe-widget-resource.js';
+
+const bearer = 'mailbox-probe-bearer-token-that-is-long-enough';
+const principal: RunnerPrincipalSelector = { kind: 'external', issuer: 'https://team.cloudflareaccess.com', subject: 'chatgpt-user' };
+const authInfo: AuthInfo = { token: 'opaque', clientId: 'chatgpt-user', scopes: [], extra: { principal, externalPrincipal: { issuer: principal.issuer, subject: principal.subject } } };
+
+const runnerClient = {
+  async call() {
+    return { ok: true as const, message: 'Stub runner result', data: { workspaces: [] }, truncated: false };
+  }
+};
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+
+function field(record: unknown, key: string): unknown {
+  return isRecord(record) ? record[key] : undefined;
+}
+
+async function inMemoryClient(): Promise<{ client: Client; close: () => Promise<void> }> {
+  const factory = createMailboxProbeServerFactory(runnerClient);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const server = factory({ era: 'modern', authInfo });
+  const client = new Client({ name: 'mailbox-probe-test', version: '1.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, close: async () => { await client.close(); await server.close(); } };
+}
+
+async function openProbe(client: Client): Promise<{ sessionId: string; capability: string; firstRequestId: string }> {
+  const opened = await client.callTool({ name: 'mailbox_probe_open', arguments: {} });
+  const meta = opened._meta;
+  const sessionId = text(field(meta, 'mailboxProbeSessionId'));
+  const capability = text(field(meta, 'mailboxProbeCapability'));
+  expect(sessionId).toMatch(/^mbp_/);
+  expect(capability.length).toBeGreaterThan(40);
+  expect(JSON.stringify(opened.structuredContent)).not.toContain(capability);
+  expect(JSON.stringify(opened.content)).not.toContain(capability);
+
+  const rejected = await client.callTool({ name: 'mailbox_probe_receive', arguments: { sessionId, capability: 'wrong-capability-that-is-long-enough', waitMs: 0 } });
+  expect(rejected.isError).toBe(true);
+
+  const received = await client.callTool({ name: 'mailbox_probe_receive', arguments: { sessionId, capability, waitMs: 500 } });
+  expect(field(received.structuredContent, 'received')).toBe(true);
+  const request = field(received.structuredContent, 'request');
+  const firstRequestId = text(field(request, 'id'));
+  expect(firstRequestId).toMatch(/^mpr_/);
+  return { sessionId, capability, firstRequestId };
+}
+
+const validSubmit = (requestId: string) => ({
+  version: 1,
+  requestId,
+  status: 'completed',
+  message: { role: 'assistant', content: [{ type: 'output_text', text: 'probe ok' }] },
+  finishReason: 'stop',
+  data: null,
+  error: null
+});
+
+let runtime: ApiRuntime | undefined;
+let httpServer: Server | undefined;
+
+afterEach(async () => {
+  await runtime?.close();
+  runtime = undefined;
+  if (httpServer) await new Promise<void>((resolve) => httpServer?.close(() => resolve()));
+  httpServer = undefined;
+});
+
+describe('mailbox probe MCP profile', () => {
+  it('exposes only probe tools plus the read-only allowlisted tool', async () => {
+    const { client, close } = await inMemoryClient();
+    try {
+      const listed = await client.listTools();
+      expect(listed.tools.map((tool) => tool.name).sort()).toEqual(['agent_probe_submit', 'mailbox_probe_open', 'mailbox_probe_receive', 'workspace_list']);
+      expect(listed.tools.find((tool) => tool.name === 'mailbox_probe_receive')?._meta).toMatchObject({ 'openai/widgetAccessible': true, 'openai/visibility': 'private' });
+      expect(listed.tools.map((tool) => tool.name)).not.toContain('exec_run');
+      await expect(client.callTool({ name: 'exec_run', arguments: {} })).rejects.toThrow();
+    } finally {
+      await close();
+    }
+  });
+
+  it('serves an MCP App resource that contains the ChatGPT autonomy probe hooks', async () => {
+    const { client, close } = await inMemoryClient();
+    try {
+      await client.callTool({ name: 'mailbox_probe_open', arguments: {} });
+      const resources = await client.listResources();
+      expect(resources.resources.find((resource) => resource.uri === MAILBOX_PROBE_RESOURCE_URI)?.mimeType).toBe(MCP_APP_RESOURCE_MIME_TYPE);
+      const resource = await client.readResource({ uri: MAILBOX_PROBE_RESOURCE_URI });
+      expect(resource.contents[0]).toMatchObject({ uri: MAILBOX_PROBE_RESOURCE_URI, mimeType: MCP_APP_RESOURCE_MIME_TYPE });
+      expect(field(resource.contents[0], '_meta')).toMatchObject({ ui: { prefersBorder: true } });
+      const html = text(field(resource.contents[0], 'text'));
+      expect(html).toContain("callTool('mailbox_probe_receive'");
+      expect(html).toContain('sendFollowUpMessage');
+      expect(html).toContain('requestDisplayMode');
+    } finally {
+      await close();
+    }
+  });
+
+  it('keeps the widget capability out of model-visible result fields and enforces strict submit', async () => {
+    const { client, close } = await inMemoryClient();
+    try {
+      const opened = await openProbe(client);
+      const invalidSubmit = await client.callTool({ name: 'agent_probe_submit', arguments: { ...validSubmit(opened.firstRequestId), extra: 'rejected' } });
+      expect(invalidSubmit.isError).toBe(true);
+      expect(JSON.stringify(invalidSubmit.content)).toContain('Unrecognized key');
+      const accepted = await client.callTool({ name: 'agent_probe_submit', arguments: validSubmit(opened.firstRequestId) });
+      expect(field(accepted.structuredContent, 'accepted')).toBe(true);
+      const second = await client.callTool({ name: 'mailbox_probe_receive', arguments: { sessionId: opened.sessionId, capability: opened.capability, waitMs: 500 } });
+      const secondRequest = field(second.structuredContent, 'request');
+      const secondRequestId = text(field(secondRequest, 'id'));
+      expect(secondRequestId).toMatch(/^mpr_/);
+      expect(secondRequestId).not.toBe(opened.firstRequestId);
+      const secondAccepted = await client.callTool({ name: 'agent_probe_submit', arguments: validSubmit(secondRequestId) });
+      expect(field(secondAccepted.structuredContent, 'accepted')).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it('keeps the draft HTTP endpoint unmounted while the feature gate is disabled', async () => {
+    const config: ApiConfig = {
+      host: '127.0.0.1', port: 0, ownerId: 'owner', bearerToken: bearer,
+      runnerUrl: 'http://127.0.0.1:9', runnerToken: 'runner-token-that-is-longer-than-32-characters',
+      publicHosts: ['127.0.0.1'], allowedOrigins: [], requestTimeoutMs: 2_000, maxBodyBytes: 65_536,
+      apiKeyAuthEnabled: false, mailboxProbeEnabled: false
+    };
+    runtime = createApiApp(config);
+    httpServer = createServer(runtime.app);
+    await new Promise<void>((resolve) => httpServer?.listen(0, '127.0.0.1', resolve));
+    const address = httpServer.address();
+    if (!address || typeof address === 'string') throw new Error('test server failed');
+    const response = await fetch(`http://127.0.0.1:${address.port}/mcp-mailbox-probe`, { method: 'POST', headers: { authorization: `Bearer ${bearer}`, 'content-type': 'application/json' }, body: '{}' });
+    expect(response.status).toBe(404);
+  });
+
+  it('mounts the draft HTTP endpoint only when the feature gate is enabled', async () => {
+    const config: ApiConfig = {
+      host: '127.0.0.1', port: 0, ownerId: 'owner', bearerToken: bearer,
+      runnerUrl: 'http://127.0.0.1:9', runnerToken: 'runner-token-that-is-longer-than-32-characters',
+      publicHosts: ['127.0.0.1'], allowedOrigins: [], requestTimeoutMs: 2_000, maxBodyBytes: 65_536,
+      apiKeyAuthEnabled: false, mailboxProbeEnabled: true
+    };
+    runtime = createApiApp(config);
+    httpServer = createServer(runtime.app);
+    await new Promise<void>((resolve) => httpServer?.listen(0, '127.0.0.1', resolve));
+    const address = httpServer.address();
+    if (!address || typeof address === 'string') throw new Error('test server failed');
+    const endpoint = new URL(`http://127.0.0.1:${address.port}/mcp-mailbox-probe`);
+    const client = new Client({ name: 'mailbox-probe-http-test', version: '1.0.0' }, { versionNegotiation: { mode: { pin: '2026-07-28' } } });
+    await client.connect(new StreamableHTTPClientTransport(endpoint, { requestInit: { headers: { authorization: `Bearer ${bearer}` } } }));
+    expect((await client.listTools()).tools.map((tool) => tool.name).sort()).toEqual(['agent_probe_submit', 'mailbox_probe_open', 'mailbox_probe_receive', 'workspace_list']);
+    const opened = await openProbe(client);
+    const accepted = await client.callTool({ name: 'agent_probe_submit', arguments: validSubmit(opened.firstRequestId) });
+    expect(field(accepted.structuredContent, 'accepted')).toBe(true);
+    await client.close();
+  });
+});

--- a/apps/api/test/runner-client-principal.test.ts
+++ b/apps/api/test/runner-client-principal.test.ts
@@ -5,7 +5,8 @@ import { RunnerClient } from '../src/runner-client.js';
 const config: ApiConfig = {
   host: '127.0.0.1', port: 3000, ownerId: 'owner', bearerToken: 'owner-token-that-is-long-enough-123456',
   runnerUrl: 'http://runner:3001', runnerToken: 'runner-token-that-is-longer-than-32-characters',
-  publicHosts: ['localhost'], allowedOrigins: [], requestTimeoutMs: 2_000, maxBodyBytes: 65_536
+  publicHosts: ['localhost'], allowedOrigins: [], requestTimeoutMs: 2_000, maxBodyBytes: 65_536,
+  apiKeyAuthEnabled: false, mailboxProbeEnabled: false
 };
 
 afterEach(() => vi.unstubAllGlobals());

--- a/packages/contracts/src/config.ts
+++ b/packages/contracts/src/config.ts
@@ -28,6 +28,7 @@ export const ApiConfigSchema = z.object({
   apiKeyGatewayAccessAudience: z.string().min(1).max(512).optional(),
   apiKeyGatewayServiceSubject: z.string().regex(/^cf-service:[A-Za-z0-9_-]+$/).max(512).optional(),
   apiKeyGatewayPublicUrl: httpsUrl.optional(),
+  mailboxProbeEnabled: enabled,
   runnerUrl: z.url(),
   runnerToken: token,
   publicHosts: z.array(z.string().min(1)).min(1),

--- a/plans/260821-0938-web-assistant-openai-compatibility-parity/plan.md
+++ b/plans/260821-0938-web-assistant-openai-compatibility-parity/plan.md
@@ -1,0 +1,124 @@
+---
+title: "Web Assistant OpenAI Compatibility Parity"
+description: "Port CatGPT-Gateway behavior into the durable web-assistant-browser core, omitting only the TUI, then refine compatibility and security after parity."
+status: in-progress
+priority: P1
+effort: "18-30d"
+tags: [openai-compatibility, browser-gateway, parity-port, xia]
+blockedBy: [260823-0614-chatgpt-mailbox-runtime-mvp]
+created: 2026-08-21
+sourceRepo: "GautamVhavle/CatGPT-Gateway"
+sourceCommit: "b203223ea41521b2309bb370e491354a8aaee3ec"
+---
+
+# Web Assistant OpenAI Compatibility Parity
+
+## Overview
+
+Replicate the externally visible API, browser-provider, multimodal, image, tool-calling, thread, provider, and VPS behavior of CatGPT-Gateway on top of `web-assistant-browser`'s existing principal-owned durable run core. Deliver source behavior parity first. Refine security, semantics, streaming, and operations only after the parity gates pass. The TUI is the only explicitly omitted source feature.
+
+Authoritative comparison: [`../260821-web-assistant-browser/reports/xia-catgpt-gateway-openai-compatibility.md`](../260821-web-assistant-browser/reports/xia-catgpt-gateway-openai-compatibility.md).
+
+## User Decisions
+
+- Port source behavior first; optimize/refine afterward.
+- Do not silently cut source capabilities.
+- Omit TUI.
+- Include OpenAI Chat Completions, Responses, models, prompt-based JSON tool calls, multimodal/file input, image generation, custom thread/status routes, Claude, MiniMax, Xvfb/noVNC runtime, completion fallbacks, selector fallbacks, diagnostics, and live compatibility scripts.
+- Preserve the local durable/auth/encryption core unless it prevents parity.
+- Keep native ChatGPT UI evidence distinct from model-authored OpenAI function calls.
+- Public ingress exposes only required OpenAI-compatible and authenticated artifact endpoints.
+- Native `/v1/chat`, `/v1/runs/*`, custom source `/chat`/thread/status routes, readiness, diagnostics, and raw durable events remain loopback/admin-only for execution support and debugging.
+
+## Goals
+
+| # | Goal | Priority |
+|---|---|---|
+| 1 | OpenAI SDK-compatible `/v1/models`, `/v1/chat/completions`, `/v1/responses`, and `/v1/images/generations` | P1 |
+| 2 | Caller-registered function tools using session envelopes, Codex-style JSONL, and correlated outputs | P1 |
+| 3 | Source-compatible vision, file attachments, generated image/file handling | P1 |
+| 4 | Source-compatible custom chat/thread/status routes and ChatGPT/Claude/MiniMax providers | P1 |
+| 5 | Source-compatible headed browser/Xvfb/noVNC runtime and diagnostics | P1 |
+| 6 | Preserve local principals, encryption, idempotency, queueing, cancellation, replay, and recovery | P1 |
+| 7 | Validate with OpenAI Python/JS SDK, LangChain, Responses/Codex patterns, live browser, and VPS smokes | P1 |
+
+## Non-goals
+
+- TUI.
+- Claiming stronger OpenAI semantic fidelity than either implementation actually provides during the parity pass.
+- Removing the native `/v1/chat` and durable event API.
+- Modifying Cloud Harness source or deployment.
+
+## Architecture
+
+```text
+OpenAI / source-compatible clients
+              |
+              v
+Fastify compatibility routes
+  | models | chat completions | responses | images | custom threads |
+              |
+              v
+Compatibility normalization and prompt construction
+              |
+              v
+Provider router
+  | ChatGPT browser | Claude browser | MiniMax HTTP |
+              |
+              v
+Existing RunService / queue / BrowserLease / encrypted SQLite
+              |
+              +--> native durable events
+              +--> OpenAI response/SSE projectors
+              +--> artifact store
+```
+
+## Phases
+
+| # | Phase | Status | Dependencies |
+|---|---|---|---|
+| 1 | [Parity Baseline And Contracts](./phase-01-start.md) | Completed | Existing Phase 2/3 commits |
+| 2 | [Chat Completions And Models](./phase-02-chat-completions-and-models.md) | Completed | 1 |
+| 3 | [Tool Calling](./phase-03-tool-calling.md) | Completed | 2 |
+| 4 | [Responses API](./phase-04-responses-api.md) | Completed | 2, 3 |
+| 5 | [Multimodal Inputs And Uploads](./phase-05-multimodal-inputs-and-uploads.md) | Completed | 2, 3 |
+| 6 | [Images And Artifact Delivery](./phase-06-images-and-artifact-delivery.md) | Completed | 5 |
+| 7 | [Thread And Provider Parity](./phase-07-thread-and-provider-parity.md) | Completed | 2, 3, 5 |
+| 8 | [Browser Runtime And VPS Parity](./phase-08-browser-runtime-and-vps-parity.md) | Completed | 2-7 |
+| 9 | [Compatibility Validation And Rollout](./phase-09-compatibility-validation-and-rollout.md) | Pending | 1-8 |
+
+## Cross-cutting Contracts
+
+- Compatibility routes are additive; native routes remain the internal durable execution/control plane.
+- Public ingress allowlists only required OpenAI-compatible and authenticated artifact endpoints.
+- Native `/v1/chat`, `/v1/runs/*`, custom source routes, health/readiness, and diagnostics are private.
+- Every browser request uses the existing single `RunService`/`BrowserLease`; no second page lock.
+- Original OpenAI items and transformed browser prompts are stored separately and encrypted.
+- `chatgpt_ui` and `model_json` tool evidence never share semantics.
+- Tool registration is scoped to the principal-owned browser session. The exact caller system instructions, registered tools, schemas, and caller-supplied tool-choice rule are synchronized into fingerprinted ChatGPT Custom Instructions; browser turns carry only user or correlated function-output payloads.
+- Agent function requests and final messages use Codex-style JSONL items. Caller results use correlated `function_call_output` wrappers.
+- Unknown names and invalid arguments are corrected from the registered catalog before an OpenAI tool call is accepted.
+- Ambiguous browser submission never auto-resubmits.
+- Source-compatible weak behavior may be enabled behind compatibility configuration, but must not silently disable local ownership/encryption.
+- Every compatibility limitation is covered by an executable contract test and documented in the model/endpoint capability matrix.
+
+## Success Criteria
+
+- [x] OpenAI Python and JavaScript SDKs can list models and perform non-stream Chat Completions.
+- [x] Source-compatible Chat Completions `stream=true` behavior is reproduced, then later refinement is gated separately.
+- [x] LangChain caller tool flow produces validated OpenAI `tool_calls` and accepts correlated outputs.
+- [x] Responses non-stream and buffered SSE work with Codex-style request/response shapes.
+- [x] Vision/file attachments upload through the current ChatGPT composer.
+- [x] Image generation returns `b64_json` and source-compatible URL behavior.
+- [x] Custom chat/thread/status routes match source behavior.
+- [x] ChatGPT, Claude, and MiniMax provider selection works.
+- [x] Headed Xvfb/noVNC production runtime retains one browser/profile/controller.
+- [ ] Source live scripts are ported or replaced with equivalent executable tests.
+- [x] Existing native run/auth/encryption/recovery suite remains green.
+- [ ] TUI is the only source capability intentionally omitted.
+
+## Rollback
+
+Each phase is additive and independently feature-gated. Disable compatibility routes/providers/artifacts without removing native routes or browser profile state. Use versioned migrations and phase-specific commits. VPS rollback removes only the compatibility service route/container and restores the prior independent-service release.
+
+<!-- slug: web-assistant-openai-compatibility-parity -->

--- a/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-01-capability-spike-and-branch-isolation.md
+++ b/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-01-capability-spike-and-branch-isolation.md
@@ -1,0 +1,111 @@
+---
+phase: 1
+title: "Capability Spike And Branch Isolation"
+status: blocked
+priority: P1
+effort: ""
+dependencies: []
+---
+
+# Phase 1: Capability Spike And Branch Isolation
+
+## Overview
+
+Create clean owner-fork worktrees, then prove the decisive ChatGPT/MCP App capabilities with an in-memory vertical slice before committing final contracts, migrations, encryption, WAB integration, docs, or durable queue code. Failure at this gate ends or downgrades the MVP without browser automation.
+
+## Requirements
+
+- Functional: mount one authenticated MCP App resource from a draft Cloud Harness endpoint.
+- Functional: widget performs one bounded delayed app-only receive call and receives one in-memory probe message.
+- Functional: widget calls `sendFollowUpMessage()` from the receive callback without user input and triggers a new model turn.
+- Functional: model calls a strict probe submit tool; widget resumes and proves a second autonomous turn.
+- Security: probe proves widget-private metadata is not model-visible and app-only calls require a server-validated capability.
+- Security: probe ChatGPT endpoint discovers/dispatches only probe tools plus an explicit harmless read-only tool; mutating existing tools are absent and denied.
+- Workflow: implementation occurs only in clean worktrees from pinned owner-fork refs.
+
+## Architecture
+
+Throwaway-capable spike:
+
+```text
+Explicit draft MCP server profile
+  ├─ mailbox_probe_open       model visible; UI resource
+  ├─ mailbox_probe_receive    app callable; requires private widget capability
+  ├─ agent_probe_submit       model visible; strict ProbeResponseV1
+  └─ one harmless read-only capability
+
+In-memory probe state
+  └─ one pending request, one consumer, no migration/reaper/encryption
+```
+
+The spike must also test actual `tools/list`/host discovery behavior. `_meta.ui.visibility` alone is not accepted as authorization evidence.
+
+## Related Code Files
+
+### Cloud Harness
+
+- Modify: `apps/api/src/mcp-server.ts`
+- Create: `apps/api/src/mailbox-probe-server.ts`
+- Create: `apps/api/src/mailbox-probe-widget-resource.ts`
+- Modify: `apps/api/src/app.ts` only for an isolated feature-gated draft path
+- Create: `apps/api/test/mailbox-probe-contract.test.ts`
+- Inspect: `apps/api/package.json` and pinned MCP SDK APIs before dependency changes
+- Do not modify runner SQLite schemas in this phase
+
+### Branch Isolation
+
+- Cloud Harness fork: `https://github.com/therichardngai-code/cloud-harness-mcp`
+- Cloud Harness branch: `feat/chatgpt-mailbox-runtime-mvp`
+- Cloud Harness base: `4149ed8c3ec27de3fb6db511b3ed361a46988811`
+- WAB branch reserved after pass: `feat/cloud-harness-mailbox-provider-mvp`
+- WAB base: `3c2000a44624e4ab46b100afe9072256f2731be2`
+
+## Implementation Steps
+
+1. Verify the owner fork contains the pinned Cloud Harness base and add a separate `fork` remote without repointing `origin`.
+2. Create a clean Cloud Harness worktree/branch and record original checkout status; never stage `.deploy`, plans, or unrelated owner work into implementation commits.
+3. Do not create the WAB worktree until the host capability gate passes; only verify the pinned WAB base exists.
+4. Inspect `@modelcontextprotocol/server` 2.0.0 for resource registration, tool metadata, private result metadata, and app bridge compatibility. Add `@modelcontextprotocol/ext-apps` only if required by the documented pinned API.
+5. Register an isolated feature-gated probe MCP endpoint/server profile; do not alter production `/mcp` discovery.
+6. Register a self-contained `ui://` probe widget and a model-visible `mailbox_probe_open` tool.
+7. Generate a random widget session capability on open; return it only in widget-private result metadata. Store only a hash/server record.
+8. Require that capability on `mailbox_probe_receive`; verify direct model/service calls without it are rejected.
+9. Add one in-memory delayed probe request and make the mounted widget receive it through a bounded app bridge tool call.
+10. From the long-poll callback, invoke `sendFollowUpMessage()` exactly once without mouse/keyboard input.
+11. Require the new model turn to call `agent_probe_submit` with strict `ProbeResponseV1`; reject unknown fields and native-text-only completion.
+12. Resume polling and deliver a second probe request to prove a second autonomous turn after the first turn settles.
+13. Request PiP and verify widget mount/poll continuity after bootstrap and after both turns.
+14. Inspect actual model tool discovery. Prove all existing mutating tools (`exec_run`, writes/deletes, Git mutations, hooks, skills, deployments) are absent and rejected at dispatch.
+15. Record host behavior as pass, semi-autonomous, or fail. If user gesture, remount failure, private metadata leakage, app-only bypass, or second-turn failure occurs, stop before Phase 2.
+16. Only after pass, remove/replace probe-only operations with the final versioned contracts in Phase 2 and create the clean WAB worktree.
+
+
+## Current Evidence
+
+- Cloud Harness owner-fork worktree created at `C:\SaaS\private\worktrees\cloud-harness-mcp-feat-chatgpt-mailbox-runtime-mvp` on branch `feat/chatgpt-mailbox-runtime-mvp`.
+- Verified Cloud Harness base commit `4149ed8c3ec27de3fb6db511b3ed361a46988811` and WAB base commit `3c2000a44624e4ab46b100afe9072256f2731be2` exist locally.
+- Implemented local gated probe profile at `/mcp-mailbox-probe` with in-memory `mailbox_probe_open`, app-capability `mailbox_probe_receive`, strict `agent_probe_submit`, one allowlisted `workspace_list`, and no durable mailbox schema or WAB provider code.
+- Local contract checks passed: `npm run lint`, `npm run typecheck`, and `npm test -- apps/api/test/mailbox-probe-contract.test.ts apps/api/test/http-security.test.ts test/integration/mcp-http.test.ts packages/contracts/test/contracts.test.ts`.
+- Reviewer concerns fixed: probe sessions are factory-scoped across HTTP requests, and the widget sends one follow-up for each new request id without exposing the private capability.
+- Existing public endpoint `https://cloud-harness-mcp.46-250-239-227.sslip.io` is healthy (`/healthz`, `/readyz`) but returns 404 for `/mcp-mailbox-probe`; it is not running this branch/probe code yet.
+- Blocked before Phase 2 until an actual ChatGPT draft host mounts the resource and proves `sendFollowUpMessage()`, PiP persistence, widget-private metadata, and two autonomous submit turns.
+
+## Success Criteria
+
+- [ ] Resource/widget mounts on the actual ChatGPT draft host.
+- [ ] Widget receives a delayed in-memory message through an app call.
+- [ ] `sendFollowUpMessage()` creates two sequential turns without user gesture.
+- [ ] Both turns call strict submit and the widget resumes polling.
+- [ ] Widget-private capability is not visible to the model and is required server-side.
+- [ ] Model discovery/dispatch excludes all mutating existing Cloud Harness operations.
+- [ ] PiP/mount survives the bootstrap and two follow-up turns.
+- [ ] Original Cloud Harness/WAB working trees remain unchanged.
+- [ ] No durable mailbox schema, WAB provider, docs update, or VPS production-like stack is built before this gate passes.
+
+## Risk Assessment
+
+- **Host feature missing:** stop or classify semi-autonomous; do not compensate with Playwright.
+- **Passive visibility only:** fail until private capability/server authorization is proven.
+- **Probe contaminates public contract:** isolated feature-gated server/path and probe names; delete before final contract.
+- **False success from one turn:** two sequential autonomous turns are mandatory.
+- **Branch contamination:** clean worktree and exact remote/base checks before first commit.

--- a/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-02-durable-mailbox-core.md
+++ b/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-02-durable-mailbox-core.md
@@ -1,0 +1,151 @@
+---
+phase: 2
+title: "Durable Mailbox Core"
+status: pending
+priority: P1
+effort: ""
+dependencies: [1]
+---
+
+# Phase 2: Durable Mailbox Core
+
+## Overview
+
+After Phase 1 passes, replace the in-memory probe with a runner-owned encrypted queue, caller capability profiles, consumer generation, dispatch fencing, renewable leases, cancellation, strict response V1, and explicit process lifecycle. SQLite is authoritative; waiters are disposable acceleration.
+
+## Requirements
+
+- Functional: implement the nine final operations in separate model/widget/service registries.
+- Functional: enqueue only against an expected fresh consumer generation, atomically preventing the presence-check/send race.
+- Functional: lease, renew, mark accepted dispatch, submit strict response, release pre-dispatch failure, cancel, get, and report status.
+- Reliability: accepted model turns are never automatically redelivered; lost dispatched turns become `outcome_unknown` at an absolute deadline.
+- Reliability: runner restart preserves queued/completed state and safely handles leased/dispatched attempts.
+- Security: widget operations require a server-validated widget session capability; service operations require a scoped service caller profile.
+- Security: autonomous model discovery/dispatch uses an explicit read-only allowlist enforced in API and runner, not annotations.
+- Security: encrypt bodies with runner key material and exclude secrets/content from logs/audit.
+
+## Architecture
+
+```text
+RunnerOperationService.execute(principal, callerProfile, operation, input)
+  ├─ final mailbox operation → MailboxService
+  └─ allowed workspace op    → WorkspaceService
+
+MCP/API registries
+  ├─ mailbox-model:  mailbox_open, agent_response_submit, read-only allowlist
+  ├─ mailbox-widget: receive/get/status/renew/release + widget capability
+  └─ mailbox-service: send/get/status/cancel + service credential
+```
+
+Process ownership:
+
+```text
+apps/runner/src/index.ts
+  ├─ one StateStore/database authority
+  ├─ migrations on the existing database handle
+  ├─ one MailboxStore
+  ├─ one MailboxService.start()/stop()
+  ├─ one waiter registry
+  └─ one lease/retention reaper cleared before DB close
+```
+
+State machine:
+
+```text
+queued → leased → dispatched → completed
+  │         │          ├→ cancel_requested
+  │         ├→ queued/dead_letter (release before accepted dispatch)
+  │         └→ cancelled
+  └→ cancelled
+
+dispatched + absolute deadline → outcome_unknown (manual decision, no redelivery)
+```
+
+## Final Contracts
+
+- `mailbox_open`: model registry; creates/recovers widget session capability in widget-private metadata.
+- `mailbox_send`: service registry; includes expected mailbox identity and fresh consumer generation.
+- `mailbox_receive`: widget registry; bounded poll and lease.
+- `mailbox_get`: widget/service registry; request state and response.
+- `mailbox_status`: widget/service registry; opaque mailbox identity, generation, online/poll state, bounded counts.
+- `mailbox_renew`: widget registry; renew current attempt before absolute deadline.
+- `mailbox_release`: widget registry; release only before accepted dispatch or dead-letter.
+- `mailbox_cancel`: service registry; queued cancellation or dispatched cancel request.
+- `agent_response_submit`: model registry; exact `MailboxAgentResponseV1` and current attempt fencing.
+
+`MailboxAgentResponseV1` is shared verbatim with WAB through a generated or copied contract package/artifact; `ToolResult.data` is not the response schema.
+
+## Related Code Files
+
+- Create: `apps/runner/src/mailbox-store.ts`
+- Create: `apps/runner/src/mailbox-service.ts`
+- Create: `apps/runner/src/runner-operation-service.ts`
+- Modify: `apps/runner/src/index.ts`
+- Modify: `apps/runner/src/app.ts`
+- Modify: `apps/runner/src/workspace-service.ts` only to remove/replace top-level dispatch ownership
+- Modify: the existing metadata migration owner; do not create an independent database connection/migration authority
+- Modify: `packages/contracts/src/runner-api.ts`
+- Modify: `packages/contracts/src/tool-schemas.ts`
+- Create: `packages/contracts/src/mailbox-contracts.ts`
+- Create: `packages/contracts/test/mailbox-contracts.test.ts`
+- Create: `apps/runner/test/mailbox-store.test.ts`
+- Create: `apps/runner/test/mailbox-service.test.ts`
+- Modify: restart/security/integration tests
+
+## Data Model Additions
+
+Message rows include:
+
+```text
+principal_id, mailbox_id, message_id, sequence
+sender_id, idempotency_hash, request_fingerprint
+status, consumer_generation, delivery_attempt
+lease_token_hash, lease_expires_at
+absolute_deadline, dispatch_state, dispatch_accepted_at
+available_at, attempts, created_at, completed_at
+body encryption columns
+```
+
+Response rows store exactly one encrypted `MailboxAgentResponseV1` per message. Widget session rows/records store capability hash, generation, expiry, and last-seen metadata; raw capabilities are never persisted or returned to the model.
+
+## Implementation Steps
+
+1. Freeze the nine-operation schemas and exact V1 response payload only after Phase 1 pass evidence.
+2. Split operation registries/caller profiles. Add negative tests proving each caller cannot invoke operations outside its profile.
+3. Add a mailbox-specific model capability profile that excludes every mutating existing operation at both discovery and runner dispatch.
+4. Apply forward-only mailbox migrations using the existing runner database handle before service start.
+5. Instantiate one process-wide MailboxStore/MailboxService in `index.ts`; implement `start`/`stop` to register/abort waiters and clear/await reapers before database close.
+6. Reuse the runner keyring with mailbox-specific associated-data contexts and unique nonces.
+7. Implement idempotent send using `(principal,sender,idempotencyKey,requestFingerprint)` and atomically require expected mailbox identity + fresh consumer generation.
+8. Implement one active waiter/consumer, bounded receive, consumer-generation fencing, FIFO lease, attempt number, delivery capability hash, and request abort cleanup.
+9. Implement `mailbox_renew` so the mounted widget extends only the current attempt before absolute deadline.
+10. Add a durable `dispatch_state`. After `sendFollowUpMessage()` acceptance, mark the attempt `dispatched`; never requeue it automatically. At deadline, move to `outcome_unknown` unless a valid response arrives.
+11. Implement `mailbox_release` only for pre-dispatch failure. Released attempts requeue/dead-letter under attempt bounds.
+12. Implement `mailbox_cancel`: queued→cancelled; leased/dispatched→cancel_requested. Late response semantics are explicit and idempotent.
+13. Implement `agent_response_submit` with widget/model caller authorization, attempt/generation/delivery-token CAS, strict V1 validation, and atomic response insert/audit.
+14. Implement status/get with an opaque stable `mailboxId` used to prove WAB and widget principal identity match.
+15. Add lease/retention reaper and restart reconciliation. Expired pre-dispatch leases may requeue; dispatched attempts never duplicate.
+16. Add audit transitions without raw bodies/tokens/arguments.
+17. Test concurrency, lost waiter, accepted-dispatch crash, late response, renewal, cancellation phases, idempotency collision, wrong caller profile, wrong principal, and process shutdown.
+18. Run focused tests then `npm run verify`.
+
+## Success Criteria
+
+- [ ] Caller registries and runner dispatch reject every cross-profile operation.
+- [ ] Autonomous model profile cannot discover or invoke any mutating existing tool.
+- [ ] Send and consumer presence/generation check are atomic.
+- [ ] One request has one current consumer generation/attempt/delivery capability.
+- [ ] Widget renews a running attempt; accepted dispatch cannot be automatically redelivered.
+- [ ] Cancellation is explicit and idempotent for queued and dispatched states.
+- [ ] Strict V1 response commits once; malformed, stale, replayed, cross-principal, and late submissions fail safely.
+- [ ] Restart/shutdown loses no queued/completed state and leaks no waiter/reaper.
+- [ ] No body/token/capability enters logs or audit.
+- [ ] Existing workspace behavior remains green.
+
+## Risk Assessment
+
+- **Duplicate turns:** dispatch fencing + consumer generation + no post-dispatch auto-redelivery.
+- **Long model run:** renewable lease bounded by absolute deadline; outcome unknown rather than duplication.
+- **Caller spoofing:** separate route/registry/capability profiles and server/runner enforcement.
+- **Database lifecycle:** one shared handle and explicit service stop before stores close.
+- **TOCTOU offline race:** expected consumer generation is part of send transaction.

--- a/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-03-mcp-app-widget.md
+++ b/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-03-mcp-app-widget.md
@@ -1,0 +1,99 @@
+---
+phase: 3
+title: "MCP App Widget"
+status: pending
+priority: P1
+effort: ""
+dependencies: [1, 2]
+---
+
+# Phase 3: MCP App Widget
+
+## Overview
+
+Productize the Phase 1-proven widget against the durable mailbox. The widget authenticates app-only calls with a private capability, keeps one renewable/fenced delivery in flight, marks accepted follow-up dispatch, and resumes polling only after authoritative terminal state.
+
+## Requirements
+
+- Phase 1 autonomous host/capability gate is passed and its probe tools are removed/replaced.
+- `mailbox_open` renders a self-contained widget and returns a session capability only in widget-private metadata.
+- Widget polls, renews, marks accepted dispatch, gets status, and releases pre-dispatch failure through the widget registry.
+- Delivery creates exactly one component-authored follow-up without user input.
+- `agent_response_submit` is the final model tool and accepts only the current attempt's `MailboxAgentResponseV1`.
+- Model discovery includes only mailbox model tools plus the explicit read-only Cloud Harness allowlist.
+- No direct OAuth/API key, WebSocket, SSE, external asset, or browser storage authority.
+- No automatic approval/reconnect/destructive action.
+
+## Architecture
+
+```text
+mailbox_open
+  ├─ model-visible tool result: sanitized mailbox status
+  └─ widget-private metadata: widgetSessionCapability
+
+Widget
+  ├─ mailbox_receive(capability, generation, waitMs)
+  ├─ mailbox_renew(capability, messageId, attempt)
+  ├─ sendFollowUpMessage(protocol envelope)
+  ├─ mark dispatch accepted through bounded app operation/receive state
+  ├─ mailbox_get(capability, messageId)
+  └─ mailbox_release only before dispatch acceptance
+```
+
+Follow-up envelope contains request ID, attempt, delivery capability, input, response schema version, and `requiredFinalTool=agent_response_submit`. It labels mailbox content as untrusted user data.
+
+After `sendFollowUpMessage()` resolves, widget marks dispatch accepted and continues renewal/status polling while the model turn runs. If the widget disappears after accepted dispatch, server expiry becomes `outcome_unknown`, never a duplicate turn.
+
+## Related Code Files
+
+- Modify: `apps/api/src/mcp-server.ts`
+- Create: `apps/api/src/mailbox-mcp-profile.ts`
+- Create: `apps/api/src/mailbox-widget-resource.ts`
+- Create: `apps/api/mailbox-widget/`
+- Modify: `docker/api.Dockerfile` if assets require explicit copy
+- Modify: `packages/contracts/src/mailbox-contracts.ts`
+- Create: `apps/api/test/mailbox-widget-contract.test.ts`
+- Modify/create MCP discovery and authorization integration tests
+- Modify: `docs/mcp-api.md`
+- Modify: `docs-site/ai-tools/chatgpt.md`
+- Regenerate references through owning scripts only
+
+## Implementation Steps
+
+1. Remove probe-only registrations after preserving Phase 1 evidence.
+2. Register a dedicated mailbox ChatGPT server/profile/path. Do not reuse the production full-tool `TOOL_SPECS` loop.
+3. Register only `mailbox_open`, `agent_response_submit`, and the approved read-only Cloud Harness subset for model discovery.
+4. Register widget operations in the host-supported app-call surface. Require the private widget capability server-side even if visibility metadata is ignored.
+5. Return widget capability only through metadata proven private in Phase 1; structured model content must not contain it.
+6. Register a bounded self-contained `ui://cloud-harness/mailbox.html` resource.
+7. Feature-detect bridge APIs and render unsupported/offline states explicitly.
+8. Generate/recover a non-secret consumer ID in widget state; reconcile it against server consumer generation.
+9. Start one `mailbox_receive(waitMs=20_000)` and abort it on unmount/suspension.
+10. On delivery, persist in-flight message/attempt, start bounded lease renewal, stop receive, and call `sendFollowUpMessage()` once.
+11. After the follow-up Promise resolves, mark dispatch accepted. A rejected Promise permits release/retry; an accepted dispatch does not.
+12. Continue `mailbox_renew` and `mailbox_get` while the model turn runs. Stop renewal at terminal/absolute deadline/unmount.
+13. Require `agent_response_submit` as the final tool. Tool result says to end the turn immediately.
+14. After completed/cancelled/dead-letter, wait a settle guard and resume receive. After `outcome_unknown`, stop and require operator decision.
+15. Request PiP and report current mount/poll/generation/in-flight state.
+16. Add mocked bridge tests for two turns, capability omission, direct unauthorized widget calls, dispatch rejection/acceptance, renewal, remount, terminal resume, and outcome unknown.
+17. Add live negative tests that named mutating tools are absent and rejected even if explicitly requested by mailbox content.
+18. Refresh only the isolated draft ChatGPT app snapshot.
+
+## Success Criteria
+
+- [ ] Private capability is available to widget, absent from model context, and required by server.
+- [ ] Model tools/list and dispatch exclude every mutating existing operation.
+- [ ] One delivery produces one accepted follow-up and one strict response.
+- [ ] Widget renews while the turn runs and never auto-redelivers accepted dispatch.
+- [ ] Two sequential requests create two non-overlapping autonomous turns.
+- [ ] Refresh before dispatch safely releases/retries; refresh after dispatch produces no duplicate.
+- [ ] Offline, approval, reconnect, and outcome-unknown states are explicit.
+- [ ] No native ChatGPT DOM/text enters mailbox state or WAB response.
+
+## Risk Assessment
+
+- **Private metadata not actually private:** Phase 1 fails; do not continue.
+- **Host visibility ignored:** widget capability and separate registry enforce authorization independently.
+- **Gesture/remount limitation:** classify semi-autonomous/fail; no Playwright workaround.
+- **Duplicate turns:** consumer generation, accepted-dispatch fence, renewals, and outcome unknown.
+- **Prompt injection:** server-enforced read-only model profile and untrusted-user envelope.

--- a/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-04-wab-mailbox-provider.md
+++ b/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-04-wab-mailbox-provider.md
@@ -1,0 +1,133 @@
+---
+phase: 4
+title: "WAB Mailbox Compatibility Service"
+status: pending
+priority: P1
+effort: ""
+dependencies: [1, 2]
+---
+
+# Phase 4: WAB Mailbox Compatibility Service
+
+## Overview
+
+Add a dedicated mailbox OpenAI compatibility seam selected before existing provider/RunService construction. It reuses WAB authentication, OpenAI schemas, route shape, and projection utilities, but bypasses BrowserLease, RunService, RunQueue, browser providers, and browser state. A mailbox-specific correlation repository provides idempotent crash recovery without becoming a second work queue.
+
+## Requirements
+
+- Support `/v1/models` and non-streaming `/v1/chat/completions` for logical model ID `chatgpt-mailbox-runtime`.
+- Do not claim a ChatGPT model or reasoning effort that the mailbox cannot attest.
+- Use the complete isolated static-key gateway lane: public Worker URL, Access service-token assertion, and principal-bound managed API key.
+- Prove WAB service transport and ChatGPT widget OAuth transport observe the same opaque mailbox identity before accepting requests.
+- Persist only correlation state: principal, idempotency hash, request fingerprint, mailbox message ID, send state, and terminal projection metadata. Do not copy the work queue or plaintext body.
+- Bypass `OpenAiCompatibilityService` browser execution and `RunService.admit` for mailbox mode.
+- Use atomic expected-consumer-generation send; do not use a status preflight followed by unfenced send.
+- Call `mailbox_cancel` on client abort under queued/leased/dispatched semantics.
+- Accept only strict `MailboxAgentResponseV1`; omit usage.
+- Reject stream, tools, images, attachments, unsupported Responses semantics, model mismatch, and effort claims explicitly.
+
+## Actual Integration Seam
+
+Current owners to inspect/update:
+
+- `src/api/openai/compatibility-config.ts`
+- `src/api/openai/openai-schemas.ts`
+- `src/api/openai/chat-completions-route.ts`
+- `src/api/openai/model-catalog.ts`
+- `src/api/app.ts`
+- `src/providers/provider.ts` and `provider-router.ts` only if a provider union is retained
+- `src/api/openai/compatibility-service.ts` only for shared projection extraction, not browser execution
+- `src/runs/run-service.ts` and `run-queue.ts` as paths mailbox mode must not enter
+- `src/store/migrations.ts` for mailbox correlation schema
+- Create: `src/store/mailbox-correlation-repository.ts`
+- Create: `src/api/openai/mailbox-compatibility-service.ts`
+- Create: `src/providers/cloud-harness-mailbox-client.ts`
+- Create: `test/api/openai-mailbox-chat-completions.test.ts`
+- Create: `test/store/mailbox-correlation-repository.test.ts`
+- Create: `scripts/mailbox-openai-live-smoke.ts`
+
+Recommended seam:
+
+```text
+buildApp
+  ├─ mailbox compatibility mode
+  │    └─ mailbox-specific route dependency/service
+  │         ├─ correlation repository
+  │         └─ CloudHarnessMailboxClient
+  └─ existing mode
+       └─ provider router + RunService + OpenAiCompatibilityService
+```
+
+Do not add `cloud-harness-mailbox` to `ProviderKind` unless every discriminator/caller is deliberately updated. A dedicated compatibility mode is smaller and avoids routing mailbox work through the provider/run queue.
+
+## Configuration
+
+```text
+MAILBOX_OPENAI_ENABLED=true
+MAILBOX_MCP_GATEWAY_URL=https://api.<isolated-test-host>/mcp
+MAILBOX_MCP_API_KEY_FILE=<principal-bound managed API key>
+MAILBOX_CF_ACCESS_CLIENT_ID_FILE=<isolated Worker/service-token client ID>
+MAILBOX_CF_ACCESS_CLIENT_SECRET_FILE=<isolated Worker/service-token secret>
+MAILBOX_LOGICAL_MODEL=chatgpt-mailbox-runtime
+MAILBOX_SYNC_DEADLINE_MS=<bounded>
+MAILBOX_POLL_WAIT_MS=20000
+```
+
+The client must send the same service-token headers/path expected by the isolated static gateway architecture plus the managed bearer key. All values are file-backed and outside source.
+
+## Correlation State
+
+```text
+principal_id
+idempotency_hash
+request_fingerprint
+mailbox_id
+message_id nullable until acknowledged
+send_state: prepared | acknowledged | terminal | outcome_unknown
+terminal_projection_json bounded/non-secret
+created_at, updated_at
+UNIQUE(principal_id, idempotency_hash)
+```
+
+Crash window protocol:
+
+1. Insert `prepared` correlation with request fingerprint.
+2. Call idempotent `mailbox_send` using the same key/fingerprint.
+3. Persist returned message ID as `acknowledged`.
+4. On restart with `prepared`, replay the same send key/fingerprint and recover the prior message ID—never create a new key.
+5. Poll/get terminal response and persist only projection metadata/result required for replay.
+
+## Implementation Steps
+
+1. Add config/schema for mailbox compatibility mode without weakening existing provider enums.
+2. Define a route/service interface shared by Chat Completion route registration so mailbox mode can bypass RunService construction.
+3. Add the correlation migration/repository and transactional idempotency/fingerprint checks.
+4. Implement a typed Cloud Harness MCP client using the existing TypeScript SDK/Streamable HTTP transport and full static-gateway headers.
+5. Before first enqueue, call `mailbox_status` through WAB and compare its opaque mailbox ID to the value displayed by the OAuth widget. Abort on mismatch.
+6. Normalize bounded OpenAI messages into the shared mailbox request envelope; store no duplicate plaintext work body in WAB.
+7. Call `mailbox_send` with expected mailbox ID + consumer generation atomically. An offline/stale consumer returns `agent_runtime_offline` without enqueue.
+8. Recover the acknowledged message ID into the correlation row. Handle prepared/acknowledged crash recovery idempotently.
+9. Poll `mailbox_get` until terminal/client deadline. Monitor consumer generation/status changes and call `mailbox_cancel` when cancellation remains safe.
+10. Map only `MailboxAgentResponseV1` to Chat Completion JSON. Omit usage and return logical model ID.
+11. Return explicit errors for offline, cancel requested, response missing, outcome unknown, dead letter, model mismatch, effort supplied, stream, tools, images, attachments, and unsupported endpoints.
+12. Add tests for no RunService/RunQueue construction in mailbox mode, idempotency crash windows, principal mismatch, service auth headers, atomic offline send, cancellation states, V1 projection, and unsupported semantics.
+13. Preserve every existing browser-provider path/test unchanged.
+
+## Success Criteria
+
+- [ ] Mailbox mode constructs no BrowserLease, RunService, RunQueue, or browser provider.
+- [ ] WAB and widget prove the same mailbox identity before send.
+- [ ] Full service-token/static-key authentication reaches the isolated mailbox service.
+- [ ] One idempotency key maps to one mailbox message across crash/restart windows.
+- [ ] Offline/generation mismatch does not enqueue synchronous work.
+- [ ] Client abort calls explicit cancellation and never blind-resubmits.
+- [ ] Completed V1 response maps to valid OpenAI JSON with logical model ID and no fabricated usage.
+- [ ] Existing browser compatibility remains green and original dirty checkout remains untouched.
+
+## Risk Assessment
+
+- **Second queue:** bypass RunService and persist correlation only.
+- **Auth 401:** deploy/verify complete static gateway lane before live WAB tests.
+- **Principal split:** opaque mailbox identity comparison gates enqueue.
+- **Crash after remote send:** same idempotency/fingerprint recovers prior message.
+- **Misleading compatibility:** logical runtime model and explicit unsupported errors.

--- a/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-05-fork-branch-vps-test-deployment.md
+++ b/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-05-fork-branch-vps-test-deployment.md
@@ -1,0 +1,122 @@
+---
+phase: 5
+title: "Fork Branch VPS Test Deployment"
+status: pending
+priority: P1
+effort: ""
+dependencies: [3, 4]
+---
+
+# Phase 5: Fork Branch VPS Test Deployment
+
+## Overview
+
+Push reviewed owner-fork branches and deploy exact commits into fully isolated Cloud Harness, static API-key gateway, and WAB gateway-only test stacks. Production services remain running and untouched. Live host/Cloudflare operations require fresh explicit authorization after Phase 1 passes.
+
+## Requirements
+
+- Separate checkouts, Compose projects, images, labels, state/data roots, secrets, loopback ports, hostnames, Cloudflare Access applications, Worker gateway, and ChatGPT draft app.
+- Full two-lane Cloud Harness auth:
+  - ChatGPT OAuth endpoint for model/widget profile.
+  - Static API-key Worker endpoint with path-scoped service assertion for WAB service profile.
+- WAB managed API key is created through the same authenticated ChatGPT external principal and verified by matching opaque `mailboxId` over both transports.
+- Server-side caller profiles/registries and read-only model allowlist are active.
+- WAB mailbox container starts only the gateway process: no Xvfb, x11vnc, websockify/noVNC, Chrome, browser profile mount, DISPLAY, or port 6080.
+- Cleanup includes exact runner-instance-labeled executor/helper containers, not Compose labels alone.
+- No production secret/key/state/repository credential reuse.
+
+## Proposed Isolation
+
+Provisional pending owner approval:
+
+```text
+Cloud Harness branch: feat/chatgpt-mailbox-runtime-mvp
+repo:                 therichardngai-code/cloud-harness-mcp
+checkout:             /opt/clawboxes/cloud-harness-mailbox-mvp
+data:                 /opt/clawboxes/cloud-harness-mailbox-mvp-data
+Compose project:      cloud-harness-mailbox-mvp
+loopback ingress:     127.0.0.1:3110
+OAuth hostname:       harness-mailbox-mvp.goclawoffice.app
+static gateway host:  api.harness-mailbox-mvp.goclawoffice.app
+
+WAB branch:           feat/cloud-harness-mailbox-provider-mvp
+repo:                 therichardngai-code/wab
+checkout:             /opt/clawboxes/wab-mailbox-mvp
+Compose project:      wab-mailbox-mvp
+loopback ingress:     127.0.0.1:3221
+hostname:             wab-mailbox-mvp.goclawoffice.app
+```
+
+Separate secrets:
+
+```text
+runner token
+mailbox encryption keyring
+Cloudflare Access OAuth audience/config
+static gateway Access audience + service subject
+Worker service-token client ID/secret
+principal-bound managed mailbox API key
+WAB client API key
+```
+
+## Related Code And Operations
+
+### Cloud Harness
+
+- Add isolated mailbox MCP/profile routes without changing production route discovery.
+- Configure separate Access applications for OAuth and exact hidden static-key origin path.
+- Deploy an isolated copy/configuration of `apps/api-key-gateway` with its own Worker route and service token.
+- Use test-only Compose overrides and paths owned by the branch.
+
+### WAB
+
+- Create a gateway-only entrypoint/service or lightweight Dockerfile.
+- Start `node dist/src/index.js` mailbox compatibility mode only.
+- Omit supervisor, DISPLAY, profile bootstrap/mount, Chrome packages/process, noVNC packages/process/port.
+
+## Implementation Steps
+
+1. Review both branch diffs and record exact SHAs. Push only owner branches.
+2. Obtain explicit authorization for exact VPS paths, ports, hostnames, Caddy edits, Cloudflare apps/Worker/service token, and service starts.
+3. Clone/fetch exact branch commits into new paths; verify ancestry and checkout exact SHAs, never unreviewed pull.
+4. Generate independent mode-0600 test secrets and state roots without printing them.
+5. Start isolated Cloud Harness Compose project with unique jobs/state/artifact roots and instance identity. Omit production GitHub App credentials/repository grants.
+6. Configure OAuth test hostname/Access application with exact ChatGPT callback allowlist.
+7. Configure the second path-scoped static-key Access application/audience, gateway service subject, Worker route, and service-token credentials exactly as the existing deployment contract requires.
+8. Authenticate the ChatGPT draft app first. Through that same dashboard principal, create the managed WAB test key.
+9. Call `mailbox_status` through ChatGPT OAuth/widget and WAB static service lane. Compare only the sanitized opaque mailbox ID and abort on mismatch.
+10. Build/start WAB gateway-only image. Assert no Chrome/X11/VNC processes, mounts, env, or published port exist.
+11. Validate Caddy before any authorized reload and verify production routes remain unchanged.
+12. Scan/refresh only the draft ChatGPT app. Confirm model discovery shows mailbox model tools + read-only allowlist, not mutating operations.
+13. Invoke `mailbox_open`, request PiP, and verify current consumer generation/poll state.
+14. Before/after each test stack change, verify production Cloud Harness/WAB health and container/state ownership.
+15. Record isolated runner instance ID and exact project labels for cleanup.
+
+## Success Criteria
+
+- [ ] Test stacks have unique projects, paths, ports, identities, data, and secrets.
+- [ ] OAuth and static-key lanes both authenticate and resolve the same mailbox ID.
+- [ ] WAB reaches the public static gateway through service assertion + managed key; no hidden-origin shortcut exists.
+- [ ] Model discovery/dispatch excludes all mutating existing tools.
+- [ ] WAB process list/mounts/ports contain no browser/noVNC surface.
+- [ ] Draft app mounts widget and consumer is online.
+- [ ] Production state/services remain unchanged.
+- [ ] No production GitHub App/API key/keyring/state is mounted.
+
+## Rollback
+
+1. Resolve and record the isolated runner instance ID from its state before stopping services.
+2. Stop/remove only executor/helper containers with that exact `cloud-harness.instance` label.
+3. Stop only `cloud-harness-mailbox-mvp` and `wab-mailbox-mvp` Compose projects; verify project labels before removal.
+4. Remove test Caddy/DNS/Access/Worker routes only after validating production routes.
+5. Revoke test managed API key, Worker service token, OAuth app, and draft ChatGPT app.
+6. Preserve test state until evidence acceptance; delete only with explicit authorization.
+7. Verify no test instance/project containers remain and production readiness/OAuth/dashboard/WAB remain healthy.
+
+## Risk Assessment
+
+- **Missing static auth hop:** deployment cannot proceed until Worker/service-token lane passes an auth-only smoke.
+- **Principal mismatch:** mailbox ID comparison blocks WAB enqueue.
+- **Browser surface accidentally retained:** gateway-only process/image assertion is mandatory.
+- **Shared Docker daemon cleanup:** exact runner instance labels plus Compose labels; no prune/broad cleanup.
+- **Live blast radius:** every host/Cloudflare mutation requires fresh explicit authorization.

--- a/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-06-end-to-end-validation-and-decision-gate.md
+++ b/plans/260823-0614-chatgpt-mailbox-runtime-mvp/phase-06-end-to-end-validation-and-decision-gate.md
@@ -1,0 +1,131 @@
+---
+phase: 6
+title: "End To End Validation And Decision Gate"
+status: pending
+priority: P1
+effort: ""
+dependencies: [5]
+---
+
+# Phase 6: End To End Validation And Decision Gate
+
+## Overview
+
+Validate the durable cross-repository MVP only after the Phase 1 autonomy gate passed. Prove strict response projection, caller/tool authority, identity binding, queue/restart/cancellation fencing, browser-free WAB operation, and two sequential autonomous turns. End with an explicit decision; no production merge is authorized.
+
+## Requirements
+
+- Verify bootstrap, automatic first and second turns, strict V1 response submission, and non-streaming OpenAI projection.
+- Verify OAuth widget and static WAB lanes share the same opaque mailbox identity.
+- Verify model discovery and direct dispatch reject every mutating existing Cloud Harness operation.
+- Verify WAB mailbox mode bypasses BrowserLease/RunService/RunQueue and starts no browser/noVNC process.
+- Exercise prepared/acknowledged correlation crashes, cancellation, generation TOCTOU, dispatch acceptance, lease renewal, late response, outcome unknown, restart, remount, and client disconnect.
+- Capture exact SHAs and sanitized state/tool evidence only.
+
+## Test Matrix
+
+### Auth And Authority
+
+- OAuth draft app authenticates mailbox model/widget registry.
+- WAB authenticates through isolated Worker + Access service assertion + managed API key.
+- Both transports return the same opaque mailbox ID.
+- Widget calls without private capability are rejected.
+- WAB service cannot call widget/model-only operations.
+- Model tools/list excludes `exec_run`, writes/deletes, Git mutations, hooks, skills, memories mutation, and deployments.
+- Named direct calls to excluded operations are rejected at API and runner dispatch.
+
+### Bootstrap
+
+1. Open dedicated conversation and manually invoke `mailbox_open` once.
+2. Confirm widget capability remains private and widget mounts/PiP/polls.
+3. Confirm no model turn while inbox is empty.
+
+### Autonomous Requests
+
+1. Send one WAB Chat Completion using logical model `chatgpt-mailbox-runtime`.
+2. Confirm one correlation row, one mailbox message, matching request fingerprint, and atomic consumer generation.
+3. Do not touch keyboard/mouse.
+4. Confirm one receive, one follow-up, accepted dispatch, renewals, one read-only tool call, one strict V1 submit, one OpenAI JSON response.
+5. Send request two after terminal settlement and confirm a second independent turn without overlap.
+
+### Idempotency And Crash Windows
+
+- Duplicate WAB key/fingerprint returns prior message/result.
+- Same key with different fingerprint conflicts.
+- Crash after correlation `prepared` but before send recovers safely.
+- Crash after remote send but before acknowledged persistence replays same mailbox key and recovers prior message ID.
+- Restart while queued preserves message.
+- Restart while leased/pre-dispatch requeues only under current attempt rules.
+- Restart/lost widget after accepted dispatch never auto-redelivers; request becomes completed or outcome_unknown.
+
+### Lease And Cancellation
+
+- Renewal extends only current generation/attempt before absolute deadline.
+- Stale generation/token renewal fails.
+- Completion after the former 120-second boundary remains single-dispatch.
+- Release is allowed only before accepted dispatch.
+- Client abort while queued cancels atomically.
+- Client abort after dispatch produces cancel_requested and does not blind-resubmit.
+- Late response semantics are deterministic and idempotent.
+
+### Runtime And Compatibility
+
+- WAB process/mount/port inspection proves no Chrome/X11/VNC/profile surface.
+- `/v1/models` reports only logical mailbox runtime model; effort claims/mismatches are rejected.
+- Valid V1 content projects to Chat Completion JSON; unknown response version/fields fail.
+- `usage` is absent; stream/tools/images/attachments/unsupported endpoints fail explicitly.
+- Offline/generation mismatch fails fast without enqueue.
+
+## Related Evidence
+
+- Cloud Harness contract/runner/API/MCP/security tests
+- WAB mailbox service/correlation/OpenAI projection tests
+- `plans/260823-0614-chatgpt-mailbox-runtime-mvp/reports/mvp-execution.md` created only during implementation
+- Sanitized request IDs, state transitions, tool names/status, auth lane health, process lists, and commit SHAs
+- No raw message body beyond fixed canaries, token, key, capability, OAuth assertion, or tool arguments
+
+## Implementation Steps
+
+1. Record branch/deployed SHAs, hostnames, projects, runner instance, and sanitized readiness.
+2. Run focused and full repository gates before live interaction.
+3. Run auth-only static-gateway and mailbox identity-binding checks.
+4. Run tools/list and direct-dispatch read-only allowlist negative matrix.
+5. Execute bootstrap and verify widget private capability/mount/poll.
+6. Execute first and second autonomous requests with no interaction.
+7. Validate exact V1→OpenAI JSON projection and no native DOM/text dependency.
+8. Execute idempotency/correlation crash-window tests.
+9. Execute consumer generation/offline TOCTOU tests.
+10. Execute renewal, accepted-dispatch loss, >120-second completion, outcome-unknown, and cancellation tests.
+11. Refresh/remount widget before and after dispatch; restart only isolated runner in queued/leased/dispatched states.
+12. Inspect WAB runtime for absence of browser/noVNC components.
+13. Review logs/audits for secret/content leakage.
+14. Classify outcome and stop/preserve isolated stacks under owner direction.
+
+## Decision Gate
+
+| Outcome | Required Evidence | Next Action |
+|---|---|---|
+| Autonomous MVP passed | Phase 1 and durable matrix pass; two turns need no gesture; authority/identity/fencing/recovery pass | Plan productization separately; no production merge |
+| Semi-autonomous only | Widget receives mail but host requires user gesture | Keep operator-assisted inbox only |
+| Host lifecycle failure | Widget unmounts, callback cannot trigger turn, private capability cannot be protected, or second turn fails | Stop; no browser automation workaround |
+| Contract/security failure | Duplicate/lost action, cross-profile access, mutating tool exposure, principal mismatch, malformed response, or unrecoverable state | Block until root contract is redesigned |
+
+## Success Criteria
+
+- [ ] Two autonomous sequential requests complete after one bootstrap interaction.
+- [ ] Every response is strict V1 and maps to valid OpenAI JSON.
+- [ ] No native ChatGPT DOM/text or fabricated model/usage claim is used.
+- [ ] No duplicate turn/tool/response occurs across retry, remount, long turn, cancellation, or restart.
+- [ ] Caller profiles and read-only allowlist are enforced at discovery and dispatch.
+- [ ] WAB/ChatGPT identities match and WAB uses the complete static gateway lane.
+- [ ] WAB mailbox process is browser-free and bypasses its existing queue.
+- [ ] Production remains unchanged.
+- [ ] Result is classified before any merge/production plan.
+
+## Risk Assessment
+
+- **False pass:** two turns plus recovery/security matrix, not one smoke.
+- **Hidden host gesture:** zero input-device interaction during autonomous cases.
+- **Duplicate accepted turn:** dispatch fence/renewal/outcome unknown, no auto-redelivery.
+- **Misleading OpenAI parity:** logical model, V1 schema, no usage/stream claims.
+- **Accidental rollout:** isolated branches/stacks; decision gate is not deployment approval.

--- a/plans/260823-0614-chatgpt-mailbox-runtime-mvp/plan.md
+++ b/plans/260823-0614-chatgpt-mailbox-runtime-mvp/plan.md
@@ -1,0 +1,228 @@
+---
+title: "ChatGPT Mailbox Runtime MVP"
+description: "Prove, before durable investment, that a Cloud Harness MCP App widget can long-poll a mailbox, create a new ChatGPT turn without user composition, force a schema-validated response tool, and return that result through a browser-free WAB OpenAI compatibility seam."
+status: pending
+priority: P1
+effort: ""
+tags: [mcp-apps, mailbox, chatgpt, openai-compatibility, cloud-harness, wab, vps-mvp]
+created: 2026-08-23
+branch: feat/chatgpt-mailbox-runtime-mvp
+blocks: [260821-0938-web-assistant-openai-compatibility-parity]
+repositories:
+  cloudHarness: https://github.com/therichardngai-code/cloud-harness-mcp
+  wab: https://github.com/therichardngai-code/wab
+---
+
+# ChatGPT Mailbox Runtime MVP
+
+## Outcome
+
+Prove this loop in two stages while a dedicated ChatGPT tab remains open:
+
+```text
+Stage A — capability spike
+in-memory pending request
+→ mounted draft MCP App widget
+→ bounded app-only receive
+→ sendFollowUpMessage()
+→ second autonomous ChatGPT turn
+→ strict submit tool
+
+Stage B — MVP only if Stage A passes
+OpenAI-compatible request
+→ browser-free WAB mailbox compatibility service
+→ Cloud Harness durable mailbox
+→ widget long poll
+→ ChatGPT read-only agent turn
+→ agent_response_submit(MailboxAgentResponseV1)
+→ WAB OpenAI-compatible JSON
+→ widget resumes polling
+```
+
+The autonomous MVP fails if the second turn needs another user click, if the widget is not kept mounted, if app-only calls cannot be protected, or if the model cannot reliably submit a strict response. Browser automation is not an allowed workaround.
+
+## Constraints
+
+- Run a thin Apps SDK/host capability spike before final schemas, migrations, WAB integration, docs, or durable queue work.
+- Preserve the Cloud Harness single-owner trust model and API/runner boundary.
+- Runner owns durable mailbox state, leasing, idempotency, encryption, audit, lifecycle, and principal scoping after the spike passes.
+- API owns MCP negotiation, separate capability-profile registries, scoped caller classification, and UI resource registration; it must not acquire Docker or state authority.
+- WAB reuses OpenAI authentication/schemas/routes/projection only through a dedicated mailbox compatibility service that bypasses BrowserLease, RunService, and RunQueue.
+- Cloud Harness SQLite is the only work queue. WAB persists only a principal-scoped correlation/idempotency record.
+- One principal, one inbox, one widget consumer generation, one in-flight request, one logical mailbox runtime model.
+- The autonomous ChatGPT draft app receives an enforced server-side allowlist: mailbox model tools plus an explicit read-only Cloud Harness subset. Annotations and prompts are not authorization.
+- Widget operations require a server-validated widget session capability delivered only in widget-private metadata; WAB service operations use a separate scoped registry and credential lane.
+- Use bounded long polls below Cloud Harness's 60-second API-to-runner timeout; target `waitMs=20_000`.
+- Dispatched model turns are fenced. A lost widget after `sendFollowUpMessage()` acknowledgement becomes `outcome_unknown` at the absolute deadline; it is not automatically redelivered.
+- Message/response bodies are encrypted and bounded. Raw bodies, OAuth material, service tokens, API keys, widget capabilities, delivery tokens, and tool arguments never enter logs.
+- Implementation uses clean worktrees from pinned refs. Production services/state/secrets/hostnames remain untouched.
+
+## Non-goals
+
+- A 24/7 agent when ChatGPT, the tab, or widget is closed.
+- True token streaming; MVP supports non-streaming Chat Completions only.
+- Multiple mailboxes/consumers, priorities, attachments, email, public webhook ingress, or callbacks.
+- Claiming or changing an exact ChatGPT model/effort through UI automation. WAB exposes an honest logical model ID such as `chatgpt-mailbox-runtime` and no authoritative effort claim.
+- Full WAB replacement, browser-provider cleanup, or upstream productization.
+- Autonomous mutating Cloud Harness tools, auto-approval, or broad 52-tool discovery.
+- Production merge/deployment from an MVP pass.
+
+## Confirmed Starting State
+
+- Owner fork exists at `therichardngai-code/cloud-harness-mcp`.
+- Cloud Harness base: `4149ed8c3ec27de3fb6db511b3ed361a46988811`.
+- WAB base: `3c2000a44624e4ab46b100afe9072256f2731be2`.
+- Cloud Harness MCP server currently registers every `TOOL_SPECS` entry uniformly; it has no UI resource or caller capability profile.
+- Cloud Harness runner dispatch currently assumes workspace scope after `workspace_open/list`; mailbox operations require a principal-global dispatcher.
+- The static API-key lane requires a dedicated Worker, path-scoped Access application, service assertion, and principal-bound managed API key—not an API key alone.
+- WAB's current OpenAI flow constructs RunService/RunQueue even for direct providers; mailbox mode must bypass that path.
+- WAB's current container always starts Xvfb/x11vnc/noVNC; mailbox mode needs a separate gateway-only process/image.
+- OpenAI documents `callTool` and `sendFollowUpMessage`, but autonomous callback behavior, widget persistence, app-only visibility, and private metadata assumptions remain unproven until Phase 1.
+
+## Architecture Decisions
+
+1. Phase 1 is a throwaway-capable in-memory vertical spike using explicitly registered probe tools. Durable work is gated on two autonomous turns.
+2. Final mailbox operations are divided into separate registries/capability profiles: model, widget, and service. Passive `_meta` visibility is never the only authorization control.
+3. A mailbox-specific ChatGPT MCP endpoint exposes only `mailbox_open`, `agent_response_submit`, and an explicit read-only Cloud Harness allowlist; all mutating existing tools are absent and rejected at dispatch.
+4. `mailbox_open` returns a widget session capability in widget-private metadata. Widget lease/receive/release/renew calls require that capability.
+5. WAB uses the existing static-key gateway architecture completely: dedicated Worker URL, service token lane, Access assertion, and principal-bound API key created under the same ChatGPT OAuth principal.
+6. `mailbox_status` exposes an opaque stable mailbox identity. Widget OAuth and WAB service transport must observe the same identity before enqueue is enabled.
+7. WAB mailbox mode branches at the composition/route seam before RunService and stores only correlation state; Cloud Harness remains sole queue authority.
+8. `MailboxAgentResponseV1` is a versioned cross-repository schema. Native ChatGPT text and token usage are never authoritative.
+9. Dispatch uses consumer generation, attempt number, delivery capability, renewable lease, accepted-dispatch state, and absolute deadline fencing.
+10. A dedicated gateway-only WAB image/entrypoint starts no Chrome, X11, profile, or noVNC processes/mounts/ports.
+11. VPS testing uses isolated owner-fork branches, exact SHAs, projects, state roots, secrets, Access apps, Worker gateway, and hostnames.
+
+## Final Operation Contract (After Spike Passes)
+
+| Operation | Registry/caller | Purpose |
+|---|---|---|
+| `mailbox_open` | ChatGPT model | Render widget; return widget-private session capability. |
+| `mailbox_send` | WAB service | Idempotently enqueue under an expected fresh consumer generation. |
+| `mailbox_receive` | widget capability | Long-poll and lease one queued request. |
+| `mailbox_get` | widget + WAB service | Read request state and validated response. |
+| `mailbox_status` | widget + WAB service | Read opaque mailbox identity, consumer generation/presence, and bounded counts. |
+| `mailbox_renew` | widget capability | Renew the current delivery lease before absolute deadline. |
+| `mailbox_release` | widget capability | Release a pre-dispatch failure or dead-letter it. |
+| `mailbox_cancel` | WAB service | `queued→cancelled`; `leased/dispatched→cancel_requested`. |
+| `agent_response_submit` | ChatGPT model | Atomically validate/commit `MailboxAgentResponseV1`. |
+
+```text
+queued → leased → dispatched → completed
+  │         │          ├→ cancel_requested
+  │         ├→ queued  (release before dispatch)
+  │         └→ dead_letter
+  └→ cancelled
+
+dispatched + lost/expired absolute deadline → outcome_unknown (no automatic redelivery)
+```
+
+## MailboxAgentResponseV1
+
+```json
+{
+  "version": 1,
+  "status": "completed",
+  "message": {
+    "role": "assistant",
+    "content": [{ "type": "output_text", "text": "bounded text" }]
+  },
+  "finishReason": "stop",
+  "data": null,
+  "error": null
+}
+```
+
+WAB supports only the documented V1 fields and omits token usage. Unknown versions/fields are rejected.
+
+## Branch And Isolation Strategy
+
+### Cloud Harness
+
+```text
+remote: fork = https://github.com/therichardngai-code/cloud-harness-mcp.git
+branch: feat/chatgpt-mailbox-runtime-mvp
+base:   4149ed8c3ec27de3fb6db511b3ed361a46988811
+```
+
+### WAB
+
+```text
+remote: origin = https://github.com/therichardngai-code/wab.git
+branch: feat/cloud-harness-mailbox-provider-mvp
+base:   3c2000a44624e4ab46b100afe9072256f2731be2
+```
+
+Both use clean worktrees. Original dirty checkouts remain untouched.
+
+## Phases
+
+| # | Phase | Status | Dependencies |
+|---|---|---|---|
+| 1 | [Capability Spike And Branch Isolation](./phase-01-capability-spike-and-branch-isolation.md) | Blocked on ChatGPT host validation | None |
+| 2 | [Durable Mailbox Core](./phase-02-durable-mailbox-core.md) | Pending | 1 pass |
+| 3 | [MCP App Widget](./phase-03-mcp-app-widget.md) | Pending | 1 pass, 2 |
+| 4 | [WAB Mailbox Compatibility Service](./phase-04-wab-mailbox-provider.md) | Pending | 1 pass, 2 |
+| 5 | [Fork Branch VPS Test Deployment](./phase-05-fork-branch-vps-test-deployment.md) | Pending | 3, 4 |
+| 6 | [End To End Validation And Decision Gate](./phase-06-end-to-end-validation-and-decision-gate.md) | Pending | 5 |
+
+## MVP Success Criteria
+
+- [ ] Phase 1 proves resource mount, private widget metadata, widget-only call enforcement, automatic `sendFollowUpMessage`, PiP/mount persistence, strict submit, and a second autonomous turn on the actual ChatGPT draft host.
+- [ ] Model discovery/dispatch excludes every mutating existing Cloud Harness operation.
+- [ ] WAB and widget resolve to the same opaque mailbox identity through the complete service-token/static-key and OAuth lanes.
+- [ ] WAB bypasses RunService/RunQueue and runs in a gateway-only process with no browser/noVNC surface.
+- [ ] One OpenAI request maps to one durable mailbox request and one `MailboxAgentResponseV1`.
+- [ ] Duplicate/cancel/restart/unmount/lease cases do not cause duplicate ChatGPT turns or tool actions.
+- [ ] A second request creates the next turn automatically after terminal settlement.
+- [ ] Offline/lost runtime fails explicitly; no silent long timeout or blind redelivery.
+- [ ] Production services/data remain unchanged.
+- [ ] Decision gate records autonomous pass, semi-autonomous only, host failure, or contract failure.
+
+## Red Team Review
+
+### Session — 2026-08-23
+
+**Findings:** 15 deduplicated, 15 accepted, 0 rejected.
+**Severity breakdown:** 2 Critical, 12 High, 1 Medium.
+
+| # | Finding | Severity | Disposition | Applied To |
+|---|---|---|---|---|
+| 1 | Full static API-key gateway lane missing | Critical | Accept | Phases 4-5 |
+| 2 | Autonomous read-only boundary not enforced | Critical | Accept | Phases 1, 3, 6 |
+| 3 | App/service/model visibility is not server authorization | High | Accept | Phases 1, 3 |
+| 4 | Apps SDK autonomy must be proved before persistence | High | Accept | Phase 1 and phase order |
+| 5 | Advertised model/effort cannot be enforced | High | Accept | Phase 4/model contract |
+| 6 | Existing WAB RunService would create a second queue | High | Accept | Phase 4 |
+| 7 | WAB needs a dedicated mailbox correlation store | High | Accept | Phase 4 |
+| 8 | Lease expiry can duplicate accepted turns | High | Accept | Phases 1-3 |
+| 9 | ChatGPT OAuth and WAB API key may resolve different principals | High | Accept | Phases 4-5 |
+| 10 | Mailbox cancellation operation is missing | High | Accept | Phases 1, 2, 4 |
+| 11 | Consumer presence preflight has a TOCTOU race | High | Accept | Phases 2, 4 |
+| 12 | WAB provider file map/discriminators were inaccurate | High | Accept | Phase 4 |
+| 13 | WAB mailbox mode still started browser/noVNC | High | Accept | Phases 4-5 |
+| 14 | Cross-repository response payload was not frozen | High | Accept | Phases 1, 4 |
+| 15 | Mailbox store/reaper/runner cleanup ownership was incomplete | Medium | Accept | Phases 2, 5 |
+
+### Whole-Plan Consistency Sweep
+
+- Files reread: `plan.md` and all six phase files.
+- Decision deltas checked: capability spike ordering; nine-operation contract; caller registries; read-only allowlist; static gateway; principal identity; WAB queue bypass; correlation store; lease fencing; cancellation; browser-free process; response V1; runner lifecycle; cleanup labels.
+- Reconciled stale references: six/seven-tool counts, nonexistent wait tool, Work/Browser provider assumptions, model/effort guarantee, passive visibility, API-key-only auth, Compose-only cleanup.
+- Unresolved contradictions: 0.
+
+## Rollback
+
+- Stop only isolated MVP projects and exact runner-instance-labeled containers.
+- Revoke test API key, Worker service token, Access apps, and draft ChatGPT app.
+- Preserve test state until evidence acceptance; delete only with explicit authorization.
+- Production requires no rollback because it is never changed.
+
+## Open Questions
+
+- Does the current ChatGPT host support the complete Phase 1 autonomous path without a user gesture?
+- Does private tool result metadata remain inaccessible to the model while available to the widget?
+- Can the pinned SDK/host implement app-only calls with server-verifiable capability semantics?
+- Which exact isolated hostnames/ports will the owner authorize after Phase 1 passes?
+
+<!-- slug: chatgpt-mailbox-runtime-mvp -->

--- a/test/e2e/coding-workflow.docker.test.ts
+++ b/test/e2e/coding-workflow.docker.test.ts
@@ -53,7 +53,8 @@ beforeAll(async () => {
   const runnerPort = await listen(runnerServer);
   const apiConfig: ApiConfig = {
     host: '127.0.0.1', port: 0, ownerId: 'owner', bearerToken: bearer, runnerUrl: `http://127.0.0.1:${runnerPort}`,
-    runnerToken: serviceToken, publicHosts: ['127.0.0.1'], allowedOrigins: [], requestTimeoutMs: 120_000, maxBodyBytes: 262_144
+    runnerToken: serviceToken, publicHosts: ['127.0.0.1'], allowedOrigins: [], requestTimeoutMs: 120_000, maxBodyBytes: 262_144,
+    apiKeyAuthEnabled: false, mailboxProbeEnabled: false
   };
   apiRuntime = createApiApp(apiConfig);
   apiServer = createServer(apiRuntime.app);

--- a/test/integration/mcp-http.test.ts
+++ b/test/integration/mcp-http.test.ts
@@ -20,7 +20,7 @@ beforeAll(async () => {
   await new Promise<void>((resolve) => runner.listen(0, '127.0.0.1', resolve));
   const runnerAddress = runner.address();
   if (!runnerAddress || typeof runnerAddress === 'string') throw new Error('runner failed');
-  const config: ApiConfig = { host: '127.0.0.1', port: 0, ownerId: 'owner', bearerToken: token, runnerUrl: `http://127.0.0.1:${runnerAddress.port}`, runnerToken: 'runner-token-that-is-longer-than-32-characters', publicHosts: ['127.0.0.1'], allowedOrigins: [], requestTimeoutMs: 5_000, maxBodyBytes: 262_144 };
+  const config: ApiConfig = { host: '127.0.0.1', port: 0, ownerId: 'owner', bearerToken: token, runnerUrl: `http://127.0.0.1:${runnerAddress.port}`, runnerToken: 'runner-token-that-is-longer-than-32-characters', publicHosts: ['127.0.0.1'], allowedOrigins: [], requestTimeoutMs: 5_000, maxBodyBytes: 262_144, apiKeyAuthEnabled: false, mailboxProbeEnabled: false };
   runtime = createApiApp(config);
   api = createServer(runtime.app);
   await new Promise<void>((resolve) => api.listen(0, '127.0.0.1', resolve));


### PR DESCRIPTION
## Summary
- add feature-gated /mcp-mailbox-probe MCP profile for the ChatGPT mailbox capability spike
- serve a minimal MCP App widget that polls with a private capability and sends autonomous follow-up prompts with request ids
- add local contract tests for tool discovery, widget resource metadata, strict submit validation, and HTTP request persistence
- add plan artifacts for 260823-0614-chatgpt-mailbox-runtime-mvp and block later phases on actual ChatGPT host validation

## Verification
- PASS: npm run lint
- PASS: npm run typecheck
- PASS: npm test -- apps/api/test/mailbox-probe-contract.test.ts apps/api/test/http-security.test.ts test/integration/mcp-http.test.ts packages/contracts/test/contracts.test.ts
- PASS: ak plan validate plans/260823-0614-chatgpt-mailbox-runtime-mvp --json --no-interactive
- FAIL (Windows local): npm run verify; failures are symlink/Windows runtime issues and pre-existing cloudharness skill packaging checks unrelated to this probe change. CI on Linux is the authoritative full gate.

## Phase 1 blocker
The existing public endpoint is healthy but returns 404 for /mcp-mailbox-probe, so actual ChatGPT draft-host validation still requires deploying a commit with the probe endpoint enabled.