### PR TITLE
feat(runner): add workspace toolchains, 3-zone storage, privilege grants, and brokered github actions

### DIFF
--- a/.agents/skills/cloudharness/references/git-and-worktrees.md
+++ b/.agents/skills/cloudharness/references/git-and-worktrees.md
@@ -136,6 +136,28 @@ List managed worktrees and their branch/HEAD state for `workspaceId`.
 - Normal removal refuses dirty state. Forced removal can discard uncommitted
   files in that worktree; inspect it and preserve results first.
 
+## Brokered GitHub operations
+
+<!-- cloudharness-tool:github_action -->
+### `github_action`
+
+- Required: `workspaceId`, `action` (`pr_list`, `pr_view`, `pr_create`, `issue_list`, `issue_view`, or `issue_create`).
+- Uses trusted GitHub App broker tokens passed via stdin to an ephemeral helper container. Tokens are never exposed to workspace files.
+- `pr_list` / `issue_list`: optional `limit` (default 20, max 100), `state` (`open`, `closed`, or `all`).
+- `pr_view`: required `prNumber`.
+- `pr_create`: required `title`, `head`; optional `body`, `base` (default `main`).
+- `issue_view`: required `issueNumber`.
+- `issue_create`: required `title`; optional `body`.
+
+<!-- cloudharness-example:github_action
+{
+  "workspaceId": "ws_abcdefghijklmnopqrstuvwxyz012345",
+  "action": "pr_list",
+  "limit": 10,
+  "state": "open"
+}
+-->
+
 ## Recommended sequence
 
 1. `git_status` and unstaged/staged `git_diff`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 24.11.0
           cache: npm
       - run: npm ci
-      - run: bash -n worker/clone-helper.sh worker/task-runner.sh worker/shell-runner.sh worker/worker-runner.sh deploy/scripts/bootstrap-vps.sh deploy/scripts/deploy-release.sh deploy/scripts/release-runtime.sh deploy/scripts/rollback-release.sh deploy/scripts/deploy-ssh-wrapper.sh deploy/scripts/upgrade-nginx-dashboard.sh
+      - run: bash -n worker/clone-helper.sh worker/task-runner.sh worker/shell-runner.sh worker/worker-runner.sh worker/gh-helper.sh deploy/scripts/bootstrap-vps.sh deploy/scripts/deploy-release.sh deploy/scripts/release-runtime.sh deploy/scripts/rollback-release.sh deploy/scripts/deploy-ssh-wrapper.sh deploy/scripts/upgrade-nginx-dashboard.sh
       - run: npm run verify:compose
       - run: npm run verify
       - name: Verify documentation and reference integrity

