### PR TITLE
feat(mailbox): default-enable ChatGPT probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ AUTH_MODE=owner-bearer
 # API_KEY_GATEWAY_SERVICE_SUBJECT=cf-service:base64url-cloudflare-service-token-client-id
 # API_KEY_GATEWAY_PUBLIC_URL=https://api.harness.zuey.me/mcp
 # Worker-only secrets CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET are configured with Wrangler, never here.
-# Internal spike endpoint; exposes /mcp-mailbox-probe when true.
-# MAILBOX_PROBE_ENABLED=false
+# Temporary ChatGPT mailbox runtime probe. Omit or set true to expose /mcp-mailbox-probe; set false to unmount.
+# MAILBOX_PROBE_ENABLED=true
 # Exact one-time legacy owner binding for the first Access rollout:
 # ACCESS_LEGACY_OWNER_ID=owner
 # ACCESS_LEGACY_ISSUER=https://your-team.cloudflareaccess.com

--- a/apps/api/test/mailbox-probe-contract.test.ts
+++ b/apps/api/test/mailbox-probe-contract.test.ts
@@ -133,7 +133,7 @@ describe('mailbox probe MCP profile', () => {
     }
   });
 
-  it('keeps the draft HTTP endpoint unmounted while the feature gate is disabled', async () => {
+  it('keeps the draft HTTP endpoint unmounted while explicitly disabled', async () => {
     const config: ApiConfig = {
       host: '127.0.0.1', port: 0, ownerId: 'owner', bearerToken: bearer,
       runnerUrl: 'http://127.0.0.1:9', runnerToken: 'runner-token-that-is-longer-than-32-characters',
@@ -149,7 +149,7 @@ describe('mailbox probe MCP profile', () => {
     expect(response.status).toBe(404);
   });
 
-  it('mounts the draft HTTP endpoint only when the feature gate is enabled', async () => {
+  it('mounts the draft HTTP endpoint when the feature gate is enabled', async () => {
     const config: ApiConfig = {
       host: '127.0.0.1', port: 0, ownerId: 'owner', bearerToken: bearer,
       runnerUrl: 'http://127.0.0.1:9', runnerToken: 'runner-token-that-is-longer-than-32-characters',

--- a/packages/contracts/src/config.ts
+++ b/packages/contracts/src/config.ts
@@ -4,6 +4,7 @@ const token = z.string().min(32).max(512).refine((value) => !value.startsWith('c
 
 const httpsUrl = z.url().refine((value) => new URL(value).protocol === 'https:', 'HTTPS URL required');
 const enabled = z.preprocess((value) => value === true || value === 'true', z.boolean()).default(false);
+const enabledByDefault = z.preprocess((value) => value === true || value === 'true', z.boolean()).default(true);
 
 const principalRelink = z.object({
   oldIssuer: httpsUrl,
@@ -28,7 +29,7 @@ export const ApiConfigSchema = z.object({
   apiKeyGatewayAccessAudience: z.string().min(1).max(512).optional(),
   apiKeyGatewayServiceSubject: z.string().regex(/^cf-service:[A-Za-z0-9_-]+$/).max(512).optional(),
   apiKeyGatewayPublicUrl: httpsUrl.optional(),
-  mailboxProbeEnabled: enabled,
+  mailboxProbeEnabled: enabledByDefault,
   runnerUrl: z.url(),
   runnerToken: token,
   publicHosts: z.array(z.string().min(1)).min(1),

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -20,6 +20,8 @@ describe('contracts', () => {
   it('defaults to owner bearer mode and rejects mixed or partial Access configuration', () => {
     const owner = ApiConfigSchema.parse({ ...commonApiConfig, bearerToken: 'owner-token-that-is-long-enough-123456' });
     expect(owner.authMode ?? 'owner-bearer').toBe('owner-bearer');
+    expect(owner.mailboxProbeEnabled).toBe(true);
+    expect(ApiConfigSchema.parse({ ...commonApiConfig, bearerToken: 'owner-token-that-is-long-enough-123456', mailboxProbeEnabled: false }).mailboxProbeEnabled).toBe(false);
     expect(() => ApiConfigSchema.parse({
       ...commonApiConfig,
       authMode: 'owner-bearer',


### PR DESCRIPTION
## Summary
- Default-enable the temporary authenticated ChatGPT mailbox probe endpoint so the deployed existing endpoint can be validated without manual runtime env edits.
- Keep explicit opt-out with MAILBOX_PROBE_ENABLED=false.
- Update contract tests and .env.example to match the temporary validation posture.

## Verification
- npm test -- apps/api/test/mailbox-probe-contract.test.ts packages/contracts/test/contracts.test.ts
- npm run lint
- npm run typecheck