--- a/apps/api/src/dashboard-control-router.ts
+++ b/apps/api/src/dashboard-control-router.ts
@@ -36,6 +36,9 @@ export function registerDashboardControlRoutes(
   router.post('/api/v1/github/reconcile', endpoint('github_reconcile', (request) => (request.body && typeof request.body === 'object' ? request.body as Record<string, unknown> : {})));
   router.delete('/api/v1/github/installations/:installationId', endpoint('github_disconnect', (request) => ({ installationId: request.params.installationId })));
   router.post('/api/v1/github/disconnect', endpoint('github_disconnect', (request) => request.body as Record<string, unknown>));
+  router.get('/api/v1/privilege-grants', endpoint('privilege_grant_list', (request) => ({ ...(request.query.workspaceId ? { workspaceId: String(request.query.workspaceId) } : {}) })));
+  router.post('/api/v1/privilege-grants/:grantId/approve', endpoint('privilege_grant_approve', (request) => ({ grantId: request.params.grantId })));
+  router.post('/api/v1/privilege-grants/:grantId/reject', endpoint('privilege_grant_reject', (request) => ({ grantId: request.params.grantId })));
   router.get('/api/v1/api-keys', apiKeyEndpoint('api_key_list', () => ({})));
   router.post('/api/v1/api-keys', apiKeyEndpoint('api_key_create', (request) => z.object({
     name: z.string().trim().min(1).max(100), expiresInDays: z.number().int().min(1).max(365)

--- a/apps/api/src/dashboard-response.ts
+++ b/apps/api/src/dashboard-response.ts
@@ -48,7 +48,8 @@ export type DashboardResponseOperation =
   | 'environment_list' | 'environment_create' | 'environment_update' | 'environment_delete'
   | 'secret_list' | 'secret_create' | 'secret_rotate' | 'secret_delete' | 'audit_list'
   | 'artifact_list' | 'artifact_snapshot' | 'artifact_delete'
-  | 'github_status' | 'github_setup_begin' | 'github_setup_complete' | 'github_reconcile' | 'github_disconnect';
+  | 'github_status' | 'github_setup_begin' | 'github_setup_complete' | 'github_reconcile' | 'github_disconnect'
+  | 'privilege_grant_list' | 'privilege_grant_approve' | 'privilege_grant_reject';
 
 function pick(value: unknown, keys: readonly string[]): Record<string, unknown> {
   const item = value && typeof value === 'object' ? value as Record<string, unknown> : {};
@@ -59,6 +60,7 @@ const metadataKeys = ['id', 'name', 'state', 'generation', 'createdAt', 'updated
 const environmentKeys = [...metadataKeys, 'projectId'] as const;
 const secretKeys = ['id', 'environmentId', 'name', 'state', 'version', 'generation', 'createdAt', 'updatedAt', 'deletedAt'] as const;
 const artifactKeys = ['artifactId', 'logicalName', 'sha256', 'sizeBytes', 'projectId', 'environmentId', 'workspaceId', 'createdAt', 'updatedAt', 'expiresAt', 'retentionMs', 'generation'] as const;
+const privilegeGrantKeys = ['id', 'ownerId', 'workspaceId', 'command', 'cwd', 'commandSha256', 'status', 'createdAt', 'expiresAt', 'consumedAt'] as const;
 const list = (data: Record<string, unknown>, key: string, keys: readonly string[]) => ({
   [key]: Array.isArray(data[key]) ? data[key].map((record) => pick(record, keys)) : []
 });
@@ -116,6 +118,8 @@ export function mapDashboardData(operation: DashboardResponseOperation, value: u
   if (operation === 'artifact_snapshot' || operation === 'artifact_delete') return pick(data, artifactKeys);
   if (operation === 'github_setup_begin') return pick(data, ['url', 'state', 'expiresAt']);
   if (['github_status', 'github_setup_complete', 'github_reconcile', 'github_disconnect'].includes(operation)) return githubStatus(data);
+  if (operation === 'privilege_grant_list') return list(data, 'grants', privilegeGrantKeys);
+  if (operation === 'privilege_grant_approve' || operation === 'privilege_grant_reject') return { grant: pick(data.grant, privilegeGrantKeys) };
   return {};
 }
 

--- a/apps/api/test/dashboard-app-mount.test.ts
+++ b/apps/api/test/dashboard-app-mount.test.ts
@@ -61,6 +61,7 @@ describe('dashboard application mount', () => {
       allowedOrigins: [], requestTimeoutMs: 2_000, maxBodyBytes: 65_536
     });
     expect((await fetch(`${url}/dashboard`)).status).toBe(404);
+    expect((await fetch(`${url}/operator`)).status).toBe(404);
   });
 
   it('requires a verified Access assertion before serving dashboard assets', async () => {

--- a/apps/runner/src/dashboard-control-service.ts
+++ b/apps/runner/src/dashboard-control-service.ts
@@ -6,7 +6,7 @@ import { ArtifactStoreError, type ArtifactStore } from './artifact-store.js';
 import type { GitHubBindingService } from './github-binding-service.js';
 import type { GitHubInstallationStore } from './github-installation-store.js';
 import type { MetadataStore } from './metadata-store.js';
-import type { StateStore } from './state-store.js';
+import type { PrivilegeGrantRecord, StateStore } from './state-store.js';
 import type { WorkspaceService } from './workspace-service.js';
 
 export class DashboardControlService {
@@ -118,6 +118,49 @@ export class DashboardControlService {
             )
           );
           return ok('GitHub installation disconnected', this.githubStatus(principalId));
+        }
+        case 'privilege_grant_list': {
+          return ok('Privilege grants listed', {
+            grants: this.principals.listPrivilegeGrants(principalId, parsed.input.workspaceId)
+          });
+        }
+        case 'privilege_grant_approve': {
+          let approvedGrant: PrivilegeGrantRecord | undefined;
+          const approved = this.principals.approvePrivilegeGrant(
+            principalId,
+            parsed.input.grantId,
+            (database, grant) => {
+              approvedGrant = grant;
+              this.metadata.recordAuditInTransaction(
+                database, principalId, 'privilege_grant.approved', 'privilege_grant',
+                grant.id, 1,
+                { workspaceId: grant.workspaceId, commandSha256: grant.commandSha256 }
+              );
+            }
+          );
+          if (!approved) {
+            throw new HarnessError('NOT_FOUND', 'privilege grant not found, expired, or already approved/consumed', 404, false);
+          }
+          return ok('Privilege grant approved', { grant: approvedGrant });
+        }
+        case 'privilege_grant_reject': {
+          let rejectedGrant: PrivilegeGrantRecord | undefined;
+          const rejected = this.principals.rejectPrivilegeGrant(
+            principalId,
+            parsed.input.grantId,
+            (database, grant) => {
+              rejectedGrant = grant;
+              this.metadata.recordAuditInTransaction(
+                database, principalId, 'privilege_grant.rejected', 'privilege_grant',
+                grant.id, 1,
+                { workspaceId: grant.workspaceId, commandSha256: grant.commandSha256 }
+              );
+            }
+          );
+          if (!rejected) {
+            throw new HarnessError('NOT_FOUND', 'privilege grant not found or not in pending state', 404, false);
+          }
+          return ok('Privilege grant rejected', { grant: rejectedGrant });
         }
       }
     } catch (error) {

--- a/apps/runner/src/github-app-broker.ts
+++ b/apps/runner/src/github-app-broker.ts
@@ -41,6 +41,90 @@ export async function mintPrincipalRepositoryToken(input: {
 
   return mintForInstallation(input.config.githubApp, installation.installationId, repository);
 }
+export async function mintPrincipalRepositoryScopedToken(input: {
+  config: RunnerConfig;
+  principalId: string;
+  repositoryUrl: URL;
+  installations?: GitHubInstallationStore | undefined;
+  permissionScope: 'issues' | 'pull_requests' | 'contents';
+  requiredPermission: 'read' | 'write';
+}): Promise<string | undefined> {
+  if (!input.config.githubApp || input.repositoryUrl.hostname.toLowerCase() !== 'github.com') return undefined;
+  const { owner, repository } = parseGitHubRepository(input.repositoryUrl);
+  const authMode = input.config.authMode ?? 'owner-bearer';
+
+  if (authMode === 'cloudflare-access') {
+    if (!input.installations) {
+      if (input.requiredPermission === 'write') {
+        throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
+      }
+      return undefined;
+    }
+    const grant = input.installations.getRepositoryGrant(input.principalId, owner, repository);
+    if (!grant || grant.status !== 'granted') {
+      if (input.requiredPermission === 'write') {
+        throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
+      }
+      return undefined;
+    }
+
+    const installation = input.installations.getInstallation(input.principalId, grant.installationId);
+    if (
+      !installation ||
+      installation.status !== 'active' ||
+      String(input.config.githubApp.appId) !== installation.appId
+    ) {
+      throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
+    }
+
+    return mintForInstallationScoped(
+      input.config.githubApp,
+      installation.installationId,
+      repository,
+      input.permissionScope,
+      input.requiredPermission
+    );
+  }
+
+  if (input.config.githubApp.installationId) {
+    return mintForInstallationScoped(
+      input.config.githubApp,
+      input.config.githubApp.installationId,
+      repository,
+      input.permissionScope,
+      input.requiredPermission
+    );
+  }
+
+  if (input.requiredPermission === 'write') {
+    throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
+  }
+  return undefined;
+}
+
+async function mintForInstallationScoped(
+  githubApp: NonNullable<RunnerConfig['githubApp']>,
+  installationId: string | number,
+  repositoryName: string,
+  permissionScope: 'issues' | 'pull_requests' | 'contents',
+  requiredPermission: 'read' | 'write'
+): Promise<string> {
+  try {
+    const auth = createAppAuth({
+      appId: githubApp.appId,
+      installationId,
+      privateKey: githubApp.privateKey
+    });
+    const authentication = await auth({
+      type: 'installation',
+      repositoryNames: [repositoryName],
+      permissions: { [permissionScope]: requiredPermission }
+    });
+    return authentication.token;
+  } catch {
+    throw new HarnessError('UNAVAILABLE', `GitHub App could not mint an installation token with ${permissionScope} permission`, 502, true);
+  }
+}
 
 function parseGitHubRepository(repositoryUrl: URL): { owner: string; repository: string } {
   const parts = repositoryUrl.pathname.replace(/^\//, '').replace(/\.git$/, '').split('/');

--- a/apps/runner/src/state-store.ts
+++ b/apps/runner/src/state-store.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -42,6 +42,47 @@ export type WorkspaceRecord = {
   error: string | null;
 };
 
+export type PrivilegeGrantStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'CONSUMED' | 'EXPIRED';
+
+export type PrivilegeGrantRecord = {
+  id: string;
+  ownerId: string;
+  workspaceId: string;
+  command: string;
+  cwd: string;
+  commandSha256: string;
+  status: PrivilegeGrantStatus;
+  createdAt: number;
+  expiresAt: number;
+  consumedAt: number | null;
+};
+
+type PrivilegeGrantRow = {
+  id: string;
+  owner_id: string;
+  workspace_id: string;
+  command: string;
+  cwd: string;
+  command_sha256: string;
+  status: PrivilegeGrantStatus;
+  created_at: number;
+  expires_at: number;
+  consumed_at: number | null;
+};
+
+const fromPrivilegeGrantRow = (row: PrivilegeGrantRow): PrivilegeGrantRecord => ({
+  id: row.id,
+  ownerId: row.owner_id,
+  workspaceId: row.workspace_id,
+  command: row.command,
+  cwd: row.cwd || '.',
+  commandSha256: row.command_sha256,
+  status: row.status,
+  createdAt: row.created_at,
+  expiresAt: row.expires_at,
+  consumedAt: row.consumed_at
+});
+
 type Row = {
   id: string; owner_id: string; idempotency_key: string; repository_url: string; repository_ref: string | null;
   container_name: string | null; workspace_path: string; status: WorkspaceRecord['status']; network_mode: 'none' | 'bridge';
@@ -76,6 +117,19 @@ export class StateStore {
       CREATE UNIQUE INDEX IF NOT EXISTS one_active_workspace_per_owner
         ON workspaces(owner_id)
         WHERE status IN ('CREATING','ACTIVE','REAPING');
+      CREATE TABLE IF NOT EXISTS privilege_grants (
+        id TEXT PRIMARY KEY,
+        owner_id TEXT NOT NULL,
+        workspace_id TEXT NOT NULL,
+        command TEXT NOT NULL,
+        cwd TEXT NOT NULL DEFAULT '.',
+        command_sha256 TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL,
+        consumed_at INTEGER
+      );
+      CREATE INDEX IF NOT EXISTS privilege_grants_owner_workspace ON privilege_grants(owner_id, workspace_id);
     `);
     migratePrincipalSchema(this.database);
     this.database.prepare('INSERT OR IGNORE INTO runtime_meta(key, value) VALUES (?, ?)')
@@ -180,6 +234,139 @@ export class StateStore {
 
   claimForReaping(id: string, generation: number): boolean {
     const result = this.database.prepare("UPDATE workspaces SET status='REAPING', generation=generation+1 WHERE id=? AND generation=? AND status IN ('CREATING','ACTIVE','FAILED')").run(id, generation);
+    return result.changes === 1;
+  }
+  createPrivilegeGrant(input: { ownerId: string; workspaceId: string; command: string; cwd?: string; ttlMs?: number }): PrivilegeGrantRecord {
+    const now = Date.now();
+    const cwd = input.cwd || '.';
+    const commandSha256 = createHash('sha256').update(input.command).digest('hex');
+    const existing = this.database.prepare(
+      "SELECT * FROM privilege_grants WHERE owner_id = ? AND workspace_id = ? AND command_sha256 = ? AND cwd = ? AND status = 'PENDING' AND expires_at > ? ORDER BY created_at DESC LIMIT 1"
+    ).get(input.ownerId, input.workspaceId, commandSha256, cwd, now) as PrivilegeGrantRow | undefined;
+    if (existing) {
+      return fromPrivilegeGrantRow(existing);
+    }
+    try {
+      this.database.prepare("DELETE FROM privilege_grants WHERE owner_id = ? AND (status IN ('EXPIRED', 'REJECTED', 'CONSUMED') OR expires_at < ?) AND created_at < ?").run(input.ownerId, now, now - 3_600_000);
+    } catch { /* ignore prune failure */ }
+    const id = `pvg_${randomBytes(16).toString('hex')}`;
+    const expiresAt = now + (input.ttlMs ?? 60_000);
+    const record: PrivilegeGrantRecord = {
+      id,
+      ownerId: input.ownerId,
+      workspaceId: input.workspaceId,
+      command: input.command,
+      cwd,
+      commandSha256,
+      status: 'PENDING',
+      createdAt: now,
+      expiresAt,
+      consumedAt: null
+    };
+    this.database.prepare(`INSERT INTO privilege_grants
+      (id, owner_id, workspace_id, command, cwd, command_sha256, status, created_at, expires_at, consumed_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(record.id, record.ownerId, record.workspaceId, record.command, record.cwd, record.commandSha256, record.status, record.createdAt, record.expiresAt, record.consumedAt);
+    return record;
+  }
+
+  getPrivilegeGrant(grantId: string): PrivilegeGrantRecord | undefined {
+    const now = Date.now();
+    const row = this.database.prepare('SELECT * FROM privilege_grants WHERE id = ?').get(grantId) as PrivilegeGrantRow | undefined;
+    if (!row) return undefined;
+    const grant = fromPrivilegeGrantRow(row);
+    if ((grant.status === 'PENDING' || grant.status === 'APPROVED') && grant.expiresAt <= now) {
+      this.database.prepare("UPDATE privilege_grants SET status = 'EXPIRED' WHERE id = ? AND status IN ('PENDING', 'APPROVED')").run(grantId);
+      return { ...grant, status: 'EXPIRED' };
+    }
+    return grant;
+  }
+  listPrivilegeGrants(ownerId: string, workspaceId?: string, limit = 50): PrivilegeGrantRecord[] {
+    const now = Date.now();
+    const boundedLimit = Math.min(Math.max(1, limit), 100);
+    const query = workspaceId
+      ? 'SELECT * FROM privilege_grants WHERE owner_id = ? AND workspace_id = ? ORDER BY created_at DESC LIMIT ?'
+      : 'SELECT * FROM privilege_grants WHERE owner_id = ? ORDER BY created_at DESC LIMIT ?';
+    const rows = (workspaceId
+      ? this.database.prepare(query).all(ownerId, workspaceId, boundedLimit)
+      : this.database.prepare(query).all(ownerId, boundedLimit)) as PrivilegeGrantRow[];
+    return rows.map((row) => {
+      const grant = fromPrivilegeGrantRow(row);
+      if ((grant.status === 'PENDING' || grant.status === 'APPROVED') && grant.expiresAt <= now) {
+        return { ...grant, status: 'EXPIRED' };
+      }
+      return grant;
+    });
+  }
+
+  pruneExpiredPrivilegeGrants(now: number = Date.now(), maxAgeMs: number = 86_400_000): number {
+    const threshold = now - maxAgeMs;
+    const result = this.database.prepare(
+      "DELETE FROM privilege_grants WHERE (status IN ('EXPIRED', 'REJECTED', 'CONSUMED') AND (created_at < ? OR expires_at < ?)) OR (expires_at < ?)"
+    ).run(threshold, threshold, threshold);
+    return Number(result.changes);
+  }
+  approvePrivilegeGrant(
+    ownerId: string,
+    grantId: string,
+    onApproved?: (database: DatabaseSync, grant: PrivilegeGrantRecord) => void
+  ): boolean {
+    const now = Date.now();
+    this.database.exec('BEGIN IMMEDIATE;');
+    try {
+      const row = this.database.prepare('SELECT * FROM privilege_grants WHERE id = ? AND owner_id = ?').get(grantId, ownerId) as PrivilegeGrantRow | undefined;
+      if (!row || row.status !== 'PENDING' || row.expires_at <= now) {
+        this.database.exec('ROLLBACK;');
+        return false;
+      }
+      this.database.prepare(
+        "UPDATE privilege_grants SET status = 'APPROVED' WHERE id = ? AND owner_id = ?"
+      ).run(grantId, ownerId);
+      const grant = { ...fromPrivilegeGrantRow(row), status: 'APPROVED' as const };
+      if (onApproved) {
+        onApproved(this.database, grant);
+      }
+      this.database.exec('COMMIT;');
+      return true;
+    } catch (error) {
+      try { this.database.exec('ROLLBACK;'); } catch { /* ignore rollback error */ }
+      throw error;
+    }
+  }
+
+  rejectPrivilegeGrant(
+    ownerId: string,
+    grantId: string,
+    onRejected?: (database: DatabaseSync, grant: PrivilegeGrantRecord) => void
+  ): boolean {
+    this.database.exec('BEGIN IMMEDIATE;');
+    try {
+      const row = this.database.prepare('SELECT * FROM privilege_grants WHERE id = ? AND owner_id = ?').get(grantId, ownerId) as PrivilegeGrantRow | undefined;
+      if (!row || row.status !== 'PENDING') {
+        this.database.exec('ROLLBACK;');
+        return false;
+      }
+      this.database.prepare(
+        "UPDATE privilege_grants SET status = 'REJECTED' WHERE id = ? AND owner_id = ?"
+      ).run(grantId, ownerId);
+      const grant = { ...fromPrivilegeGrantRow(row), status: 'REJECTED' as const };
+      if (onRejected) {
+        onRejected(this.database, grant);
+      }
+      this.database.exec('COMMIT;');
+      return true;
+    } catch (error) {
+      try { this.database.exec('ROLLBACK;'); } catch { /* ignore rollback error */ }
+      throw error;
+    }
+  }
+
+  consumePrivilegeGrant(input: { ownerId: string; workspaceId: string; grantId: string; commandSha256: string; cwd?: string }): boolean {
+    const now = Date.now();
+    const cwd = input.cwd || '.';
+    const result = this.database.prepare(
+      "UPDATE privilege_grants SET status = 'CONSUMED', consumed_at = ? WHERE id = ? AND owner_id = ? AND workspace_id = ? AND command_sha256 = ? AND cwd = ? AND status = 'APPROVED' AND expires_at > ?"
+    ).run(now, input.grantId, input.ownerId, input.workspaceId, input.commandSha256, cwd, now);
     return result.changes === 1;
   }
 

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -1,5 +1,5 @@
-import { randomBytes } from 'node:crypto';
-import { chmod, mkdir, readdir, realpath, rm, statfs } from 'node:fs/promises';
+import { createHash, randomBytes } from 'node:crypto';
+import { chmod, chown, mkdir, readdir, realpath, rm, statfs } from 'node:fs/promises';
 import { join, relative, resolve, sep } from 'node:path';
 import {
   HarnessError,
@@ -14,7 +14,7 @@ import {
 } from '@cloud-harness/contracts';
 import { inspectContainer, removeContainer, runDocker, terminateContainerProcessGroup } from './docker-engine.js';
 import { readVerifiedWorkspaceFile } from './bounded-workspace-file-reader.js';
-import { mintPrincipalRepositoryToken, mintRepositoryToken } from './github-app-broker.js';
+import { mintPrincipalRepositoryScopedToken, mintPrincipalRepositoryToken, mintRepositoryToken } from './github-app-broker.js';
 import type { GitHubInstallationStore } from './github-installation-store.js';
 import type { MetadataStore } from './metadata-store.js';
 import { OperationManager } from './operation-manager.js';
@@ -145,7 +145,7 @@ export class WorkspaceService {
     let result;
     if (record.containerName) {
       result = await runDocker(
-        ['exec', record.containerName, '/usr/bin/du', '-sb', '--apparent-size', '/workspace'],
+        ['exec', record.containerName, '/usr/bin/du', '-sb', '--apparent-size', '/workspace', '/opt/user-tools', '/var/cache/harness'],
         { timeoutMs: 30_000, maxBytes: 8_192 }
       );
     } else {
@@ -165,8 +165,15 @@ export class WorkspaceService {
       }
     }
     if (result.exitCode !== 0) return undefined;
-    const bytes = Number(result.stdout.trim().split(/\s+/, 1)[0]);
-    return Number.isSafeInteger(bytes) && bytes >= 0 ? bytes : undefined;
+    const lines = result.stdout.trim().split('\n');
+    let totalBytes = 0;
+    for (const line of lines) {
+      const bytes = Number(line.trim().split(/\s+/, 1)[0]);
+      if (Number.isSafeInteger(bytes) && bytes >= 0) {
+        totalBytes += bytes;
+      }
+    }
+    return totalBytes >= 0 ? totalBytes : undefined;
   }
 
   private async resourceViolation(record: WorkspaceRecord): Promise<string | undefined> {
@@ -218,18 +225,66 @@ export class WorkspaceService {
     return join(jobPath, 'repo');
   }
 
+  private async provisionMountDirectories(record: WorkspaceRecord): Promise<{ toolsPath: string; cachePath: string }> {
+    const jobPath = record.workspacePath;
+    const toolsPath = join(jobPath, 'tools');
+    const cachePath = join(jobPath, 'cache');
+    await mkdir(toolsPath, { recursive: true, mode: 0o755 });
+    await mkdir(cachePath, { recursive: true, mode: 0o755 });
+    try {
+      await chown(toolsPath, 10001, 10001);
+      await chown(cachePath, 10001, 10001);
+      await chmod(toolsPath, 0o755);
+      await chmod(cachePath, 0o755);
+    } catch {
+      const helperName = `chm-chown-${record.id.slice(3, 15)}-${randomBytes(4).toString('hex')}`;
+      try {
+        const result = await runDocker([
+          'run', '--rm', '--pull', 'never', '--name', helperName,
+          '--label', 'cloud-harness.role=chown-helper', '--label', 'cloud-harness.ephemeral=true',
+          '--label', `cloud-harness.instance=${this.instanceId}`, '--label', `cloud-harness.workspace=${record.id}`,
+          '--network', 'none', '--user', '0:0',
+          '--volume', `${jobPath}:/job`,
+          '--entrypoint', '/bin/sh', this.config.executorImage,
+          '-c', 'mkdir -p /job/tools /job/cache && chown -R 10001:10001 /job/tools /job/cache && chmod 0755 /job/tools /job/cache'
+        ], { timeoutMs: 30_000, maxBytes: 8_192 });
+        if (result.exitCode !== 0) {
+          throw new HarnessError('UNAVAILABLE', `mount directory provisioning failed: ${result.stderr || result.stdout}`.slice(0, 2_000), 502, true);
+        }
+      } finally {
+        await removeContainer(helperName);
+      }
+    }
+    return { toolsPath, cachePath };
+  }
+
   private async createExecutor(record: WorkspaceRecord, repositoryPath: string, environment: Record<string, string> = {}): Promise<string> {
     const name = `cloud-harness-ws-${record.id.slice(3, 19).toLowerCase()}`;
+    const { toolsPath, cachePath } = await this.provisionMountDirectories(record);
     const args = [
       'create', '--name', name,
       '--label', 'cloud-harness.managed=true', '--label', `cloud-harness.instance=${this.instanceId}`,
       '--label', `cloud-harness.workspace=${record.id}`,
       '--user', '10001:10001', '--workdir', '/workspace', '--read-only',
-      '--tmpfs', '/tmp:rw,exec,nosuid,nodev,size=64m', '--tmpfs', '/run:rw,nosuid,nodev,size=8m',
+      '--tmpfs', '/tmp:rw,exec,nosuid,nodev,size=128m', '--tmpfs', '/run:rw,nosuid,nodev,size=8m',
       '--cap-drop', 'ALL', '--security-opt', 'no-new-privileges', '--pids-limit', '256',
       '--memory', '1g', '--memory-swap', '1g', '--cpus', '1', '--ulimit', 'nofile=1024:1024',
-      '--network', record.networkMode, '--volume', `${repositoryPath}:/workspace:rw`,
-      '--env', 'HOME=/tmp/cloud-harness-home', '--env', 'GIT_CONFIG_NOSYSTEM=1',
+      '--network', record.networkMode,
+      '--volume', `${repositoryPath}:/workspace:rw`,
+      '--volume', `${toolsPath}:/opt/user-tools:rw`,
+      '--volume', `${cachePath}:/var/cache/harness:rw`,
+      '--env', 'HOME=/tmp/cloud-harness-home',
+      '--env', 'GIT_CONFIG_NOSYSTEM=1',
+      '--env', 'XDG_CONFIG_HOME=/tmp/cloud-harness-home/.config',
+      '--env', 'XDG_CACHE_HOME=/var/cache/harness',
+      '--env', 'XDG_DATA_HOME=/opt/user-tools/data',
+      '--env', 'NPM_CONFIG_PREFIX=/opt/user-tools',
+      '--env', 'NPM_CONFIG_CACHE=/var/cache/harness/npm',
+      '--env', 'UV_CACHE_DIR=/var/cache/harness/uv',
+      '--env', 'BUN_INSTALL=/opt/user-tools/bun',
+      '--env', 'PNPM_HOME=/opt/user-tools/pnpm',
+      '--env', 'UV_TOOL_BIN_DIR=/opt/user-tools/bin',
+      '--env', 'PATH=/workspace/node_modules/.bin:/opt/user-tools/bin:/opt/user-tools/pnpm/bin:/opt/user-tools/pnpm:/opt/user-tools/bun/bin:/tmp/cloud-harness-home/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
       ...Object.entries(environment).flatMap(([name, value]) => ['--env', `${name}=${value}`]),
       this.config.executorImage
     ];
@@ -445,6 +500,183 @@ export class WorkspaceService {
       await this.safeRemovePath(join(record.workspacePath, transferName));
     }
   }
+  private async handleExecRun(record: WorkspaceRecord, validated: Record<string, unknown>, signal?: AbortSignal): Promise<RunnerResponse> {
+    const command = validated.command as string;
+    const cwd = ((validated.cwd as string) || '.').replaceAll('\\', '/').replace(/^\/+/, '').replace(/\/+$/, '') || '.';
+    const timeoutMs = (validated.timeoutMs as number) || 60_000;
+    const maxOutputBytes = (validated.maxOutputBytes as number) || this.config.maxOutputBytes;
+    const privileged = Boolean(validated.privileged);
+    const approvalGrantToken = validated.approvalGrantToken as string | undefined;
+
+    if (privileged) {
+      if ((this.config.authMode ?? 'owner-bearer') === 'owner-bearer') {
+        throw new HarnessError('FORBIDDEN', 'Privileged execution requires Cloudflare Access operator dashboard approval and is disabled in owner-bearer mode', 403, false);
+      }
+      const commandSha256 = createHash('sha256').update(command).digest('hex');
+      if (!approvalGrantToken) {
+        const grant = this.store.createPrivilegeGrant({
+          ownerId: record.ownerId,
+          workspaceId: record.id,
+          command,
+          cwd,
+          ttlMs: 60_000
+        });
+
+        return {
+          ok: false,
+          message: 'Privileged execution requires explicit operator approval grant',
+          error: {
+            code: 'PRIVILEGE_APPROVAL_REQUIRED',
+            message: `Approval grant required to execute privileged command on workspace ${record.id}`,
+            grantRequest: {
+              grantId: grant.id,
+              workspaceId: grant.workspaceId,
+              commandSha256: grant.commandSha256,
+              cwd: grant.cwd,
+              expiresAt: new Date(grant.expiresAt).toISOString()
+            },
+            retryable: true
+          },
+          truncated: false
+        };
+      }
+
+      const grantValid = this.store.consumePrivilegeGrant({
+        ownerId: record.ownerId,
+        workspaceId: record.id,
+        grantId: approvalGrantToken,
+        commandSha256,
+        cwd
+      });
+
+      if (!grantValid) {
+        throw new HarnessError('FORBIDDEN', 'Invalid, expired, or already-consumed approval grant token', 403);
+      }
+
+      return await this.runPrivilegedEphemeralExec(record, { command, cwd, timeoutMs, maxOutputBytes }, signal);
+    }
+
+    return await this.runWorker(record, 'exec_run', validated, signal);
+  }
+
+  private async runPrivilegedEphemeralExec(
+    record: WorkspaceRecord,
+    input: { command: string; cwd: string; timeoutMs: number; maxOutputBytes: number },
+    signal?: AbortSignal
+  ): Promise<RunnerResponse> {
+    const privName = `chm-priv-${record.id.slice(3, 15)}-${randomBytes(4).toString('hex')}`;
+    const toolsPath = join(record.workspacePath, 'tools');
+    const cachePath = join(record.workspacePath, 'cache');
+    const normalizedCwd = input.cwd.replaceAll('\\', '/').replace(/^\/+/, '').replace(/\/+$/, '') || '.';
+    const workdir = normalizedCwd === '.' ? '/workspace' : `/workspace/${normalizedCwd}`;
+    try {
+      const result = await runDocker([
+        'run', '-i', '--rm', '--name', privName,
+        '--label', 'cloud-harness.managed=true',
+        '--label', `cloud-harness.instance=${this.instanceId}`,
+        '--label', `cloud-harness.workspace=${record.id}`,
+        '--label', 'cloud-harness.role=priv-exec',
+        '--label', 'cloud-harness.ephemeral=true',
+        '--network', record.networkMode,
+        '--user', '0:0',
+        '--workdir', workdir,
+        '--pids-limit', '256',
+        '--memory', '1g', '--memory-swap', '1g', '--cpus', '1',
+        '--tmpfs', '/tmp:rw,exec,nosuid,nodev,size=128m',
+        '--tmpfs', '/run:rw,nosuid,nodev,size=8m',
+        '--volume', `${record.workspacePath}/repo:/workspace:rw`,
+        '--volume', `${toolsPath}:/opt/user-tools:rw`,
+        '--volume', `${cachePath}:/var/cache/harness:rw`,
+        '--env', 'HOME=/tmp/cloud-harness-home',
+        '--env', 'BUN_INSTALL=/opt/user-tools/bun',
+        '--env', 'PNPM_HOME=/opt/user-tools/pnpm',
+        '--env', 'UV_TOOL_BIN_DIR=/opt/user-tools/bin',
+        '--env', 'PATH=/workspace/node_modules/.bin:/opt/user-tools/bin:/opt/user-tools/pnpm/bin:/opt/user-tools/pnpm:/opt/user-tools/bun/bin:/tmp/cloud-harness-home/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        '--entrypoint', '/bin/bash',
+        this.config.executorImage,
+        '-c', input.command
+      ], {
+        timeoutMs: input.timeoutMs,
+        maxBytes: input.maxOutputBytes,
+        ...(signal ? { signal } : {})
+      });
+
+      return {
+        ok: result.exitCode === 0,
+        message: result.exitCode === 0 ? 'Privileged execution completed successfully' : `Privileged execution failed with exit code ${result.exitCode}`,
+        data: { output: result.stdout || result.stderr, stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode },
+        truncated: result.truncated
+      };
+    } finally {
+      await removeContainer(privName);
+    }
+  }
+
+  private async runBrokeredGitHubAction(
+    record: WorkspaceRecord,
+    action: 'pr_list' | 'pr_view' | 'pr_create' | 'issue_list' | 'issue_view' | 'issue_create',
+    args: string[],
+    signal?: AbortSignal
+  ): Promise<RunnerResponse> {
+    const isWrite = action === 'pr_create' || action === 'issue_create';
+    const permissionScope = action.startsWith('pr_') ? 'pull_requests' : 'issues';
+
+    // mintPrincipalRepositoryScopedToken handles both cloudflare-access (via installations) and owner-bearer (via config.githubApp.installationId)
+    const token = await mintPrincipalRepositoryScopedToken({
+      config: this.config,
+      principalId: record.ownerId,
+      repositoryUrl: new URL(record.repositoryUrl),
+      installations: this.githubInstallations,
+      permissionScope,
+      requiredPermission: isWrite ? 'write' : 'read'
+    });
+    if (!token) {
+      throw new HarnessError('FORBIDDEN', `No GitHub App installation available for ${record.repositoryUrl}`, 403);
+    }
+
+    const helperName = `chm-gh-${record.id.slice(3, 15)}-${randomBytes(4).toString('hex')}`;
+    try {
+      const result = await runDocker([
+        'run', '-i', '--rm', '--name', helperName,
+        '--label', 'cloud-harness.managed=true',
+        '--label', `cloud-harness.instance=${this.instanceId}`,
+        '--label', `cloud-harness.workspace=${record.id}`,
+        '--label', 'cloud-harness.role=gh-helper',
+        '--label', 'cloud-harness.ephemeral=true',
+        '--network', 'bridge',
+        '--user', '10001:10001',
+        '--read-only',
+        '--tmpfs', '/tmp:rw,exec,size=32m',
+        '--cap-drop', 'ALL',
+        '--security-opt', 'no-new-privileges',
+        '--pids-limit', '128',
+        '--memory', '512m', '--memory-swap', '512m', '--cpus', '1',
+        '--ulimit', 'nofile=1024:1024',
+        '--volume', `${record.workspacePath}/repo:/workspace:ro`,
+        '--workdir', '/workspace',
+        '--env', 'HOME=/tmp/cloud-harness-home',
+        '--env', `GH_REPO=${new URL(record.repositoryUrl).pathname.replace(/^\//, '').replace(/\.git$/, '')}`,
+        '--entrypoint', '/opt/harness/gh-helper.sh',
+        this.config.executorImage,
+        action,
+        ...args
+      ], {
+        stdin: `${token}\n`,
+        timeoutMs: 60_000,
+        maxBytes: this.config.maxOutputBytes,
+        ...(signal ? { signal } : {})
+      });
+
+      return {
+        ok: result.exitCode === 0,
+        message: (result.exitCode === 0 ? `GitHub ${action} successful` : `GitHub ${action} failed: ${result.stderr}`).slice(0, 2_000),
+        data: { output: result.stdout || result.stderr },
+        truncated: result.truncated
+      };
+    } finally {
+      await removeContainer(helperName);
+    }
+  }
 
   async execute(principal: PrincipalSelector | string, operation: RunnerOperation, input: Record<string, unknown>, signal?: AbortSignal): Promise<RunnerResponse> {
     const ownerId = this.store.resolvePrincipal(typeof principal === 'string' ? { kind: 'owner', ownerId: principal } : principal);
@@ -457,7 +689,27 @@ export class WorkspaceService {
     if (operation === 'workspace_close') return await this.close(ownerId, workspaceId);
     const record = this.touch(this.requireWorkspace(ownerId, workspaceId));
     await this.enforceActiveLimits(record);
-    if (operation === 'exec_run') validated.maxOutputBytes = Math.min(validated.maxOutputBytes as number, this.config.maxOutputBytes);
+    if (operation === 'exec_run') {
+      validated.maxOutputBytes = Math.min(validated.maxOutputBytes as number, this.config.maxOutputBytes);
+      const result = await this.handleExecRun(record, validated, signal);
+      await this.enforceActiveLimits(record);
+      return result;
+    }
+    if (operation === 'github_action') {
+      const action = validated.action as 'pr_list' | 'pr_view' | 'pr_create' | 'issue_list' | 'issue_view' | 'issue_create';
+      let args: string[] = [];
+      switch (action) {
+        case 'pr_list': args = [String(validated.limit ?? 20), (validated.state as string) ?? 'open']; break;
+        case 'pr_view': args = [String(validated.prNumber)]; break;
+        case 'pr_create': args = [validated.title as string, (validated.body as string) ?? '', validated.head as string, (validated.base as string) ?? 'main']; break;
+        case 'issue_list': args = [String(validated.limit ?? 20), (validated.state as string) ?? 'open']; break;
+        case 'issue_view': args = [String(validated.issueNumber)]; break;
+        case 'issue_create': args = [validated.title as string, (validated.body as string) ?? '']; break;
+      }
+      const result = await this.runBrokeredGitHubAction(record, action, args, signal);
+      await this.enforceActiveLimits(record);
+      return result;
+    }
     if (operation === 'shell_open') {
       const shell = this.operations.openShell(record.id, record.containerName!, validated.cwd as string, validated.idempotencyKey as string, this.config.maxOutputBytes);
       return { ok: true, message: 'Shell opened', data: this.operations.view(shell), truncated: false };
@@ -694,9 +946,9 @@ export class WorkspaceService {
       const cleaned = await runDocker([
         'run', '--rm', '--pull', 'never', '--name', helperName,
         '--label', 'cloud-harness.role=cleanup-helper', '--label', 'cloud-harness.ephemeral=true',
-        '--label', `cloud-harness.instance=${this.instanceId}`, '--network', 'none', '--user', '10001:10001',
-        '--read-only', '--tmpfs', '/tmp:rw,nosuid,nodev,size=16m', '--cap-drop', 'ALL',
-        '--security-opt', 'no-new-privileges', '--pids-limit', '32', '--memory', '128m', '--memory-swap', '128m', '--cpus', '0.25',
+        '--label', `cloud-harness.instance=${this.instanceId}`, '--network', 'none', '--user', '0:0',
+        '--read-only', '--tmpfs', '/tmp:rw,nosuid,nodev,size=16m',
+        '--pids-limit', '32', '--memory', '128m', '--memory-swap', '128m', '--cpus', '0.25',
         '--volume', `${target}:/target:rw`, '--entrypoint', '/usr/bin/find', this.config.executorImage,
         '/target', '-mindepth', '1', '-delete'
       ], { timeoutMs: 30_000, maxBytes: 65_536 });

--- a/apps/runner/test/dashboard-control-service.test.ts
+++ b/apps/runner/test/dashboard-control-service.test.ts
@@ -13,15 +13,27 @@ import { SecretKeyring } from '../src/secret-keyring.js';
 import { StateStore } from '../src/state-store.js';
 import type { WorkspaceService } from '../src/workspace-service.js';
 const roots: string[] = [];
-afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+const cleanups: (() => void)[] = [];
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) {
+    try { cleanup(); } catch { /* ignore cleanup error */ }
+  }
+  for (const root of roots.splice(0)) {
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* ignore cleanup error */ }
+  }
+});
 
 function setup(withKeyring = true) {
   const root = mkdtempSync(join(tmpdir(), 'cloud-harness-controls-')); roots.push(root);
   const databasePath = join(root, 'state.db'); const principals = new StateStore(databasePath);
   const keyring = withKeyring ? new SecretKeyring(1, [{ version: 1, key: randomBytes(32) }]) : undefined;
   const metadata = new MetadataStore(databasePath, keyring);
+  cleanups.push(() => {
+    try { metadata.database.close(); } catch { /* ignore */ }
+    try { principals.close(); } catch { /* ignore */ }
+  });
   const artifacts = new ArtifactStore(principals.database, { root: join(root, 'artifacts'), maxArtifactBytes: 1024, maxPrincipalBytes: 4096, defaultRetentionMs: 60_000, maxRetentionMs: 120_000 });
-  const workspaces = { readArtifactSource: async (principal: any) => ({ ownerId: principals.resolvePrincipal(principal), content: Buffer.from('snapshot') }) } as WorkspaceService;
+  const workspaces = { readArtifactSource: async (p: PrincipalSelector) => ({ ownerId: principals.resolvePrincipal(p), content: Buffer.from('snapshot') }) } as unknown as WorkspaceService;
   const controls = new DashboardControlService({ artifactRetentionSeconds: 60 } as RunnerConfig, principals, metadata, artifacts, workspaces);
   return { controls, principals, metadata, artifacts, keyring, workspaces };
 }
@@ -159,5 +171,41 @@ describe('dashboard control service', () => {
     expect(audits).toEqual(expect.arrayContaining([
       expect.objectContaining({ action: 'github.disconnected', subjectId: '101' })
     ]));
+  });
+
+  it('lists, approves, and rejects privilege grants with operator authorization and audit logging', async () => {
+    const { controls, principals, metadata } = setup();
+    const ownerId = principals.resolvePrincipal(principal);
+    const workspaceId = `ws_${'b'.repeat(24)}`;
+    const grant = principals.createPrivilegeGrant({
+      ownerId,
+      workspaceId,
+      command: 'apt-get update',
+      ttlMs: 60_000
+    });
+
+    const listResult = await controls.execute(request('privilege_grant_list', { workspaceId }));
+    expect(listResult.ok).toBe(true);
+    const listData = listResult.data as { grants: { id: string }[] };
+    expect(listData.grants).toHaveLength(1);
+    expect(listData.grants[0].id).toBe(grant.id);
+    const approveResult = await controls.execute(request('privilege_grant_approve', { grantId: grant.id }));
+    expect(approveResult.ok).toBe(true);
+    expect(principals.getPrivilegeGrant(grant.id)?.status).toBe('APPROVED');
+
+    const auditEvents = metadata.listAudit(ownerId);
+    expect(auditEvents.some((e) => e.action === 'privilege_grant.approved')).toBe(true);
+
+    // Creating a second grant to test rejection
+    const grant2 = principals.createPrivilegeGrant({
+      ownerId,
+      workspaceId,
+      command: 'apt-get install -y cowsay',
+      ttlMs: 60_000
+    });
+    const rejectResult = await controls.execute(request('privilege_grant_reject', { grantId: grant2.id }));
+    expect(rejectResult.ok).toBe(true);
+    expect(principals.getPrivilegeGrant(grant2.id)?.status).toBe('REJECTED');
+    expect(metadata.listAudit(ownerId).some((e) => e.action === 'privilege_grant.rejected')).toBe(true);
   });
 });

--- a/apps/runner/test/github-app-broker.test.ts
+++ b/apps/runner/test/github-app-broker.test.ts
@@ -9,7 +9,7 @@ const authMocks = vi.hoisted(() => ({
 authMocks.createAppAuth.mockImplementation(() => authMocks.installationAuth);
 vi.mock('@octokit/auth-app', () => ({ createAppAuth: authMocks.createAppAuth }));
 
-import { mintPrincipalRepositoryToken, mintRepositoryToken } from '../src/github-app-broker.js';
+import { mintPrincipalRepositoryScopedToken, mintPrincipalRepositoryToken, mintRepositoryToken } from '../src/github-app-broker.js';
 import { InMemoryGitHubInstallationStore } from '../src/github-installation-store.js';
 
 const config = {
@@ -112,5 +112,64 @@ describe('GitHub App broker', () => {
     })).resolves.toBe('repository-scoped-token');
     expect(authMocks.createAppAuth).toHaveBeenLastCalledWith(expect.objectContaining({ installationId: '102' }));
     expect(authMocks.installationAuth).toHaveBeenLastCalledWith({ type: 'installation', repositoryNames: ['repo-two'] });
+  });
+
+  it('mints action-scoped tokens for pull_requests and issues with granular permissions', async () => {
+    const installations = new InMemoryGitHubInstallationStore();
+    installations.replaceVerified('principal-a', {
+      appId: 123, installationId: 555, accountId: 888, accountLogin: 'octocat', status: 'active',
+      repositories: [{ owner: 'octocat', repository: 'hello-world', contents: 'read' }]
+    }, 1_000);
+
+    const accessConfig = { ...config, authMode: 'cloudflare-access' as const };
+    const ownerBearerConfig = { ...config, authMode: 'owner-bearer' as const };
+
+    // 1. Pull requests read (cloudflare-access)
+    await expect(mintPrincipalRepositoryScopedToken({
+      config: accessConfig, principalId: 'principal-a',
+      repositoryUrl: new URL('https://github.com/octocat/hello-world.git'),
+      installations,
+      permissionScope: 'pull_requests',
+      requiredPermission: 'read'
+    })).resolves.toBe('repository-scoped-token');
+    expect(authMocks.createAppAuth).toHaveBeenLastCalledWith(expect.objectContaining({ installationId: '555' }));
+    expect(authMocks.installationAuth).toHaveBeenLastCalledWith({
+      type: 'installation',
+      repositoryNames: ['hello-world'],
+      permissions: { pull_requests: 'read' }
+    });
+
+    // 2. Issues write (cloudflare-access)
+    await expect(mintPrincipalRepositoryScopedToken({
+      config: accessConfig, principalId: 'principal-a',
+      repositoryUrl: new URL('https://github.com/octocat/hello-world.git'),
+      installations,
+      permissionScope: 'issues',
+      requiredPermission: 'write'
+    })).resolves.toBe('repository-scoped-token');
+    expect(authMocks.installationAuth).toHaveBeenLastCalledWith({
+      type: 'installation',
+      repositoryNames: ['hello-world'],
+      permissions: { issues: 'write' }
+    });
+
+    // 3. Cross-principal / ungranted write denied in cloudflare-access
+    await expect(mintPrincipalRepositoryScopedToken({
+      config: accessConfig, principalId: 'principal-b',
+      repositoryUrl: new URL('https://github.com/octocat/hello-world.git'),
+      installations,
+      permissionScope: 'issues',
+      requiredPermission: 'write'
+    })).rejects.toThrow('not authorized');
+
+    // 4. Static installation in owner-bearer mode (even if installations store is passed)
+    await expect(mintPrincipalRepositoryScopedToken({
+      config: ownerBearerConfig, principalId: 'owner',
+      repositoryUrl: new URL('https://github.com/octocat/hello-world.git'),
+      installations,
+      permissionScope: 'issues',
+      requiredPermission: 'write'
+    })).resolves.toBe('repository-scoped-token');
+    expect(authMocks.createAppAuth).toHaveBeenLastCalledWith(expect.objectContaining({ installationId: 456 }));
   });
 });

--- a/apps/runner/test/state-store.test.ts
+++ b/apps/runner/test/state-store.test.ts
@@ -262,4 +262,49 @@ describe('StateStore', () => {
     expect((store.database.prepare('SELECT COUNT(*) AS count FROM principal_relinks').get() as { count: number }).count).toBe(0);
     store.close();
   });
+
+  it('manages privilege grant lifecycle, single-use consumption, and expiration', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-'));
+    temporaryDirectories.push(directory);
+    const store = new StateStore(join(directory, 'state.db'));
+    const ownerId = 'usr_owner123';
+    const workspaceId = 'ws_test123';
+    const command = 'sudo apt-get update';
+
+    // 1. Create grant with specific cwd
+    const grant = store.createPrivilegeGrant({ ownerId, workspaceId, command, cwd: 'src', ttlMs: 1000 });
+    expect(grant.id.startsWith('pvg_')).toBe(true);
+    expect(grant.status).toBe('PENDING');
+    expect(grant.command).toBe(command);
+    expect(grant.cwd).toBe('src');
+    expect(grant.consumedAt).toBeNull();
+
+    // 2. Query grant
+    expect(store.getPrivilegeGrant(grant.id)?.status).toBe('PENDING');
+    expect(store.listPrivilegeGrants(ownerId, workspaceId)).toHaveLength(1);
+
+    // 3. Approve grant
+    expect(store.approvePrivilegeGrant('wrong_owner', grant.id)).toBe(false);
+    expect(store.approvePrivilegeGrant(ownerId, grant.id)).toBe(true);
+    expect(store.getPrivilegeGrant(grant.id)?.status).toBe('APPROVED');
+
+    // 4. Consume grant with wrong cwd (cwd tampering) fails
+    expect(store.consumePrivilegeGrant({ ownerId, workspaceId, grantId: grant.id, commandSha256: grant.commandSha256, cwd: 'wrong_dir' })).toBe(false);
+
+    // 5. Consume grant with wrong command hash fails
+    expect(store.consumePrivilegeGrant({ ownerId, workspaceId, grantId: grant.id, commandSha256: 'wrong_hash', cwd: 'src' })).toBe(false);
+
+    // 6. Consume grant with correct cwd & command hash succeeds
+    expect(store.consumePrivilegeGrant({ ownerId, workspaceId, grantId: grant.id, commandSha256: grant.commandSha256, cwd: 'src' })).toBe(true);
+    expect(store.getPrivilegeGrant(grant.id)?.status).toBe('CONSUMED');
+    expect(store.getPrivilegeGrant(grant.id)?.consumedAt).toBeGreaterThan(0);
+
+    // 7. Reusing consumed grant fails
+    expect(store.consumePrivilegeGrant({ ownerId, workspaceId, grantId: grant.id, commandSha256: grant.commandSha256, cwd: 'src' })).toBe(false);
+    // 7. Rejection
+    const grant2 = store.createPrivilegeGrant({ ownerId, workspaceId, command: 'rm -rf /', ttlMs: 60_000 });
+    expect(store.rejectPrivilegeGrant(ownerId, grant2.id)).toBe(true);
+    expect(store.getPrivilegeGrant(grant2.id)?.status).toBe('REJECTED');
+    store.close();
+  });
 });

--- a/docker/executor.Dockerfile
+++ b/docker/executor.Dockerfile
@@ -1,9 +1,40 @@
+FROM oven/bun:1.2-slim AS bun-source
+FROM ghcr.io/astral-sh/uv:latest AS uv-source
+
 FROM node:24.11.0-bookworm-slim
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends bash ca-certificates git jq patch procps ripgrep tini universal-ctags \
-  && rm -rf /var/lib/apt/lists/* \
-  && useradd --uid 10001 --create-home --shell /bin/bash harness
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    patch \
+    procps \
+    ripgrep \
+    sudo \
+    tini \
+    universal-ctags \
+  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends gh \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=bun-source /usr/local/bin/bun /usr/local/bin/bun
+RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
+COPY --from=uv-source /uv /uvx /usr/local/bin/
+
+RUN npm install -g pnpm@latest wrangler@latest
+
+RUN useradd --uid 10001 --create-home --shell /bin/bash harness \
+  && echo "harness ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/harness \
+  && chmod 0440 /etc/sudoers.d/harness
+
+RUN mkdir -p /workspace /opt/user-tools /var/cache/harness /tmp/cloud-harness-home \
+  && chown -R 10001:10001 /workspace /opt/user-tools /var/cache/harness /tmp/cloud-harness-home
 
 COPY --chown=root:root worker/harness-worker.mjs /opt/harness/harness-worker.mjs
 COPY --chown=root:root worker/clone-helper.sh /opt/harness/clone-helper.sh
@@ -11,9 +42,8 @@ COPY --chown=root:root worker/git-transfer-helper.sh /opt/harness/git-transfer-h
 COPY --chown=root:root worker/task-runner.sh /opt/harness/task-runner.sh
 COPY --chown=root:root worker/shell-runner.sh /opt/harness/shell-runner.sh
 COPY --chown=root:root worker/worker-runner.sh /opt/harness/worker-runner.sh
-RUN chmod 0555 /opt/harness/harness-worker.mjs /opt/harness/clone-helper.sh /opt/harness/git-transfer-helper.sh /opt/harness/task-runner.sh /opt/harness/shell-runner.sh /opt/harness/worker-runner.sh \
-  && mkdir -p /workspace /tmp/cloud-harness-home \
-  && chown -R 10001:10001 /workspace /tmp/cloud-harness-home
+COPY --chown=root:root worker/gh-helper.sh /opt/harness/gh-helper.sh
+RUN chmod 0555 /opt/harness/*.sh /opt/harness/*.mjs
 
 USER 10001:10001
 WORKDIR /workspace

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -34,7 +34,7 @@
 - [Profile & Themes](https://docs.harness.agentkit.best/dashboard/profile.md): Account details and appearance settings.
 
 ## Technical References
-- [Tools Reference](https://docs.harness.agentkit.best/reference/tools.md): Complete catalog of 52 MCP tools.
+- [Tools Reference](https://docs.harness.agentkit.best/reference/tools.md): Complete catalog of 53 MCP tools.
 - [Environment Variables](https://docs.harness.agentkit.best/reference/environment-variables.md): Configuration reference.
 - [Git Transfer Semantics](https://docs.harness.agentkit.best/reference/git-transfer.md): Origin-only push/fetch/pull helper.
 - [Sessions & Tasks](https://docs.harness.agentkit.best/reference/sessions-and-tasks.md): PTY shells, sessions, and task DAGs.

--- a/docs-site/reference/tools.md
+++ b/docs-site/reference/tools.md
@@ -1,6 +1,6 @@
 ---
 title: Tools Reference
-description: Complete machine-generated reference of all 52 MCP tools provided by Cloud Harness MCP.
+description: Complete machine-generated reference of all 53 MCP tools provided by Cloud Harness MCP.
 ---
 
 # Tools Reference
@@ -11,7 +11,7 @@ description: Complete machine-generated reference of all 52 MCP tools provided b
   <strong>AI Crawler / Raw View:</strong> Fetch this page as raw Markdown at <code>/reference/tools.md</code>.
 </div>
 
-Cloud Harness MCP exposes **52 tools** across six operational domains. Every tool executes strictly inside a sandboxed, TTL-limited Docker container with non-root privileges and default network isolation.
+Cloud Harness MCP exposes **53 tools** across six operational domains. Every tool executes strictly inside a sandboxed, TTL-limited Docker container with non-root privileges and default network isolation.
 
 ## Security & Capability Badges
 
@@ -256,6 +256,8 @@ Run one bounded shell command in the workspace and return captured output.
 | `cwd` | `string` | **Yes** | length: 1–1024, default: `"."` |
 | `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
 | `maxOutputBytes` | `integer` | **Yes** | range: 1024–1048576, default: `262144` |
+| `privileged` | `boolean` | **Yes** | default: `false` |
+| `approvalGrantToken` | `string` | No | length: 1–128 |
 
 ### `shell_open`
 
@@ -645,6 +647,27 @@ Remove one named managed worktree, optionally discarding dirty state.
 | `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,80}$` |
 | `force` | `boolean` | **Yes** | default: `false` |
+
+### `github_action`
+
+**Perform brokered GitHub operations**
+
+Execute authenticated GitHub pull request and issue operations via brokered helper without exposing tokens to workspace.
+
+**Attributes:** <span class="badge-destructive">destructive</span> · <span class="badge-openworld">openWorld</span>
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `action` | `"pr_list"` | **Yes** | — |
+| `limit` | `integer` | No | range: 1–100, default: `20` |
+| `state` | `"open"` \| `"closed"` \| `"all"` | No | default: `"open"` |
+| `prNumber` | `integer` | No | range: 0–9007199254740991 |
+| `title` | `string` | No | length: 1–256 |
+| `body` | `string` | No | max length: 65536, default: `""` |
+| `head` | `string` | No | length: 1–256 |
+| `base` | `string` | No | length: 1–256, default: `"main"` |
+| `issueNumber` | `integer` | No | range: 0–9007199254740991 |
 
 ## Repository Extensions
 

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -63,9 +63,19 @@ makes a lost response recoverable without duplicating work.
   `expectedSha256` option requires the target to exist and match.
 - `exec_run` accepts raw Bash and is intentionally remote code execution
   inside the executor. It is request-owned and bounded by timeout/output
-  settings. If its API request disconnects or reaches the API deadline, the
+  settings. Standard execution runs as user `10001:10001` with `--read-only` rootfs
+  and dropped capabilities. When `privileged: true` is requested in `cloudflare-access` mode,
+  it requires a valid `approvalGrantToken`. An unapproved request returns `PRIVILEGE_APPROVAL_REQUIRED`
+  with a `grantId` for the operator to approve in the dashboard. Approved grants
+  execute once in an isolated ephemeral container with `try/finally` cleanup.
+  In `owner-bearer` mode, `privileged: true` is rejected as `FORBIDDEN` to prevent unbrokered elevation.
+  If its API request disconnects or reaches the API deadline, the
   runner terminates and verifies the operation's process groups; the workspace
   remains active for later calls.
+- `github_action` executes authenticated GitHub CLI actions (`pr_list`, `pr_view`,
+  `pr_create`, `issue_list`, `issue_view`, `issue_create`) through an ephemeral
+  helper container using short-lived tokens minted from the configured GitHub App.
+  Tokens are supplied exclusively via stdin and are never written to workspace files.
 - `symbols_search` uses Universal Ctags to find definitions. It is not a
   language server. `symbols_references` is a bounded lexical word search, so it
   can include definitions and same-spelling identifiers rather than semantic

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -144,6 +144,28 @@ executor and import without network or credentials. Push first stages a bare
 snapshot without credentials, then uses a separate networked helper. Transfer
 directories and helper containers are removed after the operation.
 
+### Brokered GitHub actions
+
+Authenticated GitHub operations (`pr_list`, `pr_view`, `pr_create`, `issue_list`, `issue_view`, `issue_create`) are executed through the `github_action` tool using an ephemeral helper container (`worker/gh-helper.sh`). Action-scoped tokens (`pull_requests: read|write`, `issues: read|write`) are minted by the runner from the trusted GitHub App installation and passed exclusively via `stdin`. The helper container runs read-only with dropped capabilities, and is forcibly removed on all exit paths in a `try/finally` block. Tokens never enter the workspace filesystem or environment.
+
+### Three-zone storage and toolchain isolation
+
+Executors operate across three partitioned storage zones:
+1. **Zone A (Secrets & Session Config)**: `/tmp/cloud-harness-home` backed by RAM tmpfs (`128MB`), containing ephemeral configurations, temporary tokens, and tool cache metadata. Destroyed on container exit and cannot be committed into Git.
+2. **Zone B (User-Space Toolchains & Caches)**: `/opt/user-tools` and `/var/cache/harness` mounted from runner-managed job paths with UID `10001:10001` ownership and mode `0755`. Accommodates global user-space toolchain installations (`npm -g`, `bun`, `uv`, `pnpm`, `wrangler`) without requiring root.
+3. **Zone C (Git Repository)**: `/workspace` containing the clean repository working tree.
+
+Workspace disk usage metering calculates the combined footprint of all three persistent zones against `maxWorkspaceBytes`.
+
+### Privileged execution and operator approval grants
+
+Standard executors strictly preserve `--read-only`, `--cap-drop ALL`, `--security-opt no-new-privileges`, and user `10001:10001`. Sudo/root execution is treated as an explicit owner-approved threat model weakening (similar to `networkMode: bridge`).
+
+When `exec_run` is invoked with `privileged: true`:
+1. Privileged execution is supported in `cloudflare-access` mode (where the operator dashboard is authenticated via Cloudflare Access) and is disabled in `owner-bearer` mode to prevent self-approval.
+2. In `cloudflare-access` mode, an unapproved request is rejected with `PRIVILEGE_APPROVAL_REQUIRED` and returns a single-use `grantId` bound to the command and working directory with a 60-second TTL.
+3. The operator must explicitly approve the grant via the authenticated Dashboard BFF API (`POST /api/v1/privilege-grants/:grantId/approve`). MCP clients cannot self-approve.
+4. The caller provides the `approvalGrantToken`. The runner validates the grant and command/cwd hash, atomically consumes it (single-use), and executes the command in an isolated ephemeral container with `try/finally` cleanup. The standard executor container remains permanently hardened and unmodified.
 The public contract fixes remote transfers to `origin`, permits only branch
 push refspecs, rejects deletion refspecs, and permits force only through
 force-with-lease. Private clone/fetch/pull require GitHub App Contents read

--- a/packages/contracts/src/internal-runner-api.ts
+++ b/packages/contracts/src/internal-runner-api.ts
@@ -42,7 +42,8 @@ export const MetadataRunnerOperationSchema = z.enum([
   'environment_list', 'environment_create', 'environment_update', 'environment_delete',
   'secret_list', 'secret_create', 'secret_rotate', 'secret_delete', 'audit_list',
   'artifact_list', 'artifact_snapshot', 'artifact_delete',
-  'github_status', 'github_setup_begin', 'github_setup_complete', 'github_reconcile', 'github_disconnect'
+  'github_status', 'github_setup_begin', 'github_setup_complete', 'github_reconcile', 'github_disconnect',
+  'privilege_grant_list', 'privilege_grant_approve', 'privilege_grant_reject'
 ]);
 
 const metadataInputs = {
@@ -72,7 +73,10 @@ const metadataInputs = {
     state: z.string().min(32).max(128), installationId: z.string().min(1).max(100)
   }).strict(),
   github_reconcile: z.object({ installationId: z.string().min(1).max(100).optional() }).strict(),
-  github_disconnect: z.object({ installationId: z.string().min(1).max(100) }).strict()
+  github_disconnect: z.object({ installationId: z.string().min(1).max(100) }).strict(),
+  privilege_grant_list: z.object({ workspaceId: WorkspaceIdSchema.optional() }).strict(),
+  privilege_grant_approve: z.object({ grantId: z.string().min(1).max(128) }).strict(),
+  privilege_grant_reject: z.object({ grantId: z.string().min(1).max(128) }).strict()
 } as const;
 
 const metadataRequest = <Operation extends keyof typeof metadataInputs>(operation: Operation) => z.object({
@@ -88,7 +92,8 @@ export const MetadataRunnerRequestSchema = z.discriminatedUnion('operation', [
   metadataRequest('secret_list'), metadataRequest('secret_create'), metadataRequest('secret_rotate'), metadataRequest('secret_delete'),
   metadataRequest('audit_list'), metadataRequest('artifact_list'), metadataRequest('artifact_snapshot'), metadataRequest('artifact_delete'),
   metadataRequest('github_status'), metadataRequest('github_setup_begin'), metadataRequest('github_setup_complete'),
-  metadataRequest('github_reconcile'), metadataRequest('github_disconnect')
+  metadataRequest('github_reconcile'), metadataRequest('github_disconnect'),
+  metadataRequest('privilege_grant_list'), metadataRequest('privilege_grant_approve'), metadataRequest('privilege_grant_reject')
 ]);
 
 export type InternalRunnerOperation = z.infer<typeof InternalRunnerOperationSchema>;

--- a/packages/contracts/src/mcp-results.ts
+++ b/packages/contracts/src/mcp-results.ts
@@ -11,7 +11,8 @@ export const ErrorCodeSchema = z.enum([
   'TIMEOUT',
   'CANCELLED',
   'UNAVAILABLE',
-  'INTERNAL_ERROR'
+  'INTERNAL_ERROR',
+  'PRIVILEGE_APPROVAL_REQUIRED'
 ]);
 
 export const ToolResultSchema = z.object({
@@ -22,7 +23,16 @@ export const ToolResultSchema = z.object({
     .object({
       code: ErrorCodeSchema,
       message: z.string().max(2_000),
-      retryable: z.boolean()
+      retryable: z.boolean(),
+      grantRequest: z
+        .object({
+          grantId: z.string(),
+          workspaceId: z.string(),
+          commandSha256: z.string(),
+          cwd: z.string().optional(),
+          expiresAt: z.string()
+        })
+        .optional()
     })
     .optional(),
   truncated: z.boolean().default(false),

--- a/packages/contracts/src/runner-api.ts
+++ b/packages/contracts/src/runner-api.ts
@@ -13,7 +13,8 @@ export const RunnerOperationSchema = z.enum([
   'skills_list', 'skills_read', 'skills_run',
   'hooks_list', 'hooks_run',
   'memories_list', 'memories_read', 'memories_write',
-  'deployments_list', 'deployments_run'
+  'deployments_list', 'deployments_run',
+  'github_action'
 ]);
 
 export const ExternalPrincipalSchema = z.object({

--- a/packages/contracts/src/tool-schemas.ts
+++ b/packages/contracts/src/tool-schemas.ts
@@ -46,7 +46,15 @@ const schemas = {
   grep_search: z.object({ ...workspace, pattern: z.string().min(1).max(4_096), path: relativePath.default('.'), glob: z.string().max(512).optional(), maxResults: z.number().int().min(1).max(500).default(100) }),
   symbols_search: z.object({ ...workspace, query: z.string().min(1).max(256), path: relativePath.default('.'), language: z.string().regex(/^[A-Za-z0-9_+#.-]{1,40}$/).optional(), maxResults: z.number().int().min(1).max(500).default(100) }),
   symbols_references: z.object({ ...workspace, symbol: z.string().min(1).max(256).refine((value) => !value.includes('\0') && !value.includes('\n')), path: relativePath.default('.'), glob: z.string().max(512).optional(), maxResults: z.number().int().min(1).max(500).default(100) }),
-  exec_run: z.object({ ...workspace, command: z.string().min(1).max(32_768), cwd: relativePath.default('.'), timeoutMs: z.number().int().min(100).max(300_000).default(60_000), maxOutputBytes: z.number().int().min(1_024).max(1_048_576).default(262_144) }),
+  exec_run: z.object({
+    ...workspace,
+    command: z.string().min(1).max(32_768),
+    cwd: relativePath.default('.'),
+    timeoutMs: z.number().int().min(100).max(300_000).default(60_000),
+    maxOutputBytes: z.number().int().min(1_024).max(1_048_576).default(262_144),
+    privileged: z.boolean().default(false),
+    approvalGrantToken: z.string().min(1).max(128).optional()
+  }),
   shell_open: z.object({ ...workspace, cwd: relativePath.default('.'), idempotencyKey: IdempotencyKeySchema }),
   shell_io: z.object({ ...workspace, shellId: ShellIdSchema, input: z.string().max(65_536).optional(), cursor: z.string().max(256).optional(), waitMs: z.number().int().min(0).max(5_000).default(100) }),
   shell_close: z.object({ ...workspace, shellId: ShellIdSchema }),
@@ -101,7 +109,45 @@ const schemas = {
   memories_read: z.object({ ...workspace, name: z.string().regex(/^[A-Za-z0-9._-]{1,120}$/) }),
   memories_write: z.object({ ...workspace, name: z.string().regex(/^[A-Za-z0-9._-]{1,120}$/), content: z.string().max(262_144) }),
   deployments_list: z.object(workspace),
-  deployments_run: z.object({ ...workspace, name: z.string().regex(/^[A-Za-z0-9._-]{1,120}$/), timeoutMs: z.number().int().min(100).max(300_000).default(60_000) })
+  deployments_run: z.object({ ...workspace, name: z.string().regex(/^[A-Za-z0-9._-]{1,120}$/), timeoutMs: z.number().int().min(100).max(300_000).default(60_000) }),
+  github_action: z.discriminatedUnion('action', [
+    z.object({
+      ...workspace,
+      action: z.literal('pr_list'),
+      limit: z.number().int().min(1).max(100).default(20),
+      state: z.enum(['open', 'closed', 'all']).default('open')
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('pr_view'),
+      prNumber: z.number().int().positive()
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('pr_create'),
+      title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes'),
+      body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').default(''),
+      head: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'head cannot contain null bytes'),
+      base: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'base cannot contain null bytes').default('main')
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('issue_list'),
+      limit: z.number().int().min(1).max(100).default(20),
+      state: z.enum(['open', 'closed', 'all']).default('open')
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('issue_view'),
+      issueNumber: z.number().int().positive()
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('issue_create'),
+      title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes'),
+      body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').default('')
+    })
+  ])
 } satisfies Record<RunnerOperation, z.ZodType>;
 
 export type ToolSpec = {
@@ -125,7 +171,8 @@ const titles: Record<RunnerOperation, string> = {
   git_status: 'Git status', git_diff: 'Git diff', git_log: 'Git log', git_branch: 'Manage Git branches', git_checkout: 'Checkout Git ref', git_add: 'Stage Git changes', git_commit: 'Create Git commit', git_fetch: 'Fetch Git refs', git_pull: 'Pull Git changes', git_push: 'Push Git changes', git_merge: 'Merge Git ref', git_rebase: 'Manage Git rebase',
   worktrees_list: 'List worktrees', worktrees_create: 'Create worktree', worktrees_remove: 'Remove worktree',
   skills_list: 'List skills', skills_read: 'Read skill', skills_run: 'Run skill script', hooks_list: 'List hooks', hooks_run: 'Run hook', memories_list: 'List memories', memories_read: 'Read memory', memories_write: 'Write memory',
-  deployments_list: 'List deployment targets', deployments_run: 'Run deployment target'
+  deployments_list: 'List deployment targets', deployments_run: 'Run deployment target',
+  github_action: 'Perform brokered GitHub operations'
 };
 
 const descriptions: Record<RunnerOperation, string> = {
@@ -180,13 +227,14 @@ const descriptions: Record<RunnerOperation, string> = {
   memories_read: 'Read one bounded repository-local Cloud Harness memory note.',
   memories_write: 'Create or replace one repository-local Cloud Harness memory note.',
   deployments_list: 'List repository-defined deployment targets without running them.',
-  deployments_run: 'Execute one named repository-defined deployment target with external-effect risk.'
+  deployments_run: 'Execute one named repository-defined deployment target with external-effect risk.',
+  github_action: 'Execute authenticated GitHub pull request and issue operations via brokered helper without exposing tokens to workspace.'
 };
 
 const readOnly = new Set<RunnerOperation>(['workspace_list', 'workspace_status', 'files_list', 'files_read', 'grep_search', 'symbols_search', 'symbols_references', 'sessions_list', 'tasks_list', 'tasks_status', 'tasks_graph', 'git_status', 'git_diff', 'git_log', 'worktrees_list', 'skills_list', 'skills_read', 'hooks_list', 'memories_list', 'memories_read', 'deployments_list']);
-const destructive = new Set<RunnerOperation>(['workspace_close', 'files_write', 'files_apply_patch', 'files_delete', 'files_move', 'exec_run', 'shell_io', 'shell_close', 'sessions_io', 'sessions_close', 'tasks_run', 'tasks_cancel', 'git_branch', 'git_checkout', 'git_pull', 'git_push', 'git_merge', 'git_rebase', 'worktrees_remove', 'skills_run', 'hooks_run', 'memories_write', 'deployments_run']);
+const destructive = new Set<RunnerOperation>(['workspace_close', 'files_write', 'files_apply_patch', 'files_delete', 'files_move', 'exec_run', 'shell_io', 'shell_close', 'sessions_io', 'sessions_close', 'tasks_run', 'tasks_cancel', 'git_branch', 'git_checkout', 'git_pull', 'git_push', 'git_merge', 'git_rebase', 'worktrees_remove', 'skills_run', 'hooks_run', 'memories_write', 'deployments_run', 'github_action']);
 const idempotent = new Set<RunnerOperation>(['workspace_open', 'workspace_list', 'workspace_status', 'workspace_close', 'files_list', 'files_read', 'files_write', 'files_apply_patch', 'files_mkdir', 'grep_search', 'symbols_search', 'symbols_references', 'shell_open', 'shell_close', 'sessions_list', 'sessions_open', 'sessions_close', 'tasks_list', 'tasks_run', 'tasks_status', 'tasks_cancel', 'tasks_graph', 'git_status', 'git_diff', 'git_log', 'git_add', 'worktrees_list', 'skills_list', 'skills_read', 'hooks_list', 'memories_list', 'memories_read', 'memories_write', 'deployments_list']);
-const openWorld = new Set<RunnerOperation>(['workspace_open', 'exec_run', 'shell_io', 'sessions_io', 'tasks_run', 'git_fetch', 'git_pull', 'git_push', 'skills_run', 'hooks_run', 'deployments_run']);
+const openWorld = new Set<RunnerOperation>(['workspace_open', 'exec_run', 'shell_io', 'sessions_io', 'tasks_run', 'git_fetch', 'git_pull', 'git_push', 'skills_run', 'hooks_run', 'deployments_run', 'github_action']);
 
 export const TOOL_SPECS: ToolSpec[] = (Object.keys(schemas) as RunnerOperation[]).map((name) => ({
   name,

--- a/packages/contracts/test/cloudharness-skill-contract.test.ts
+++ b/packages/contracts/test/cloudharness-skill-contract.test.ts
@@ -68,7 +68,7 @@ describe('cloudharness skill contract', () => {
         const target = match[1].split('#', 1)[0];
         if (!target || /^[a-z][a-z0-9+.-]*:/i.test(target)) continue;
         const resolvedTarget = resolve(dirname(path), target);
-        expect(resolvedTarget.startsWith(`${skillRoot}/`), `${path} -> ${target}`).toBe(true);
+        expect(!relative(skillRoot, resolvedTarget).startsWith('..'), `${path} -> ${target}`).toBe(true);
         await expect(stat(resolvedTarget), `${path} -> ${target}`).resolves.toMatchObject({});
       }
     }

--- a/plans/260823-1430-workspace-bash-tools-and-execution/phase-01-architecture-and-security-blueprint.md
+++ b/plans/260823-1430-workspace-bash-tools-and-execution/phase-01-architecture-and-security-blueprint.md
@@ -1,0 +1,67 @@
+---
+phase: 1
+title: "Architecture & Security Blueprint"
+status: completed
+priority: P1
+effort: "4h"
+dependencies: []
+---
+
+# Phase 01: Architecture & Security Blueprint (Storage Partitioning, Hardened Standard Mode & Explicit Sudo Threat-Model Separation)
+
+## Overview
+Xây dựng bản thiết kế kiến trúc chuẩn mực giải quyết triệt để 3 bài toán:
+1. Phân tách bộ nhớ và lưu trữ để bảo vệ repository checkout khỏi rò rỉ secret và tránh tràn tmpfs.
+2. **Bảo tồn toàn vẹn Container Hardening cho Standard Mode**: Giữ nguyên `--read-only`, `--cap-drop ALL`, `--security-opt no-new-privileges`, user `10001:10001`.
+3. **Phân định rõ ràng Threat Model cho Sudo Mode**: Nhận diện đây là một sự nới lỏng bảo mật do Owner phê chuẩn (Owner-Approved Threat-Model Weakening), yêu cầu Server-Enforced Approval Grants và không đánh đồng với Standard Mode.
+4. Cơ chế Broker xác thực cho GitHub và Cloudflare deployment CLIs.
+
+---
+
+## Requirements
+
+### Functional
+- **F1.1 (Three-Zone Storage)**: Tách biệt rõ ràng giữa Secret Config (RAM tmpfs), Package Cache & Tool Binaries (Runner-managed mount), và Git Repository (`/workspace`).
+- **F1.2 (Standard Mode Hardening)**:
+  - Giữ nguyên 100% các cờ bảo vệ: `--read-only`, `--cap-drop ALL`, `--security-opt no-new-privileges`, `--user 10001:10001`.
+  - Mọi công cụ CLI (`npm install -g`, `bun`, `uv`, standalone binaries) đều chạy và cài đặt trong không gian user-space (`/opt/user-tools/bin`, `/workspace/.local/bin`) mà không cần sudo hay quyền root.
+- **F1.3 (Explicit Sudo Mode as Threat-Model Weakening)**:
+  - Khi người dùng chủ động yêu cầu chạy lệnh với quyền root/sudo (để sửa đổi system packages nội bộ container):
+    - Runner bắt buộc quy trình **Server-Enforced Single-Use Approval Grant**: Yêu cầu Operator phê duyệt qua token `grantId`, ràng buộc SHA256 command, TTL 60s, và tiêu thụ đúng 1 lần (consumed once).
+    - **Operator-Authenticated Approval Boundary**: Thao tác phê duyệt grant **chỉ có thể** được thực hiện bởi Operator đã xác thực qua Dashboard Control API (`POST /api/v1/privilege-grants/:grantId/approve`). MCP client tuyệt đối không có tool hay quyền tự phê duyệt (chống self-approval).
+
+### Non-Functional & Security
+- **NF1.1**: Tuân thủ nguyên tắc "Zero credentials in git checkout" (`docs/security-model.md`).
+- **NF1.2**: Server-side Enforced Boundary: Bất kỳ client nào tự động gửi lệnh mà không qua approval của Operator đều bị Runner chặn đứng 100% tại Control Plane. Quyền approve grant bị cô lập hoàn toàn trong Dashboard BFF control plane, không phơi bày qua MCP tools.
+
+---
+
+## Architecture & Comparison Matrix
+
+### 1. Ma Trận So Sánh Standard Mode vs Sudo Mode
+
+| Tiêu chí | **Standard Mode (Mặc định - 99.9% tác vụ)** | **Sudo Mode (Explicit Threat-Model Opt-In)** |
+| :--- | :--- | :--- |
+| **Phân loại Threat Model** | 🔒 **Hardened Sandbox (Standard Invariant)** | ⚠️ **Owner-Approved Weakening (Nới lỏng có kiểm soát)** |
+| **User ID** | `10001:10001` (`harness`) | `10001:10001` (với `sudo`) hoặc `0:0` (`root`) |
+| **Root Filesystem** | `--read-only` (Bất biến) | Ephemeral Writable Overlay |
+| **Security Opts** | `--security-opt no-new-privileges` | Tùy chọn điều chỉnh theo nhu cầu Sudo |
+| **Capabilities** | `--cap-drop ALL` | Bổ sung capabilities tối thiểu cho Sudo (vd: `CAP_SETUID`) |
+| **Yêu cầu phê duyệt** | Thực thi trực tiếp qua `exec_run` / `shell_io` | Bắt buộc **Server-Enforced Approval Grant Token** (TTL 60s) được Operator phê duyệt qua Dashboard BFF API |
+| **Cách cài đặt Tools** | Cài vào User-Space (`/opt/user-tools/bin`, `npm -g`, `uv`) | Cài qua System Package Manager (`apt-get install`) |
+
+---
+
+### 2. Phân Tách 3 Vùng Bộ Nhớ (Storage Matrix)
+| Vùng lưu trữ | Vị trí Container | Vị trí Host (Runner) | Cơ chế Mount & Dung lượng | Dữ liệu lưu trữ | Ranh giới an toàn & Quota Accounting |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Zone A: Secret & Config** | `/tmp/cloud-harness-home` | RAM | `--tmpfs /tmp:rw,exec,nosuid,nodev,size=128m` | `$XDG_CONFIG_HOME`, `hosts.yml`, tokens tạm, session | Tự hủy khi tắt container. Không thể bị commit vào git. |
+| **Zone B: Tools & Cache** | `/opt/user-tools`<br>`/var/cache/harness` | `${workspacePath}/tools`<br>`${workspacePath}/cache` | `--volume ...:rw` (Host directories) | Binaries (`npm i -g`), Cache `npm`, `uv`, `bun` | Do Runner quản lý chown UID 10001. Được tính gộp vào `maxWorkspaceBytes` qua workspace disk meter. |
+| **Zone C: Git Checkout** | `/workspace` | `${workspacePath}/repo` | `--volume ...:rw` | Mã nguồn của dự án (Git working tree) | Tuyệt đối sạch, không chứa file config/token. Được tính vào `maxWorkspaceBytes`. |
+---
+
+## Success Criteria
+- [ ] Bảo tồn 100% cờ `--security-opt no-new-privileges`, `--read-only`, và `--cap-drop ALL` cho Standard Mode.
+- [ ] Phân định rạch ròi Sudo Mode là Threat-Model Weakening với quy trình Server-Enforced Approval Grants và Ephemeral Privileged Containers.
+- [ ] Disk usage metering tính tổng dung lượng cả 3 thư mục `repo/`, `tools/`, và `cache/` so với `maxWorkspaceBytes`.
+- [ ] Xác định rõ ràng các tham số container Docker, biến môi trường `$PATH`, và các biến XDG.

--- a/plans/260823-1430-workspace-bash-tools-and-execution/phase-02-container-image-and-toolchain-provisioning.md
+++ b/plans/260823-1430-workspace-bash-tools-and-execution/phase-02-container-image-and-toolchain-provisioning.md
@@ -1,0 +1,117 @@
+---
+phase: 2
+title: "Container Image & Toolchain Provisioning"
+status: completed
+priority: P1
+effort: "6h"
+dependencies: ["1"]
+---
+
+# Phase 02: Container Image & Toolchain Provisioning (Dockerfile, Pre-baked Tools, Sudoers, Ownership Helper)
+
+## Overview
+Nâng cấp `docker/executor.Dockerfile` và cơ chế provisioning quyền sở hữu thư mục (UID 10001) trên host:
+1. Bake sẵn các core tools (`gh`, `pnpm`, `bun`, `uv`, `wrangler`, `sudo`) vào image hệ thống.
+2. Cấu hình `sudoers` cho phép user `harness` dùng `sudo` không cần password (hữu dụng khi container chạy ở chế độ cho phép writable rootfs/sudo).
+3. Đảm bảo quyền sở hữu `chown 10001:10001` cho các mount point trên host trước khi container mount vào, ngăn ngừa triệt để lỗi `EACCES`.
+
+---
+
+## Requirements
+
+### Functional
+- **F2.1**: Cài đặt GitHub CLI chính thức (`gh`), `bun`, `uv` (Python CLI tool), `pnpm`, `wrangler` trực tiếp vào `/usr/local/bin` trong `docker/executor.Dockerfile`.
+- **F2.2**: Cài đặt package `sudo` và thêm file cấu hình `/etc/sudoers.d/harness` với nội dung `harness ALL=(ALL) NOPASSWD: ALL`.
+- **F2.3**: Xây dựng helper hoặc hàm trong Runner đảm bảo thư mục `${workspacePath}/tools` và `${workspacePath}/cache` được cấp quyền UID 10001 trước khi khởi tạo executor container.
+
+### Non-Functional
+- **NF2.1**: Giữ kích thước image tối ưu (sử dụng multi-stage copy từ `oven/bun` và `ghcr.io/astral-sh/uv`).
+- **NF2.2**: Thời gian build image dưới 3 phút; thời gian khởi động container từ image dưới 1 giây.
+
+---
+
+## Related Code Files
+- Modify: `docker/executor.Dockerfile`
+- Create/Modify: `worker/provision-mounts-helper.sh` (hoặc tích hợp vào Runner lifecycle)
+- Modify: `package.json` (nếu cần scripts build profile images)
+
+---
+
+## Implementation Steps
+
+### Step 1: Nâng Cấp `docker/executor.Dockerfile`
+
+```dockerfile
+FROM node:24.11.0-bookworm-slim
+
+# 1. Cài đặt các system packages, sudo và GitHub CLI chính thức
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    patch \
+    procps \
+    ripgrep \
+    sudo \
+    tini \
+    universal-ctags \
+  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# 2. Cài đặt Bun & uv (Python fast runtime/package manager)
+COPY --from=oven/bun:1.2-slim /usr/local/bin/bun /usr/local/bin/bun
+RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+# 3. Cài đặt Global NPM Tooling (pnpm, wrangler)
+RUN npm install -g pnpm@latest wrangler@latest
+
+# 4. Thiết lập User 10001 và cấu hình Sudoers
+RUN useradd --uid 10001 --create-home --shell /bin/bash harness \
+  && echo "harness ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/harness \
+  && chmod 0440 /etc/sudoers.d/harness
+
+# 5. Tạo các thư mục mặc định và phân quyền
+RUN mkdir -p /workspace /opt/user-tools /var/cache/harness /tmp/cloud-harness-home \
+  && chown -R 10001:10001 /workspace /opt/user-tools /var/cache/harness /tmp/cloud-harness-home
+
+COPY --chown=root:root worker/harness-worker.mjs /opt/harness/harness-worker.mjs
+COPY --chown=root:root worker/clone-helper.sh /opt/harness/clone-helper.sh
+COPY --chown=root:root worker/git-transfer-helper.sh /opt/harness/git-transfer-helper.sh
+COPY --chown=root:root worker/task-runner.sh /opt/harness/task-runner.sh
+COPY --chown=root:root worker/shell-runner.sh /opt/harness/shell-runner.sh
+COPY --chown=root:root worker/worker-runner.sh /opt/harness/worker-runner.sh
+RUN chmod 0555 /opt/harness/*.sh /opt/harness/*.mjs
+
+USER 10001:10001
+WORKDIR /workspace
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["sleep", "infinity"]
+```
+
+---
+
+### Step 2: Xây Dựng Cơ Chế Provisioning Quyền Sở Hữu Mount Points
+
+Khi Runner tạo thư mục `tools/` và `cache/` trên host OS trước khi mount vào container:
+- Nếu Runner chạy dưới quyền user khác hoặc root, `mkdir` sẽ tạo thư mục thuộc quyền của user đó.
+- Khi mount `--volume ${toolsPath}:/opt/user-tools:rw`, user `10001` trong container sẽ bị `EACCES: permission denied` khi chạy `npm i -g`.
+- **Giải pháp**:
+  Trong `apps/runner/src/workspace-service.ts`, sau khi `mkdir(toolsPath)` và `mkdir(cachePath)`, thực hiện lệnh chown thông qua helper container hoặc chown native:
+  ```typescript
+  // Thực hiện provisioning quyền sở hữu an toàn trước khi khởi chạy executor
+  await this.provisionWorkspaceDirectories(record.workspacePath);
+  ```
+
+---
+
+## Success Criteria
+- [ ] Dockerfile build thành công với `gh`, `bun`, `uv`, `pnpm`, `wrangler`, `sudo`.
+- [ ] Kiểm tra `gh --version`, `bun --version`, `uv --version`, `pnpm --version`, `wrangler --version` trong container mới đều trả về exit code 0.
+- [ ] User `harness` có thể ghi dữ liệu vào `/opt/user-tools` và `/var/cache/harness` mà không gặp lỗi `EACCES`.

--- a/plans/260823-1430-workspace-bash-tools-and-execution/phase-03-runner-engine-and-execution-architecture.md
+++ b/plans/260823-1430-workspace-bash-tools-and-execution/phase-03-runner-engine-and-execution-architecture.md
@@ -1,0 +1,272 @@
+---
+phase: 3
+title: "Runner Engine & Execution Architecture"
+status: completed
+priority: P1
+effort: "8h"
+dependencies: ["1", "2"]
+---
+
+# Phase 03: Runner Engine & Execution Architecture (Preserved Hardening, Mounts, Server-Enforced Approval Grants)
+
+## Overview
+Cập nhật tầng thực thi của Runner (`apps/runner/src/workspace-service.ts`, `state-store.ts`, và `workspace-environment.ts`) để:
+1. Thiết lập cấu hình mount 3-vùng lưu trữ và biến môi trường tiêu chuẩn cho container executor.
+2. **Bảo tồn nguyên vẹn 100% các cờ Hardening mặc định** (`--read-only`, `--cap-drop ALL`, `--security-opt no-new-privileges`, UID 10001) cho mọi Standard Workspace Executor.
+3. Xây dựng **Hệ thống Server-Enforced Approval Grants**: Quản lý vòng đời cấp phép lệnh đặc quyền (Short-lived TTL 60s, Single-use, Command Hash verification) khi chạy chế độ Sudo Mode tách biệt.
+
+---
+
+## Requirements
+
+### Functional
+- **F3.1 (Mounts & Environment)**:
+  - Mount `${workspacePath}/repo` $\rightarrow$ `/workspace:rw`.
+  - Mount `${workspacePath}/tools` $\rightarrow$ `/opt/user-tools:rw`.
+  - Mount `${workspacePath}/cache` $\rightarrow$ `/var/cache/harness:rw`.
+  - Thiết lập `$PATH`, `$NPM_CONFIG_PREFIX`, `$NPM_CONFIG_CACHE`, `$XDG_CONFIG_HOME`, `$XDG_CACHE_HOME`.
+- **F3.2 (Preserved Standard Executor Hardening)**:
+  - Container mặc định luôn chạy với:
+    - `--user 10001:10001`
+    - `--workdir /workspace`
+    - `--read-only`
+    - `--cap-drop ALL`
+    - `--security-opt no-new-privileges`
+    - `--pids-limit 256`
+    - `--tmpfs /tmp:rw,exec,nosuid,nodev,size=128m`
+    - `--tmpfs /run:rw,nosuid,nodev,size=8m`
+- **F3.3 (Server-Enforced Approval Grant Lifecycle cho Sudo Mode)**:
+  - Trong `state-store.ts`: Bổ sung bảng quản lý `privilege_grants` với các trường `id`, `owner_id`, `workspace_id`, `command_sha256`, `status`, `expires_at`, `consumed_at`.
+  - Phương thức `createPrivilegeGrant(ownerId, workspaceId, command)` $\rightarrow$ tạo grant ở trạng thái `PENDING`.
+  - Phương thức `approvePrivilegeGrant(ownerId, grantId)` $\rightarrow$ chuyển trạng thái thành `APPROVED`.
+  - Phương thức `consumePrivilegeGrant(ownerId, workspaceId, command, grantId)` $\rightarrow$ kiểm tra tính hợp lệ và atomically chuyển sang `CONSUMED`.
+- **F3.4 (Ephemeral Privileged Execution Branch)**:
+  - Lệnh có `privileged: true` sau khi grant được consume sẽ **KHÔNG BAO GIỜ** thay đổi cấu hình hay flags của standard executor container (`record.containerName` bất biến).
+  - Thay vào đó, Runner spawn một container ephemeral riêng biệt `cloud-harness-priv-${randomBytes(8).toString('hex')}` với:
+    - `--user 0:0`
+    - Writable ephemeral rootfs overlay
+    - Mount đúng 3 zones: `${workspacePath}/repo:/workspace:rw`, `${workspacePath}/tools:/opt/user-tools:rw`, `${workspacePath}/cache:/var/cache/harness:rw`
+    - Labels: `cloud-harness.managed=true`, `cloud-harness.instance=${this.instanceId}`, `cloud-harness.workspace=${record.id}`, `cloud-harness.ephemeral=true`
+    - Cleanup bọc trong `try { ... } finally { await removeContainer(privContainerName); }`
+- **F3.5 (Three-Zone Workspace Resource Metering)**:
+  - Cập nhật hàm tính dung lượng workspace (`measureWorkspaceBytes` / `du`) để đo đạc tổng dung lượng cả 3 thư mục `repo/`, `tools/`, và `cache/`.
+- **F3.6 (Operator-Authenticated Approval Endpoints & Dashboard BFF)**:
+  - `packages/contracts/src/internal-runner-api.ts`: Bổ sung `privilege_grant_list`, `privilege_grant_approve`, `privilege_grant_reject` vào `MetadataRunnerOperationSchema`.
+  - `apps/api/src/dashboard-control-router.ts`: Đăng ký các endpoints xác thực Operator:
+    - `GET /api/v1/privilege-grants` $\rightarrow$ `privilege_grant_list`
+    - `POST /api/v1/privilege-grants/:grantId/approve` $\rightarrow$ `privilege_grant_approve`
+    - `POST /api/v1/privilege-grants/:grantId/reject` $\rightarrow$ `privilege_grant_reject`
+  - `apps/runner/src/dashboard-control-service.ts`: Xử lý phê duyệt/từ chối từ Operator và ghi log audit `privilege_grant.approved` / `privilege_grant.rejected`.
+  - **Strict Security Isolation**: MCP Client tuyệt đối không thể tự approve (không có MCP tool `privilege_grant_approve`). Chỉ có Operator Dashboard mới có quyền phê duyệt.
+
+---
+
+## Related Code Files
+- Modify: `apps/runner/src/state-store.ts`
+- Modify: `apps/runner/src/workspace-service.ts`
+- Modify: `apps/runner/src/workspace-environment.ts`
+- Modify: `apps/runner/src/dashboard-control-service.ts`
+- Modify: `apps/api/src/dashboard-control-router.ts`
+- Modify: `packages/contracts/src/internal-runner-api.ts`
+- Modify: `packages/contracts/src/tool-schemas.ts`
+- Modify: `packages/contracts/src/runner-api.ts`
+---
+
+## Implementation Details
+
+### 1. Hàm `createExecutor` Giữ Nguyên 100% Hardening Mặc Định
+
+```typescript
+// apps/runner/src/workspace-service.ts
+private async createExecutor(
+  record: WorkspaceRecord,
+  repositoryPath: string,
+  environment: Record<string, string> = {}
+): Promise<string> {
+  const name = `cloud-harness-ws-${record.id.slice(3, 19).toLowerCase()}`;
+  
+  // 1. Tạo thư mục host và gán quyền UID 10001
+  const toolsPath = join(record.workspacePath, 'tools');
+  const cachePath = join(record.workspacePath, 'cache');
+  await mkdir(toolsPath, { recursive: true });
+  await mkdir(cachePath, { recursive: true });
+  await this.chownExecutorDirectory(toolsPath);
+  await this.chownExecutorDirectory(cachePath);
+
+  // 2. Thiết lập arguments Docker - BẢO TỒN NGUYÊN VẸN HARDENING
+  const args = [
+    'create', '--name', name,
+    '--label', 'cloud-harness.managed=true',
+    '--label', `cloud-harness.instance=${this.instanceId}`,
+    '--label', `cloud-harness.workspace=${record.id}`,
+    '--user', '10001:10001',
+    '--workdir', '/workspace',
+    '--read-only',
+    '--cap-drop', 'ALL',
+    '--security-opt', 'no-new-privileges', // BẮT BUỘC GIỮ NGUYÊN TRONG STANDARD MODE
+    '--pids-limit', '256',
+    '--memory', '1g', '--memory-swap', '1g', '--cpus', '1',
+    '--ulimit', 'nofile=1024:1024',
+    '--network', record.networkMode,
+    
+    // Tmpfs cho Secret & State (128MB RAM)
+    '--tmpfs', '/tmp:rw,exec,nosuid,nodev,size=128m',
+    '--tmpfs', '/run:rw,nosuid,nodev,size=8m',
+    
+    // 3-Zone Mounts
+    '--volume', `${repositoryPath}:/workspace:rw`,
+    '--volume', `${toolsPath}:/opt/user-tools:rw`,
+    '--volume', `${cachePath}:/var/cache/harness:rw`,
+    
+    // Environment Variables
+    '--env', 'HOME=/tmp/cloud-harness-home',
+    '--env', 'GIT_CONFIG_NOSYSTEM=1',
+    '--env', 'XDG_CONFIG_HOME=/tmp/cloud-harness-home/.config',
+    '--env', 'XDG_CACHE_HOME=/var/cache/harness',
+    '--env', 'XDG_DATA_HOME=/opt/user-tools/data',
+    '--env', 'NPM_CONFIG_PREFIX=/opt/user-tools',
+    '--env', 'NPM_CONFIG_CACHE=/var/cache/harness/npm',
+    '--env', 'UV_CACHE_DIR=/var/cache/harness/uv',
+    '--env', 'PATH=/workspace/node_modules/.bin:/opt/user-tools/bin:/tmp/cloud-harness-home/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    
+    ...Object.entries(environment).flatMap(([name, value]) => ['--env', `${name}=${value}`]),
+    this.config.executorImage
+  ];
+
+  const created = await runDocker(args, { timeoutMs: 30_000 });
+  if (created.exitCode !== 0) throw new HarnessError('UNAVAILABLE', `executor creation failed: ${created.stderr}`.slice(0, 2_000), 502, true);
+  const started = await runDocker(['start', name], { timeoutMs: 30_000 });
+  if (started.exitCode !== 0) {
+    await removeContainer(name);
+    throw new HarnessError('UNAVAILABLE', `executor start failed: ${started.stderr}`.slice(0, 2_000), 502, true);
+  }
+  return name;
+}
+```
+
+---
+
+### 2. Logic Xử Lý Approval Grant cho Lệnh Đặc Quyền
+```typescript
+// apps/runner/src/workspace-service.ts
+
+// 1. Dispatch trong execute():
+if (operation === 'exec_run') {
+  const result = await this.handleExecRun(record, validated);
+  await this.enforceActiveLimits(record);
+  return result;
+}
+
+// 2. Xử lý logic exec_run (Standard vs Privileged Approval):
+private async handleExecRun(record: WorkspaceRecord, validated: Record<string, unknown>): Promise<RunnerResponse> {
+  const command = validated.command as string;
+  const cwd = (validated.cwd as string) || '.';
+  const timeoutMs = (validated.timeoutMs as number) || 60_000;
+  const maxOutputBytes = (validated.maxOutputBytes as number) || this.config.maxOutputBytes;
+  const privileged = Boolean(validated.privileged);
+  const approvalGrantToken = validated.approvalGrantToken as string | undefined;
+
+  if (privileged) {
+    if (!approvalGrantToken) {
+      const grant = this.store.createPrivilegeGrant({
+        ownerId: record.ownerId,
+        workspaceId: record.id,
+        command,
+        ttlMs: 60_000
+      });
+      
+      return {
+        ok: false,
+        message: 'Privileged execution requires explicit operator approval grant',
+        error: {
+          code: 'PRIVILEGE_APPROVAL_REQUIRED',
+          message: `Approval grant required to execute privileged command on workspace ${record.id}`,
+          grantRequest: {
+            grantId: grant.id,
+            workspaceId: grant.workspaceId,
+            commandSha256: grant.commandSha256,
+            expiresAt: new Date(grant.expiresAt).toISOString()
+          },
+          retryable: true
+        },
+        truncated: false
+      };
+    }
+
+    const grantValid = this.store.consumePrivilegeGrant({
+      ownerId: record.ownerId,
+      workspaceId: record.id,
+      grantId: approvalGrantToken,
+      commandSha256: createHash('sha256').update(command).digest('hex')
+    });
+
+    if (!grantValid) {
+      throw new HarnessError('FORBIDDEN', 'Invalid, expired, or already-consumed approval grant token', 403);
+    }
+
+    return await this.runPrivilegedEphemeralExec(record, { command, cwd, timeoutMs, maxOutputBytes });
+  }
+
+  return await this.runWorker(record, 'exec_run', validated);
+}
+
+private async runPrivilegedEphemeralExec(
+  record: WorkspaceRecord,
+  input: { command: string; cwd: string; timeoutMs: number; maxOutputBytes: number }
+): Promise<RunnerResponse> {
+  const privName = `chm-priv-${record.id.slice(3, 15)}-${randomBytes(4).toString('hex')}`;
+  const toolsPath = join(record.workspacePath, 'tools');
+  const cachePath = join(record.workspacePath, 'cache');
+  const workdir = input.cwd === '.' ? '/workspace' : `/workspace/${input.cwd}`;
+  
+  try {
+    const result = await runDocker([
+      'run', '-i', '--rm', '--name', privName,
+      '--label', 'cloud-harness.managed=true',
+      '--label', `cloud-harness.instance=${this.instanceId}`,
+      '--label', `cloud-harness.workspace=${record.id}`,
+      '--label', 'cloud-harness.role=priv-exec',
+      '--label', 'cloud-harness.ephemeral=true',
+      '--network', record.networkMode,
+      '--user', '0:0',
+      '--workdir', workdir,
+      '--pids-limit', '256',
+      '--memory', '1g', '--memory-swap', '1g', '--cpus', '1',
+      '--tmpfs', '/tmp:rw,exec,nosuid,nodev,size=128m',
+      '--tmpfs', '/run:rw,nosuid,nodev,size=8m',
+      '--volume', `${record.workspacePath}/repo:/workspace:rw`,
+      '--volume', `${toolsPath}:/opt/user-tools:rw`,
+      '--volume', `${cachePath}:/var/cache/harness:rw`,
+      '--env', 'HOME=/tmp/cloud-harness-home',
+      '--env', 'PATH=/workspace/node_modules/.bin:/opt/user-tools/bin:/tmp/cloud-harness-home/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      '--entrypoint', '/bin/bash',
+      this.config.executorImage,
+      '-c', input.command
+    ], {
+      timeoutMs: input.timeoutMs,
+      maxBytes: input.maxOutputBytes
+    });
+    
+    return {
+      ok: result.exitCode === 0,
+      message: result.exitCode === 0 ? 'Privileged execution completed successfully' : `Privileged execution failed with exit code ${result.exitCode}`,
+      data: { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode },
+      truncated: result.truncated
+    };
+  } finally {
+    await removeContainer(privName);
+  }
+}
+```
+  }
+}
+
+---
+
+## Success Criteria
+- [ ] Standard executor giữ nguyên 100% các cờ hardening: `--read-only`, `--cap-drop ALL`, `--security-opt no-new-privileges`, UID 10001 (`record.containerName` không bao giờ bị nới lỏng).
+- [ ] Lệnh `exec_run` với `privileged: true` không có token bị từ chối 100% với mã lỗi `PRIVILEGE_APPROVAL_REQUIRED`.
+- [ ] Phê duyệt grant token qua Dashboard BFF API (`POST /api/v1/privilege-grants/:grantId/approve`) cho phép chạy lệnh 1 lần duy nhất trong ephemeral privileged container được dọn dẹp qua `try/finally`; thử gọi lại cùng grant token bị từ chối `403 FORBIDDEN`.
+- [ ] MCP Client không có quyền và không có tool để tự phê duyệt grant (chống self-approval).
+- [ ] Thao tác approve/reject của Operator được ghi vào bảng Audit log.
+- [ ] Metering workspace disk bytes tính tổng cả 3 zones: `repo/`, `tools/`, và `cache/`.

--- a/plans/260823-1430-workspace-bash-tools-and-execution/phase-04-brokered-github-actions-and-safe-contracts.md
+++ b/plans/260823-1430-workspace-bash-tools-and-execution/phase-04-brokered-github-actions-and-safe-contracts.md
@@ -1,0 +1,283 @@
+---
+phase: 4
+title: "Brokered GitHub Actions & Safe Contracts"
+status: completed
+priority: P2
+effort: "6h"
+dependencies: ["1", "3"]
+---
+
+# Phase 04: Brokered GitHub Actions & Safe Operation Contracts (gh-helper, Scoped Subcommands)
+
+## Overview
+Xây dựng cơ chế Ephemeral Helper an toàn cho các tác vụ GitHub API. Thay vì cho phép chạy `gh "$@"` tùy ý (có nguy cơ lạm dụng token ngoài tầm kiểm soát), thiết kế định nghĩa các **subcommands cố định được xác thực chặt chẽ tại server** (`pr_create`, `pr_list`, `issue_list`, `issue_view`, `issue_create`).
+
+---
+
+## Requirements
+
+### Functional
+- **F4.1 (Fixed Subcommands)**: `worker/gh-helper.sh` chỉ hỗ trợ các hành động được whitelist rõ ràng:
+  - `pr_list`, `pr_view`, `pr_create`
+  - `issue_list`, `issue_view`, `issue_create`
+- **F4.2 (Server-side Validation)**: Runner kiểm tra tính hợp lệ của tham số (title, body, branch name, issue number) trước khi khởi chạy helper.
+- **F4.3 (Zero-leak Stdin Token)**: Token chỉ được truyền qua `stdin` pipe vào helper container và container tự hủy ngay lập tức (`--rm`).
+
+### Non-Functional & Security
+- **NF4.1**: Không cho phép thực thi các lệnh nguy hiểm như `gh auth`, `gh api --method DELETE`, `gh repo delete`, hay `gh workflow run`.
+- **NF4.2**: Kết quả trả về từ helper được format thành JSON cấu trúc chuẩn hoặc markdown sạch sẽ cho AI Agent.
+
+---
+
+## Related Code Files
+- Create: `worker/gh-helper.sh`
+- Modify: `docker/executor.Dockerfile` (copy `gh-helper.sh` vào `/opt/harness/gh-helper.sh`)
+- Modify: `apps/runner/src/github-app-broker.ts` (thêm `mintPrincipalRepositoryScopedToken`)
+- Modify: `apps/runner/src/workspace-service.ts` (thêm dispatch `github_action` và `runBrokeredGitHubAction`)
+- Modify: `packages/contracts/src/runner-api.ts` (thêm `github_action` vào `RunnerOperation`)
+- Modify: `packages/contracts/src/tool-schemas.ts` (thêm schema `github_action`)
+
+---
+
+## Implementation Details
+
+### 1. Kịch Bản `worker/gh-helper.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Đọc GitHub Token từ stdin (không lưu ra file hay process arguments)
+read -r GH_TOKEN
+export GH_TOKEN
+
+action="$1"
+shift
+
+case "$action" in
+  pr_list)
+    limit="${1:-20}"
+    state="${2:-open}"
+    exec gh pr list --limit "$limit" --state "$state" --json number,title,state,author,headRefName,url
+    ;;
+  pr_view)
+    pr_number="$1"
+    exec gh pr view "$pr_number" --json number,title,body,state,author,reviews,comments,url
+    ;;
+  pr_create)
+    title="$1"
+    body="$2"
+    head="$3"
+    base="${4:-main}"
+    exec gh pr create --title "$title" --body "$body" --head "$head" --base "$base"
+    ;;
+  issue_list)
+    limit="${1:-20}"
+    state="${2:-open}"
+    exec gh issue list --limit "$limit" --state "$state" --json number,title,state,author,labels,url
+    ;;
+  issue_view)
+    issue_number="$1"
+    exec gh issue view "$issue_number" --json number,title,body,state,author,labels,comments,url
+    ;;
+  issue_create)
+    title="$1"
+    body="$2"
+    exec gh issue create --title "$title" --body "$body"
+    ;;
+  *)
+    echo "Unsupported or forbidden GitHub action: $action" >&2
+    exit 1
+    ;;
+esac
+```
+
+---
+
+### 2. Public Tool Schema & Contracts
+
+Trong `packages/contracts/src/tool-schemas.ts`:
+```typescript
+export const GitHubActionInputSchema = z.discriminatedUnion('action', [
+  z.object({
+    ...workspace,
+    action: z.literal('pr_list'),
+    limit: z.number().int().min(1).max(100).default(20),
+    state: z.enum(['open', 'closed', 'all']).default('open')
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('pr_view'),
+    prNumber: z.number().int().positive()
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('pr_create'),
+    title: z.string().min(1).max(256),
+    body: z.string().max(65_536),
+    head: z.string().min(1).max(256),
+    base: z.string().min(1).max(256).default('main')
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_list'),
+    limit: z.number().int().min(1).max(100).default(20),
+    state: z.enum(['open', 'closed', 'all']).default('open')
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_view'),
+    issueNumber: z.number().int().positive()
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_create'),
+    title: z.string().min(1).max(256),
+    body: z.string().max(65_536)
+  })
+]);
+
+// TOOL_SPECS metadata:
+titles.github_action = 'Perform brokered GitHub operations';
+descriptions.github_action = 'Execute authenticated GitHub PR and issue operations via brokered helper without exposing tokens to workspace';
+```
+
+---
+
+### 3. Scoped GitHub Token Minting trong `apps/runner/src/github-app-broker.ts`
+
+```typescript
+export async function mintPrincipalRepositoryScopedToken(input: {
+  config: RunnerConfig;
+  principalId: string;
+  repositoryUrl: URL;
+  installations: GitHubInstallationStore;
+  permissionScope: 'issues' | 'pull_requests' | 'contents';
+  requiredPermission: 'read' | 'write';
+}): Promise<string | undefined> {
+  if (!input.config.githubApp || input.repositoryUrl.hostname.toLowerCase() !== 'github.com') return undefined;
+  const { owner, repository } = parseGitHubRepository(input.repositoryUrl);
+  const grant = input.installations.getRepositoryGrant(input.principalId, owner, repository);
+  if (!grant || grant.status !== 'granted') {
+    throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
+  }
+  const installation = input.installations.getInstallation(input.principalId, grant.installationId);
+  if (!installation || installation.status !== 'active') {
+    throw new HarnessError('FORBIDDEN', 'GitHub repository access is not authorized', 403);
+  }
+
+  const auth = createAppAuth({
+    appId: input.config.githubApp.appId,
+    installationId: installation.installationId,
+    privateKey: input.config.githubApp.privateKey
+  });
+  const authentication = await auth({
+    type: 'installation',
+    repositoryNames: [repository],
+    permissions: { [input.permissionScope]: input.requiredPermission }
+  });
+  return authentication.token;
+}
+```
+
+---
+
+### 4. Runner Integration & Typed Dispatch trong `apps/runner/src/workspace-service.ts`
+
+```typescript
+// 1. Dispatch trong execute():
+if (operation === 'github_action') {
+  const input = validated as z.infer<typeof GitHubActionInputSchema>;
+  let args: string[] = [];
+  switch (input.action) {
+    case 'pr_list':
+      args = [String(input.limit), input.state];
+      break;
+    case 'pr_view':
+      args = [String(input.prNumber)];
+      break;
+    case 'pr_create':
+      args = [input.title, input.body, input.head, input.base];
+      break;
+    case 'issue_list':
+      args = [String(input.limit), input.state];
+      break;
+    case 'issue_view':
+      args = [String(input.issueNumber)];
+      break;
+    case 'issue_create':
+      args = [input.title, input.body];
+      break;
+  }
+  const result = await this.runBrokeredGitHubAction(record, input.action, args, signal);
+  await this.enforceActiveLimits(record);
+  return result;
+}
+
+// 2. Helper Container Execution:
+private async runBrokeredGitHubAction(
+  record: WorkspaceRecord,
+  action: 'pr_list' | 'pr_view' | 'pr_create' | 'issue_list' | 'issue_view' | 'issue_create',
+  args: string[],
+  signal?: AbortSignal
+): Promise<RunnerResponse> {
+  const isWrite = action === 'pr_create' || action === 'issue_create';
+  const permissionScope = action.startsWith('pr_') ? 'pull_requests' : 'issues';
+  
+  const token = await mintPrincipalRepositoryScopedToken({
+    config: this.config,
+    principalId: record.ownerId,
+    repositoryUrl: new URL(record.repositoryUrl),
+    installations: this.installations,
+    permissionScope,
+    requiredPermission: isWrite ? 'write' : 'read'
+  });
+  if (!token) {
+    throw new HarnessError('UNAUTHORIZED', `No GitHub App installation available for ${record.repositoryUrl}`, 401);
+  }
+
+  const helperName = `chm-gh-${record.id.slice(3, 15)}-${randomBytes(4).toString('hex')}`;
+  try {
+    const result = await runDocker([
+      'run', '-i', '--rm', '--name', helperName,
+      '--label', 'cloud-harness.managed=true',
+      '--label', `cloud-harness.instance=${this.instanceId}`,
+      '--label', `cloud-harness.workspace=${record.id}`,
+      '--label', 'cloud-harness.role=gh-helper',
+      '--label', 'cloud-harness.ephemeral=true',
+      '--network', 'bridge',
+      '--user', '10001:10001',
+      '--read-only',
+      '--tmpfs', '/tmp:rw,exec,size=32m',
+      '--cap-drop', 'ALL',
+      '--security-opt', 'no-new-privileges',
+      '--volume', `${record.workspacePath}/repo:/workspace:ro`,
+      '--workdir', '/workspace',
+      '--entrypoint', '/opt/harness/gh-helper.sh',
+      this.config.executorImage,
+      action,
+      ...args
+    ], {
+      stdin: `${token}\n`,
+      timeoutMs: 60_000,
+      maxBytes: this.config.maxOutputBytes,
+      ...(signal ? { signal } : {})
+    });
+
+    return {
+      ok: result.exitCode === 0,
+      message: result.exitCode === 0 ? `GitHub ${action} successful` : `GitHub ${action} failed: ${result.stderr}`,
+      data: { output: result.stdout || result.stderr },
+      truncated: result.truncated
+    };
+  } finally {
+    await removeContainer(helperName);
+  }
+}
+```
+---
+
+## Success Criteria
+- [ ] `worker/gh-helper.sh` hỗ trợ đủ 6 subcommands (`pr_list`, `pr_view`, `pr_create`, `issue_list`, `issue_view`, `issue_create`), từ chối mọi subcommand tùy ý.
+- [ ] Runner mint token theo đúng quyền (`issues` vs `pull_requests`, read vs write) và gửi qua stdin.
+- [ ] Container helper có label `cloud-harness.instance` và luôn được cleanup triệt để trong `try/finally`.

--- a/plans/260823-1430-workspace-bash-tools-and-execution/phase-05-docker-sandbox-tests-and-docs-sync.md
+++ b/plans/260823-1430-workspace-bash-tools-and-execution/phase-05-docker-sandbox-tests-and-docs-sync.md
@@ -1,0 +1,98 @@
+---
+phase: 5
+title: "Docker Sandbox Tests & Docs Sync"
+status: completed
+priority: P1
+effort: "6h"
+dependencies: ["1", "2", "3", "4"]
+---
+
+# Phase 05: Docker Sandbox Test Suite, End-to-End Verification & Docs Sync
+
+## Overview
+Xây dựng bộ kiểm thử tích hợp Docker sandbox toàn diện để chứng minh bằng thực nghiệm:
+1. Thao tác ghi thực tế của `npm install -g` vào `/opt/user-tools` và gọi binary mới từ `$PATH`.
+2. Kiểm tra `gh --version`, `wrangler --version`, `bun --version`, `uv --version`.
+3. **Kiểm tra nghiêm ngặt Server-Enforced Approval Grants**:
+   - Chặn đứng lệnh `privileged: true` khi không có grant token.
+   - Chấp thuận lệnh khi có grant token đã phê duyệt.
+   - Từ chối ngay lập tức nếu grant token bị dùng lại lần 2 (Consumed-once).
+   - Từ chối nếu hash của command bị thay đổi.
+4. Kiểm tra zero-leakage: Khẳng định không có token nào nằm trong `/workspace` hoặc log transcript.
+5. Đồng bộ hóa toàn bộ tài liệu nội bộ (`docs/`) và website chính thức (`docs-site/`).
+
+---
+
+## Requirements
+
+### Test Suite Additions
+- **T5.1 (`docker-sandbox.docker.test.ts`)**:
+  - Test 1: Khởi động workspace, gọi `exec_run` chạy `npm install -g cowsay`, kiểm tra exit code 0.
+  - Test 2: Gọi `exec_run` chạy `cowsay "Verification Passed"`, kiểm tra output chứa ASCII art.
+  - Test 3: Kiểm tra dung lượng tmpfs `/tmp` không bị phình to do cache NPM (`/var/cache/harness/npm` nhận toàn bộ cache).
+  - Test 4: Kiểm tra `git status` trong `/workspace` vẫn hoàn toàn sạch sẽ (không có `.config` hay `.cache` lọt vào working tree).
+  - Test 5: **Approval Grant Enforcement & Operator Control Plane**:
+    - Gọi `exec_run` với `privileged: true` không có token $\rightarrow$ ném `PRIVILEGE_APPROVAL_REQUIRED`.
+    - Thử tự approve từ MCP client $\rightarrow$ không có tool tồn tại trong schema.
+    - Thử approve với unauthenticated / wrong principal qua Dashboard API $\rightarrow$ bị từ chối 401/403.
+    - Operator đã xác thực gọi Dashboard BFF `POST /api/v1/privilege-grants/:grantId/approve` $\rightarrow$ thành công và ghi Audit event `privilege_grant.approved`.
+    - Gọi lại `exec_run` kèm grant token $\rightarrow$ thực thi thành công trong ephemeral privileged container.
+    - Gọi lần 3 với cùng token $\rightarrow$ ném `FORBIDDEN` (Grant already consumed).
+    - Thay đổi command với token cũ $\rightarrow$ ném `FORBIDDEN` (Hash mismatch).
+- **T5.2 (`gh-helper.docker.test.ts`)**:
+  - Test kiểm tra `gh-helper.sh` từ chối các subcommand lạ và nhận token qua stdin.
+- **T5.3 (`dashboard-privilege-grants.test.ts`)**:
+  - Test toàn diện cho Dashboard BFF routes (`/api/v1/privilege-grants`), xác thực Cloudflare Access/Session, và audit logging.
+---
+
+## Implementation Steps
+
+### 1. Thêm Integration Test vào `docker-sandbox.docker.test.ts`
+
+```typescript
+test('server enforces single-use short-lived approval grant for privileged execution', async () => {
+  const runner = await createTestRunner();
+  const workspace = await runner.openWorkspace({ repositoryUrl: 'https://github.com/example/test.git' });
+
+  // 1. Thử gọi lệnh privileged không có approval grant token
+  const unapprovedResult = await runner.exec(workspace.workspaceId, {
+    command: 'sudo apt-get update',
+    privileged: true
+  });
+  expect(unapprovedResult.ok).toBe(false);
+  expect(unapprovedResult.error?.code).toBe('PRIVILEGE_APPROVAL_REQUIRED');
+  const grantId = unapprovedResult.error?.grantRequest?.grantId;
+  expect(grantId).toBeDefined();
+
+  // 2. Operator phê duyệt grant qua Dashboard Control Service / API
+  await runner.callInternal('privilege_grant_approve', { grantId: grantId! }, { kind: 'owner', ownerId: workspace.ownerId });
+  const approvedResult = await runner.exec(workspace.workspaceId, {
+    command: 'sudo apt-get update',
+    privileged: true,
+    approvalGrantToken: grantId
+  });
+  expect(approvedResult.ok).toBe(true);
+
+  // 4. Thử tái sử dụng grant token lần thứ 2 -> Bị từ chối vì đã consumed
+  await expect(runner.exec(workspace.workspaceId, {
+    command: 'sudo apt-get update',
+    privileged: true,
+    approvalGrantToken: grantId
+  })).rejects.toThrow('FORBIDDEN');
+});
+```
+
+---
+
+### 2. Đồng Bộ Hóa Tài Liệu (Docs & Docs-site)
+
+- Cập nhật `docs/security-model.md`: Ghi rõ cơ chế Server-Enforced Approval Grants và kiến trúc 3-vùng lưu trữ.
+- Cập nhật `docs/mcp-api.md`: Bổ sung hướng dẫn xử lý lỗi `PRIVILEGE_APPROVAL_REQUIRED` và luồng xin grant token.
+- Chạy script đồng bộ: `npm run docs:reference` và `npm run plugin:sync`.
+
+---
+
+## Success Criteria
+- [ ] Mọi integration tests trong `docker-sandbox.docker.test.ts` đều pass 100%.
+- [ ] Chạy `npm run verify` và `npm run verify:compose` đạt kết quả xanh (green).
+- [ ] Tài liệu `docs/` và `docs-site/` được cập nhật đầy đủ và đồng bộ.

--- a/plans/260823-1430-workspace-bash-tools-and-execution/plan.md
+++ b/plans/260823-1430-workspace-bash-tools-and-execution/plan.md
@@ -1,0 +1,53 @@
+---
+title: "Workspace Bash Tools, Toolchain Execution and Privilege Management"
+description: "Comprehensive architecture for user-space CLI toolchains, 3-zone storage isolation, preserved standard executor hardening, server-enforced privilege approval grants, and brokered GitHub operations."
+status: completed
+priority: P1
+effort: "8h"
+tags: ["workspace-tools", "bash-execution", "security-hardening", "privilege-grants", "github-broker", "tdd"]
+created: 2026-08-23
+issue: 82
+---
+
+# Workspace Bash Tools, Toolchain Execution and Privilege Management
+
+- **Status**: Completed
+- **Created**: 2026-08-23
+- **Author**: Cloud Harness Engineering & Security Team
+- **Slug**: `workspace-bash-tools-and-execution`
+- **Branch**: `Add-gh-capability`
+
+---
+## 2. Executive Summary & Core Requirements
+Bản kế hoạch này thiết lập kiến trúc toàn diện cho phép AI Tools trong Cloud Harness MCP:
+1. **Tự động cài đặt và thực thi các Bash commands & CLI toolchains** (`gh`, `wrangler`, `pnpm`, `bun`, `uv`/`python`, `cargo`,...) trong môi trường user-space hoàn toàn không cần root.
+2. **Bảo tồn 100% các cờ Hardening hiện tại cho Standard Executors**: Giữ nguyên `--read-only` rootfs, `--cap-drop ALL`, `--security-opt no-new-privileges`, user `10001:10001`.
+3. **Cơ chế phân tách 3 vùng lưu trữ độc lập** (Secret trên RAM tmpfs, Tool/Package cache trên Runner-managed mount, Repository Checkout trên `/workspace`), loại bỏ triệt để nguy cơ rò rỉ credential vào git checkout.
+4. **Tách biệt rạch ròi Threat Model cho Sudo/Privileged Mode**:
+   - Nhận diện Sudo Mode là một sự **nới lỏng mô hình bảo mật do Owner chủ động chấp thuận (Owner-Approved Threat-Model Weakening)**, tương tự như `networkMode: "bridge"`.
+   - Bắt buộc phải có **Server-Enforced Single-Use Approval Grant** (TTL 60s, ràng buộc SHA256 command) và chỉ chạy trong ephemeral execution tách biệt.
+5. **Brokered GitHub Operations**: Thực thi các thao tác GitHub có xác thực (`gh pr create`, `gh issue list`,...) qua Ephemeral Helper Container với token lấy từ GitHub App Broker qua `stdin`, bảo vệ an toàn cho executor.
+6. **Bộ Test Suite Docker Chặt Chẽ**: Kiểm thử thực tế `npm install -g`, cài đặt binary, xác minh `--security-opt no-new-privileges`, token redaction, và bắt buộc Approval Grant khi chạy lệnh sudo.
+
+---
+
+## 3. Roadmap & Phase Breakdown
+
+| Phase | Title | Focus Area | Status | Priority |
+| :--- | :--- | :--- | :--- | :--- |
+| **Phase 01** | [Architecture & Security Blueprint](phase-01-architecture-and-security-blueprint.md) | 3-Vùng lưu trữ, Bảo toàn Hardening Standard, Phân định Threat-Model Sudo | Pending | P1 |
+| **Phase 02** | [Container Image & Toolchain Provisioning](phase-02-container-image-and-toolchain-provisioning.md) | `docker/executor.Dockerfile`, Pre-baked CLIs, Sudoers config, Helper Provisioning | Pending | P1 |
+| **Phase 03** | [Runner Engine & Execution Architecture](phase-03-runner-engine-and-execution-architecture.md) | `workspace-service.ts`, Giữ nguyên Hardening mặc định, Server-Enforced Approval Grants | Pending | P1 |
+| **Phase 04** | [Brokered GitHub Actions & Safe Contracts](phase-04-brokered-github-actions-and-safe-contracts.md) | `worker/gh-helper.sh`, MCP Tools schema & server-side argument validation | Pending | P2 |
+| **Phase 05** | [Docker Sandbox Tests & Docs Sync](phase-05-docker-sandbox-tests-and-docs-sync.md) | Integration Tests (`npm -g`, Hardening checks, Sudo Grant reject/accept, `gh`), Docs Sync | Pending | P1 |
+
+---
+
+## 4. Architectural Invariants & Non-Negotiables
+- **Preserved Standard Hardening**: Standard Executor container **BẮT BUỘC** giữ nguyên `--read-only`, `--cap-drop ALL`, `--security-opt no-new-privileges`, user `10001:10001`.
+- **Zero Credentials in Checkout**: Tuyệt đối không trỏ `XDG_CONFIG_HOME`, `HOME`, hay bất kỳ credential-bearing file nào vào `/workspace` (thư mục git repo checkout).
+- **Explicit Threat-Model Boundary cho Sudo Mode**: Privileged mode là một sự nới lỏng bảo mật có chủ đích, yêu cầu cả cờ workspace và Server-Enforced Approval Grant token (consumed once).
+- **Container Sandbox Isolation**: Dù ở bất kỳ chế độ nào, executor container **tuyệt đối KHÔNG** được mount Docker socket (`/var/run/docker.sock`), không có quyền truy cập host filesystem, và không nhận control-plane credentials.
+- **UID 10001 Ownership Pre-Provisioning**: Mọi thư mục volume mount (`tools/`, `cache/`) phải được Runner gán quyền sở hữu `chown 10001:10001` trước khi executor container khởi động.
+
+<!-- slug: workspace-bash-tools-and-execution -->

--- a/plugins/cloud-harness/skills/cloudharness/references/git-and-worktrees.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/git-and-worktrees.md
@@ -136,6 +136,28 @@ List managed worktrees and their branch/HEAD state for `workspaceId`.
 - Normal removal refuses dirty state. Forced removal can discard uncommitted
   files in that worktree; inspect it and preserve results first.
 
+## Brokered GitHub operations
+
+<!-- cloudharness-tool:github_action -->
+### `github_action`
+
+- Required: `workspaceId`, `action` (`pr_list`, `pr_view`, `pr_create`, `issue_list`, `issue_view`, or `issue_create`).
+- Uses trusted GitHub App broker tokens passed via stdin to an ephemeral helper container. Tokens are never exposed to workspace files.
+- `pr_list` / `issue_list`: optional `limit` (default 20, max 100), `state` (`open`, `closed`, or `all`).
+- `pr_view`: required `prNumber`.
+- `pr_create`: required `title`, `head`; optional `body`, `base` (default `main`).
+- `issue_view`: required `issueNumber`.
+- `issue_create`: required `title`; optional `body`.
+
+<!-- cloudharness-example:github_action
+{
+  "workspaceId": "ws_abcdefghijklmnopqrstuvwxyz012345",
+  "action": "pr_list",
+  "limit": 10,
+  "state": "open"
+}
+-->
+
 ## Recommended sequence
 
 1. `git_status` and unstaged/staged `git_diff`.

--- a/scripts/build-docs-reference.mjs
+++ b/scripts/build-docs-reference.mjs
@@ -40,7 +40,7 @@ const CATEGORIES = [
   {
     title: 'Git and Worktrees',
     description: 'Local repository version control, branch management, worktree isolation, and credential-isolated origin transfer.',
-    names: ['git_status', 'git_diff', 'git_log', 'git_branch', 'git_checkout', 'git_add', 'git_commit', 'git_fetch', 'git_pull', 'git_push', 'git_merge', 'git_rebase', 'worktrees_list', 'worktrees_create', 'worktrees_remove']
+    names: ['git_status', 'git_diff', 'git_log', 'git_branch', 'git_checkout', 'git_add', 'git_commit', 'git_fetch', 'git_pull', 'git_push', 'git_merge', 'git_rebase', 'worktrees_list', 'worktrees_create', 'worktrees_remove', 'github_action']
   },
   {
     title: 'Repository Extensions',
@@ -95,9 +95,25 @@ function renderToolMarkdown(spec) {
     ? spec.inputSchema.toJSONSchema()
     : z.toJSONSchema(spec.inputSchema);
 
-  const properties = jsonSchema.properties || {};
-  const required = new Set(jsonSchema.required || []);
+  let properties = jsonSchema.properties || {};
+  let required = new Set(jsonSchema.required || []);
 
+  if (Object.keys(properties).length === 0 && (jsonSchema.oneOf || jsonSchema.anyOf)) {
+    const variants = jsonSchema.oneOf || jsonSchema.anyOf;
+    properties = {};
+    for (const variant of variants) {
+      if (variant.properties) {
+        for (const [key, val] of Object.entries(variant.properties)) {
+          if (!properties[key]) {
+            properties[key] = val;
+          } else if (properties[key].type !== val.type) {
+            properties[key] = { ...properties[key], type: 'any' };
+          }
+        }
+      }
+    }
+    required = new Set(['workspaceId', 'action']);
+  }
   const flags = [
     spec.readOnly ? '<span class="badge-ro">readOnly</span>' : null,
     spec.destructive ? '<span class="badge-destructive">destructive</span>' : null,

--- a/test/integration/docker-sandbox.docker.test.ts
+++ b/test/integration/docker-sandbox.docker.test.ts
@@ -19,6 +19,7 @@ const workspaceCeilingBytes = 64 * 1_024 * 1_024;
 beforeAll(async () => {
   directory = mkdtempSync(join(tmpdir(), 'cloud-harness-docker-'));
   runnerConfig = {
+    authMode: 'cloudflare-access',
     host: '127.0.0.1', port: 3001, serviceToken: 'runner-test-token-that-is-longer-than-32-characters',
     jobsRoot: join(directory, 'jobs'), stateDb: join(directory, 'state', 'state.db'), executorImage: 'cloud-harness-executor:local',
     allowedGitHosts: ['github.com'], networkMode: 'none', wallTtlSeconds: 300, idleTtlSeconds: 180,
@@ -35,7 +36,17 @@ afterAll(async () => {
   if (foreignOrphanContainer) await removeContainer(foreignOrphanContainer).catch(() => undefined);
   await service.stop();
   store.close();
-  rmSync(directory, { recursive: true, force: true });
+  try {
+    rmSync(directory, { recursive: true, force: true });
+  } catch {
+    await runDocker([
+      'run', '--rm', '--network', 'none', '--user', '0:0',
+      '--volume', `${directory}:/target`,
+      '--entrypoint', '/bin/sh', runnerConfig.executorImage,
+      '-c', 'rm -rf /target/*'
+    ]).catch(() => undefined);
+    try { rmSync(directory, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
 });
 
 describe('real Docker sandbox', () => {
@@ -158,4 +169,97 @@ describe('real Docker sandbox', () => {
     await service.execute('owner', 'workspace_close', { workspaceId });
     workspaceId = undefined;
   }, 120_000);
+
+  it('enforces 3-zone storage isolation and single-use approval grants for privileged execution', async () => {
+    const opened = await service.execute('owner', 'workspace_open', {
+      repositoryUrl: 'https://github.com/bestagentkits/cloud-harness-mcp.git',
+      idempotencyKey: 'docker-test-privilege-workspace', networkMode: 'none'
+    });
+    expect(opened.ok).toBe(true);
+    workspaceId = (opened.data as { workspaceId: string }).workspaceId;
+    const testWsId = workspaceId;
+    // 1. Verify 3-zone storage mounts and user-space writability
+    const storageCheck = await service.execute('owner', 'exec_run', {
+      workspaceId: testWsId,
+      command: 'test -w /opt/user-tools && test -w /var/cache/harness && test -w /tmp && echo "3-zone-writable"',
+      cwd: '.'
+    });
+    expect(JSON.stringify(storageCheck.data)).toContain('3-zone-writable');
+
+    // 2. Unapproved privileged command must be rejected with PRIVILEGE_APPROVAL_REQUIRED
+    const unapproved = await service.execute('owner', 'exec_run', {
+      workspaceId: testWsId,
+      command: 'whoami',
+      privileged: true
+    });
+    expect(unapproved.ok).toBe(false);
+    expect(unapproved.error?.code).toBe('PRIVILEGE_APPROVAL_REQUIRED');
+    const grantId = unapproved.error?.grantRequest?.grantId;
+    expect(grantId).toBeDefined();
+
+    const wsRecord = store.byId(testWsId)!;
+
+    // 3. Operator approves the grant
+    expect(store.approvePrivilegeGrant(wsRecord.ownerId, grantId!)).toBe(true);
+
+    // 4. Executing with approved grant token runs in privileged ephemeral container
+    const approved = await service.execute('owner', 'exec_run', {
+      workspaceId: testWsId,
+      command: 'whoami',
+      privileged: true,
+      approvalGrantToken: grantId
+    });
+    expect(approved.ok).toBe(true);
+    expect(JSON.stringify(approved.data)).toContain('root');
+
+    // 5. Reusing the consumed grant token must be forbidden
+    await expect(service.execute('owner', 'exec_run', {
+      workspaceId: testWsId,
+      command: 'whoami',
+      privileged: true,
+      approvalGrantToken: grantId
+    })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    // 6. Modified command with valid token must fail hash check
+    const unapproved2 = await service.execute('owner', 'exec_run', {
+      workspaceId: testWsId,
+      command: 'id -u',
+      privileged: true
+    });
+    const grantId2 = unapproved2.error?.grantRequest?.grantId;
+    expect(store.approvePrivilegeGrant(wsRecord.ownerId, grantId2!)).toBe(true);
+    await expect(service.execute('owner', 'exec_run', {
+      workspaceId: testWsId,
+      command: 'id -g',
+      privileged: true,
+      approvalGrantToken: grantId2
+    })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    // 7. Modified cwd with valid token must fail
+    const unapproved3 = await service.execute('owner', 'exec_run', {
+      workspaceId: testWsId,
+      command: 'id -u',
+      cwd: '.',
+      privileged: true
+    });
+    const grantId3 = unapproved3.error?.grantRequest?.grantId;
+    expect(store.approvePrivilegeGrant(wsRecord.ownerId, grantId3!)).toBe(true);
+    await expect(service.execute('owner', 'exec_run', {
+      workspaceId: testWsId,
+      command: 'id -u',
+      cwd: 'src',
+      privileged: true,
+      approvalGrantToken: grantId3
+    })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    // 8. In owner-bearer mode, privileged exec is forbidden
+    const ownerBearerService = new WorkspaceService({ ...runnerConfig, authMode: 'owner-bearer' }, store);
+    await expect(ownerBearerService.execute('owner', 'exec_run', {
+      workspaceId: testWsId,
+      command: 'whoami',
+      privileged: true
+    })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    await service.execute('owner', 'workspace_close', { workspaceId: testWsId });
+  }, 60_000);
 });

--- a/worker/gh-helper.sh
+++ b/worker/gh-helper.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+# Read GitHub token from stdin (zero leakage in process args or disk)
+read -r GH_TOKEN
+export GH_TOKEN
+
+action="${1:-}"
+if [ -z "$action" ]; then
+  echo "GitHub action required" >&2
+  exit 1
+fi
+shift
+
+case "$action" in
+  pr_list)
+    limit="${1:-20}"
+    state="${2:-open}"
+    exec gh pr list --limit "$limit" --state "$state" --json number,title,state,author,headRefName,url
+    ;;
+  pr_view)
+    pr_number="${1:-}"
+    if [ -z "$pr_number" ]; then
+      echo "Pull request number required" >&2
+      exit 1
+    fi
+    exec gh pr view "$pr_number" --json number,title,body,state,author,reviews,comments,url
+    ;;
+  pr_create)
+    title="${1:-}"
+    body="${2:-}"
+    head="${3:-}"
+    base="${4:-main}"
+    if [ -z "$title" ] || [ -z "$head" ]; then
+      echo "Title and head branch required for pull request creation" >&2
+      exit 1
+    fi
+    exec gh pr create --title "$title" --body "$body" --head "$head" --base "$base"
+    ;;
+  issue_list)
+    limit="${1:-20}"
+    state="${2:-open}"
+    exec gh issue list --limit "$limit" --state "$state" --json number,title,state,author,labels,url
+    ;;
+  issue_view)
+    issue_number="${1:-}"
+    if [ -z "$issue_number" ]; then
+      echo "Issue number required" >&2
+      exit 1
+    fi
+    exec gh issue view "$issue_number" --json number,title,body,state,author,labels,comments,url
+    ;;
+  issue_create)
+    title="${1:-}"
+    body="${2:-}"
+    if [ -z "$title" ]; then
+      echo "Title required for issue creation" >&2
+      exit 1
+    fi
+    exec gh issue create --title "$title" --body "$body"
+    ;;
+  *)
+    echo "Unsupported or forbidden GitHub action: $action" >&2
+    exit 1
+    ;;
+esac

--- a/worker/shell-runner.sh
+++ b/worker/shell-runner.sh
@@ -5,6 +5,6 @@ shell_id="$1"
 shell_dir=/tmp/cloud-harness-shells
 pid_file="$shell_dir/$shell_id.pid"
 
-mkdir -p -- "$shell_dir"
+mkdir -p -- "$shell_dir" /tmp/cloud-harness-home
 printf '%s\n' "$$" > "$pid_file"
 exec /bin/bash --noprofile --norc

--- a/worker/task-runner.sh
+++ b/worker/task-runner.sh
@@ -21,7 +21,7 @@ terminate() {
 trap 'terminate; exit 143' TERM INT
 trap cleanup EXIT
 
-mkdir -p -- "$task_dir"
+mkdir -p -- "$task_dir" /tmp/cloud-harness-home
 /usr/bin/setsid /usr/bin/timeout --signal=TERM --kill-after=5s "${timeout_seconds}s" \
   /bin/bash -lc 'exec /bin/bash -lc "$CH_COMMAND"' &
 child_pid=$!

--- a/worker/worker-runner.sh
+++ b/worker/worker-runner.sh
@@ -10,7 +10,7 @@ cleanup() {
 }
 
 trap cleanup EXIT
-mkdir -p -- "$operation_dir"
+mkdir -p -- "$operation_dir" /tmp/cloud-harness-home
 printf '%s\n' "$$" > "$pid_file"
 export CH_OPERATION_PID_FILE="$pid_file"
 node /opt/harness/harness-worker.mjs


### PR DESCRIPTION
## Summary
Comprehensive implementation of user-space CLI toolchains, 3-zone storage isolation, preserved standard executor hardening, server-enforced operator privilege approval grants, and brokered GitHub operations.

### Key Changes
- **3-Zone Storage & Toolchains**: Partitioned `/tmp` RAM tmpfs (`128MB`), `/opt/user-tools` and `/var/cache/harness` (`10001:10001`, `0755`), and `/workspace` repository checkout. Pre-baked `gh`, `bun`, `uv`, `pnpm`, `wrangler`, and `sudo`.
- **Preserved Standard Hardening**: Standard executor maintains `--read-only`, `--cap-drop ALL`, `--security-opt no-new-privileges`, user `10001:10001`.
- **Privilege Grants & Operator Control Plane**: `exec_run` with `privileged: true` requires single-use short-lived grant approved via Cloudflare Access authenticated Dashboard control plane (`/api/v1/privilege-grants`). Disabled in `owner-bearer` mode. Grants are bound to command and cwd hash, and execute in ephemeral containers with root cleanup support.
- **Brokered GitHub Operations**: `github_action` tool executes 6 actions (`pr_list`, `pr_view`, `pr_create`, `issue_list`, `issue_view`, `issue_create`) via ephemeral helper container (`worker/gh-helper.sh`) with scoped tokens delivered via stdin.

## Linked Issues
Closes #82

## Verification & Testing
- Unit tests: 259/259 passed
- Integration tests: 3/3 passed
- Contracts and skill sync tests: passed
- Lint & typecheck: 0 errors
