### PR TITLE
test(runner): add global toolchain, dashboard privilege grant, and gh-helper test suites

### DIFF
--- a/apps/api/test/dashboard-privilege-grants.test.ts
+++ b/apps/api/test/dashboard-privilege-grants.test.ts
@@ -1,0 +1,202 @@
+import { createServer, request as httpRequest, type Server } from 'node:http';
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ApiConfig, RunnerPrincipalSelector, RunnerResponse } from '@cloud-harness/contracts';
+import { createDashboardRouter } from '../src/dashboard-router.js';
+import type { DashboardRunnerClient } from '../src/dashboard-types.js';
+
+const principal: RunnerPrincipalSelector = { kind: 'external', issuer: 'https://team.cloudflareaccess.com', subject: 'operator' };
+const config: ApiConfig = {
+  host: '127.0.0.1', port: 3000, authMode: 'cloudflare-access', ownerId: 'owner',
+  accessIssuer: 'https://team.cloudflareaccess.com', accessAudience: 'audience',
+  accessJwksUrl: 'https://team.cloudflareaccess.com/cdn-cgi/access/certs', runnerUrl: 'http://runner:3001',
+  apiKeyAuthEnabled: false,
+  runnerToken: 'runner-token-that-is-longer-than-32-characters', publicHosts: ['dashboard.example'],
+  allowedOrigins: ['https://dashboard.example'], requestTimeoutMs: 2_000, maxBodyBytes: 65_536
+};
+
+type Reply = { status: number; text: string; json: Record<string, unknown>; headers: Record<string, string | string[] | undefined> };
+let server: Server;
+let port: number;
+let runner: DashboardRunnerClient;
+let calls: Array<{ operation: string; input: Record<string, unknown>; principal: RunnerPrincipalSelector }>;
+
+beforeEach(async () => {
+  calls = [];
+  runner = {
+    call: vi.fn(),
+    callInternal: vi.fn(async (operation, input, selected): Promise<RunnerResponse> => {
+      calls.push({ operation, input, principal: selected });
+      if (operation === 'privilege_grant_list') {
+        return {
+          ok: true,
+          message: 'Privilege grants listed',
+          truncated: false,
+          data: {
+            grants: [{
+              id: 'pvg_1234567890abcdef',
+              ownerId: 'owner',
+              workspaceId: 'ws_1234567890abcdef',
+              command: 'whoami',
+              cwd: '.',
+              commandSha256: 'a'.repeat(64),
+              status: 'PENDING',
+              createdAt: Date.now(),
+              expiresAt: Date.now() + 60_000,
+              consumedAt: null
+            }]
+          }
+        };
+      }
+      if (operation === 'privilege_grant_approve') {
+        return {
+          ok: true,
+          message: 'Privilege grant approved',
+          truncated: false,
+          data: {
+            grant: {
+              id: String(input.grantId),
+              ownerId: 'owner',
+              workspaceId: 'ws_1234567890abcdef',
+              command: 'whoami',
+              cwd: '.',
+              commandSha256: 'a'.repeat(64),
+              status: 'APPROVED',
+              createdAt: Date.now(),
+              expiresAt: Date.now() + 60_000,
+              consumedAt: null
+            }
+          }
+        };
+      }
+      if (operation === 'privilege_grant_reject') {
+        return {
+          ok: true,
+          message: 'Privilege grant rejected',
+          truncated: false,
+          data: {
+            grant: {
+              id: String(input.grantId),
+              ownerId: 'owner',
+              workspaceId: 'ws_1234567890abcdef',
+              command: 'whoami',
+              cwd: '.',
+              commandSha256: 'a'.repeat(64),
+              status: 'REJECTED',
+              createdAt: Date.now(),
+              expiresAt: Date.now() + 60_000,
+              consumedAt: null
+            }
+          }
+        };
+      }
+      return { ok: true, message: 'ok', truncated: false, data: {} };
+    })
+  };
+  const app = express();
+  app.use((request: express.Request & { auth?: unknown }, _response, next) => {
+    request.auth = { token: 'cloudflare-access', clientId: 'operator', scopes: [], extra: { principal } };
+    next();
+  });
+  app.use('/dashboard', createDashboardRouter(config, runner));
+  server = createServer(app);
+  const { promise, resolve } = Promise.withResolvers<void>();
+  server.listen(0, '127.0.0.1', () => resolve());
+  await promise;
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server unavailable');
+  port = address.port;
+});
+
+afterEach(async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  server.close(() => resolve());
+  await promise;
+});
+
+function request(path: string, options: { method?: string; body?: unknown; headers?: Record<string, string> } = {}): Promise<Reply> {
+  const { promise, resolve, reject } = Promise.withResolvers<Reply>();
+  const payload = options.body ? JSON.stringify(options.body) : undefined;
+  const req = httpRequest({
+    host: '127.0.0.1', port, path: `/dashboard${path}`, method: options.method ?? 'GET',
+    headers: {
+      host: 'dashboard.example',
+      origin: 'https://dashboard.example',
+      'content-type': 'application/json',
+      ...(payload ? { 'content-length': String(Buffer.byteLength(payload)) } : {}),
+      ...options.headers
+    }
+  }, (res) => {
+    let text = '';
+    res.setEncoding('utf8');
+    res.on('data', (chunk) => { text += chunk; });
+    res.on('end', () => {
+      let json: Record<string, unknown> = {};
+      try { json = JSON.parse(text) as Record<string, unknown>; } catch { /* non-json response */ }
+      resolve({ status: res.statusCode ?? 0, text, json, headers: res.headers });
+    });
+  });
+  req.on('error', reject);
+  if (payload) req.write(payload);
+  req.end();
+  return promise;
+}
+
+describe('Dashboard privilege grant routes', () => {
+  it('lists privilege grants through the dashboard control router', async () => {
+    const reply = await request('/api/v1/privilege-grants?workspaceId=ws_1234567890abcdef');
+    expect(reply.status).toBe(200);
+    expect(calls[0]).toMatchObject({
+      operation: 'privilege_grant_list',
+      input: { workspaceId: 'ws_1234567890abcdef' },
+      principal
+    });
+    expect(reply.json.data).toMatchObject({
+      grants: [expect.objectContaining({ id: 'pvg_1234567890abcdef', status: 'PENDING' })]
+    });
+  });
+
+  it('approves a privilege grant through the dashboard control router', async () => {
+    const session = await request('/api/v1/session');
+    const cookie = String(session.headers['set-cookie']?.[0]).split(';', 1)[0];
+    const csrfHeaders = {
+      origin: 'https://dashboard.example',
+      cookie,
+      'content-type': 'application/json',
+      'x-csrf-token': String(session.json.csrfToken)
+    };
+
+    const reply = await request('/api/v1/privilege-grants/pvg_1234567890abcdef/approve', {
+      method: 'POST',
+      body: {},
+      headers: csrfHeaders
+    });
+    expect(reply.status).toBe(200);
+    expect(calls.some((c) => c.operation === 'privilege_grant_approve' && c.input.grantId === 'pvg_1234567890abcdef')).toBe(true);
+    expect(reply.json.data).toMatchObject({
+      grant: expect.objectContaining({ id: 'pvg_1234567890abcdef', status: 'APPROVED' })
+    });
+  });
+
+  it('rejects a privilege grant through the dashboard control router', async () => {
+    const session = await request('/api/v1/session');
+    const cookie = String(session.headers['set-cookie']?.[0]).split(';', 1)[0];
+    const csrfHeaders = {
+      origin: 'https://dashboard.example',
+      cookie,
+      'content-type': 'application/json',
+      'x-csrf-token': String(session.json.csrfToken)
+    };
+
+    const reply = await request('/api/v1/privilege-grants/pvg_1234567890abcdef/reject', {
+      method: 'POST',
+      body: {},
+      headers: csrfHeaders
+    });
+    expect(reply.status).toBe(200);
+    expect(calls.some((c) => c.operation === 'privilege_grant_reject' && c.input.grantId === 'pvg_1234567890abcdef')).toBe(true);
+    expect(reply.json.data).toMatchObject({
+      grant: expect.objectContaining({ id: 'pvg_1234567890abcdef', status: 'REJECTED' })
+    });
+  });
+});

--- a/docker/executor.Dockerfile
+++ b/docker/executor.Dockerfile
@@ -33,6 +33,9 @@ RUN useradd --uid 10001 --create-home --shell /bin/bash harness \
   && echo "harness ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/harness \
   && chmod 0440 /etc/sudoers.d/harness
 
+RUN echo 'export PATH="/workspace/node_modules/.bin:/opt/user-tools/bin:/opt/user-tools/pnpm/bin:/opt/user-tools/pnpm:/opt/user-tools/bun/bin:/tmp/cloud-harness-home/.local/bin:$PATH"' > /etc/profile.d/harness.sh \
+  && chmod 0644 /etc/profile.d/harness.sh
+
 RUN mkdir -p /workspace /opt/user-tools /var/cache/harness /tmp/cloud-harness-home \
   && chown -R 10001:10001 /workspace /opt/user-tools /var/cache/harness /tmp/cloud-harness-home
 

--- a/docs-site/concepts.md
+++ b/docs-site/concepts.md
@@ -15,8 +15,7 @@ description: Essential domain concepts, terminology, and invariants in Cloud Har
 A bounded, temporary working directory created on the host filesystem at `/var/lib/cloud-harness/jobs/<workspaceId>/repo`. A workspace hosts a clean clone of the target Git repository and is mounted exclusively into a single executor container.
 
 ### Executor
-The Docker container (`cloud-harness-executor:local`) executing repository commands on behalf of the workspace. It runs with UID/GID 1000 (`node`), has no Docker socket, lacks host mount access, and is isolated by network namespaces.
-
+The Docker container (`cloud-harness-executor:local`) executing repository commands on behalf of the workspace. It runs with UID/GID 10001 (`harness`), preserves strict hardening (`--read-only`, `--cap-drop ALL`, `--security-opt no-new-privileges`), operates across 3 partitioned storage zones (`/tmp/cloud-harness-home` RAM tmpfs, `/opt/user-tools` & `/var/cache/harness`, `/workspace`), has no Docker socket, lacks host mount access, and is isolated by network namespaces.
 ### Runner
 The trusted central daemon (`apps/runner`) responsible for Docker container lifecycle, SQLite state persistence, GitHub App token brokerage, and audit recording. It is not exposed to the public Internet.
 

--- a/docs-site/how-it-works.md
+++ b/docs-site/how-it-works.md
@@ -45,10 +45,11 @@ Cloud Harness MCP is architected as a split control plane and execution runtime.
                     ▼                                   ▼
         ┌───────────────────────┐           ┌───────────────────────┐
         │   WORKSPACE EXECUTOR  │           │   GIT TRANSFER HELPER │
-        │  • Non-root (UID 1000)│           │  • Ephemeral bare repo│
-        │  • Network: NONE (def)│           │  • GitHub App Token   │
-        │  • No Docker socket   │           │    passed via STDIN   │
-        │  • TTL auto-cleanup   │           │  • Origin-only push   │
+        │  • Non-root (UID 10001│           │  • Ephemeral bare repo│
+        │  • 3-Zone Storage     │           │  • GitHub App Token   │
+        │  • Network: NONE (def)│           │    passed via STDIN   │
+        │  • No Docker socket   │           │  • Origin-only push   │
+        │  • TTL auto-cleanup   │           │  • Ephemeral cleanup  │
         └───────────────────────┘           └───────────────────────┘
 ```
 
@@ -61,7 +62,7 @@ Cloud Harness MCP is architected as a split control plane and execution runtime.
 3. **Policy & Lifecycle Execution:**
    The API performs JSON schema validation against `TOOL_SCHEMA_BY_NAME` and issues an internal RPC to the **Runner**. The Runner validates principal permissions, checks concurrency bounds, and orchestrates the workspace container.
 4. **Isolated Execution:**
-   The **Workspace Executor** is spawned from `cloud-harness-executor:local`. The repository is cloned into a dedicated directory. Commands, file edits, and tasks execute inside this container under user `node` (UID 1000).
+   The **Workspace Executor** is spawned from `cloud-harness-executor:local`. The repository is cloned into a dedicated directory. Commands, file edits, and tasks execute inside this container under user `harness` (UID 10001) across partitioned user-space toolchain directories (`/opt/user-tools`) and temporary home (`/tmp/cloud-harness-home`).
 5. **Credential-Free Git Origin Transfer:**
    When `git_push` is invoked, the Runner starts an ephemeral helper container, streams a short-lived GitHub App installation token over `stdin`, pushes to GitHub origin, and immediately tears down the helper. The workspace executor never touches or observes the token.
 6. **Result Normalization:**

--- a/docs-site/reference/tools.md
+++ b/docs-site/reference/tools.md
@@ -659,9 +659,9 @@ Execute authenticated GitHub pull request and issue operations via brokered help
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `action` | `"pr_list"` | **Yes** | — |
+| `action` | `"pr_list"` \| `"pr_view"` \| `"pr_create"` \| `"issue_list"` \| `"issue_view"` \| `"issue_create"` | **Yes** | — |
 | `limit` | `integer` | No | range: 1–100, default: `20` |
-| `state` | `"open"` \| `"closed"` \| `"all"` | No | default: `"open"` |
+| `state` | `"open"` \| `"closed"` \| `"all"` | No | — |
 | `prNumber` | `integer` | No | range: 0–9007199254740991 |
 | `title` | `string` | No | length: 1–256 |
 | `body` | `string` | No | max length: 65536, default: `""` |

--- a/docs-site/security-model.md
+++ b/docs-site/security-model.md
@@ -20,11 +20,19 @@ Cloud Harness MCP is intentionally a **private, single-owner remote coding harne
 - The API and Runner never publish host ports directly.
 - The API has no access to the Docker socket or host filesystem mounts.
 
-### 2. Executor Confinement
-- **Non-Root User:** Containers execute as UID 1000 (`node`).
-- **No Docker Authority:** No socket mount or privileged capabilities.
+### 2. Executor Confinement & Hardening
+- **Non-Root User:** Containers execute as UID 10001 (`harness`).
+- **Hardened Standard Mode:** Standard executors strictly maintain `--read-only`, `--cap-drop ALL`, and `--security-opt no-new-privileges`.
+- **3-Zone Storage Partitioning:** Ephemeral secrets/config in RAM tmpfs (`/tmp/cloud-harness-home`), persistent user-space toolchains in `/opt/user-tools` & `/var/cache/harness`, and clean Git checkout in `/workspace`.
+- **No Docker Authority:** No socket mount or host filesystem access.
 - **Default Network `none`:** Outbound network is disabled unless explicitly requested as `bridge`.
 
-### 3. Credential Safety
-- Private clone and push tokens exist only in memory during the lifetime of the ephemeral Git helper.
-- Tokens are streamed over `stdin` and never stored in environment variables, configuration files, or repository commit history.
+### 3. Privileged Execution & Operator Grants
+- Privileged (`sudo`/root) commands are treated as an explicit threat model weakening and are supported in **Cloudflare Access** mode only.
+- Running with `privileged: true` requires an operator approval grant (`PRIVILEGE_APPROVAL_REQUIRED`), single-use, 60s TTL, bound to command and working directory hash.
+- Approval is performed by authenticated operators via the Dashboard control plane (`/api/v1/privilege-grants`). MCP clients cannot self-approve.
+- Approved privileged commands run in isolated ephemeral containers with root cleanup normalizers.
+
+### 4. Credential Safety
+- Private clone, push, and GitHub CLI operations use short-lived GitHub App tokens passed exclusively over `stdin` into ephemeral helpers.
+- Tokens are never stored in environment variables, configuration files, or repository commit history.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:unit": "vitest run packages apps --exclude '**/*.docker.test.ts'",
     "test:integration": "vitest run test/integration --exclude '**/*.docker.test.ts'",
     "pretest:docker": "npm run build -w @cloud-harness/contracts",
-    "test:docker": "vitest run test/integration/docker-sandbox.docker.test.ts test/integration/git-transfer-helper.docker.test.ts --testTimeout=120000",
+    "test:docker": "vitest run test/integration/docker-sandbox.docker.test.ts test/integration/git-transfer-helper.docker.test.ts test/integration/gh-helper.docker.test.ts --testTimeout=120000",
     "pretest:e2e": "npm run build -w @cloud-harness/contracts",
     "test:e2e": "vitest run test/e2e --testTimeout=120000",
     "pages:check": "node scripts/verify-pages-artifact.mjs",

--- a/scripts/build-docs-reference.mjs
+++ b/scripts/build-docs-reference.mjs
@@ -101,15 +101,30 @@ function renderToolMarkdown(spec) {
   if (Object.keys(properties).length === 0 && (jsonSchema.oneOf || jsonSchema.anyOf)) {
     const variants = jsonSchema.oneOf || jsonSchema.anyOf;
     properties = {};
+    const enumValuesByKey = {};
     for (const variant of variants) {
       if (variant.properties) {
         for (const [key, val] of Object.entries(variant.properties)) {
+          if (val.const !== undefined) {
+            enumValuesByKey[key] = enumValuesByKey[key] || [];
+            if (!enumValuesByKey[key].includes(val.const)) enumValuesByKey[key].push(val.const);
+          } else if (Array.isArray(val.enum)) {
+            enumValuesByKey[key] = enumValuesByKey[key] || [];
+            for (const e of val.enum) {
+              if (!enumValuesByKey[key].includes(e)) enumValuesByKey[key].push(e);
+            }
+          }
           if (!properties[key]) {
-            properties[key] = val;
+            properties[key] = { ...val };
           } else if (properties[key].type !== val.type) {
             properties[key] = { ...properties[key], type: 'any' };
           }
         }
+      }
+    }
+    for (const [key, enums] of Object.entries(enumValuesByKey)) {
+      if (enums.length > 1) {
+        properties[key] = { type: 'string', enum: enums };
       }
     }
     required = new Set(['workspaceId', 'action']);

--- a/test/integration/docker-sandbox.docker.test.ts
+++ b/test/integration/docker-sandbox.docker.test.ts
@@ -178,14 +178,14 @@ describe('real Docker sandbox', () => {
     expect(opened.ok).toBe(true);
     workspaceId = (opened.data as { workspaceId: string }).workspaceId;
     const testWsId = workspaceId;
-    // 1. Verify 3-zone storage mounts and user-space writability
+    // 1. Verify 3-zone storage mounts, pre-baked toolchain versions, and user-space writability
     const storageCheck = await service.execute('owner', 'exec_run', {
       workspaceId: testWsId,
-      command: 'test -w /opt/user-tools && test -w /var/cache/harness && test -w /tmp && echo "3-zone-writable"',
+      command: 'test -w /opt/user-tools && test -w /var/cache/harness && test -w /tmp && gh --version && bun --version && uv --version && pnpm --version && wrangler --version && echo "3-zone-writable"',
       cwd: '.'
     });
     expect(JSON.stringify(storageCheck.data)).toContain('3-zone-writable');
-
+    expect(JSON.stringify(storageCheck.data)).toContain('gh version');
     // 2. Unapproved privileged command must be rejected with PRIVILEGE_APPROVAL_REQUIRED
     const unapproved = await service.execute('owner', 'exec_run', {
       workspaceId: testWsId,
@@ -287,5 +287,34 @@ describe('real Docker sandbox', () => {
     expect(JSON.stringify(nextExec.data)).toContain('post-root-ok');
 
     await service.execute('owner', 'workspace_close', { workspaceId: testWsId });
-  }, 60_000);
+  }, 120_000);
+
+  it('installs and executes real user-space global packages in bridge network mode', async () => {
+    const bridgeOpened = await service.execute('owner', 'workspace_open', {
+      repositoryUrl: 'https://github.com/bestagentkits/cloud-harness-mcp.git',
+      idempotencyKey: 'docker-test-npm-bridge-workspace', networkMode: 'bridge'
+    });
+    expect(bridgeOpened.ok).toBe(true);
+    const bridgeWsId = (bridgeOpened.data as { workspaceId: string }).workspaceId;
+    try {
+      const installResult = await service.execute('owner', 'exec_run', {
+        workspaceId: bridgeWsId,
+        command: 'npm install -g cowsay',
+        cwd: '.',
+        timeoutMs: 120_000
+      });
+      expect(installResult.ok).toBe(true);
+
+      const execResult = await service.execute('owner', 'exec_run', {
+        workspaceId: bridgeWsId,
+        command: 'cowsay "Verification Passed"',
+        cwd: '.',
+        timeoutMs: 120_000
+      });
+      expect(execResult.ok).toBe(true);
+      expect(JSON.stringify(execResult.data)).toContain('Verification Passed');
+    } finally {
+      await service.execute('owner', 'workspace_close', { workspaceId: bridgeWsId }).catch(() => undefined);
+    }
+  }, 120_000);
 });

--- a/test/integration/gh-helper.docker.test.ts
+++ b/test/integration/gh-helper.docker.test.ts
@@ -1,0 +1,51 @@
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+describe('brokered GitHub helper', () => {
+  it('reads token from stdin and rejects unsupported actions', () => {
+    const result = spawnSync('docker', [
+      'run', '-i', '--rm', '--network', 'none', '--user', '10001:10001',
+      '--entrypoint', '/opt/harness/gh-helper.sh',
+      'cloud-harness-executor:local',
+      'forbidden_action'
+    ], { input: 'dummy_token\n', encoding: 'utf8' });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Unsupported or forbidden GitHub action: forbidden_action');
+  });
+
+  it('rejects invocation without an action', () => {
+    const result = spawnSync('docker', [
+      'run', '-i', '--rm', '--network', 'none', '--user', '10001:10001',
+      '--entrypoint', '/opt/harness/gh-helper.sh',
+      'cloud-harness-executor:local'
+    ], { input: 'dummy_token\n', encoding: 'utf8' });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('GitHub action required');
+  });
+
+  it('rejects pr_view when pull request number is missing', () => {
+    const result = spawnSync('docker', [
+      'run', '-i', '--rm', '--network', 'none', '--user', '10001:10001',
+      '--entrypoint', '/opt/harness/gh-helper.sh',
+      'cloud-harness-executor:local',
+      'pr_view'
+    ], { input: 'dummy_token\n', encoding: 'utf8' });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Pull request number required');
+  });
+
+  it('rejects issue_create when title is missing', () => {
+    const result = spawnSync('docker', [
+      'run', '-i', '--rm', '--network', 'none', '--user', '10001:10001',
+      '--entrypoint', '/opt/harness/gh-helper.sh',
+      'cloud-harness-executor:local',
+      'issue_create'
+    ], { input: 'dummy_token\n', encoding: 'utf8' });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Title required for issue creation');
+  });
+});

--- a/worker/shell-runner.sh
+++ b/worker/shell-runner.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -u
+export PATH="/workspace/node_modules/.bin:/opt/user-tools/bin:/opt/user-tools/pnpm/bin:/opt/user-tools/pnpm:/opt/user-tools/bun/bin:/tmp/cloud-harness-home/.local/bin:${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
 
 shell_id="$1"
 shell_dir=/tmp/cloud-harness-shells

--- a/worker/task-runner.sh
+++ b/worker/task-runner.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -u
+export PATH="/workspace/node_modules/.bin:/opt/user-tools/bin:/opt/user-tools/pnpm/bin:/opt/user-tools/pnpm:/opt/user-tools/bun/bin:/tmp/cloud-harness-home/.local/bin:${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
 
 task_id="$1"
 timeout_seconds="$2"

--- a/worker/worker-runner.sh
+++ b/worker/worker-runner.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -u
+export PATH="/workspace/node_modules/.bin:/opt/user-tools/bin:/opt/user-tools/pnpm/bin:/opt/user-tools/pnpm:/opt/user-tools/bun/bin:/tmp/cloud-harness-home/.local/bin:${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
 
 operation_id="$1"
 operation_dir=/tmp/cloud-harness-operations


### PR DESCRIPTION
## Summary
Completes remaining test suites, reference documentation generator fixes, and documentation site synchronization for the workspace tools, 3-zone storage, and privilege management feature:
- Added explicit `npm install -g cowsay` execution test and toolchain version checks (`gh`, `bun`, `uv`, `pnpm`, `wrangler`) to `docker-sandbox.docker.test.ts`.
- Created `test/integration/gh-helper.docker.test.ts` verifying stdin token reading, action whitelisting, and argument validation for `worker/gh-helper.sh`.
- Created `apps/api/test/dashboard-privilege-grants.test.ts` testing Dashboard BFF routes for grant listing, approval, and rejection.
- Fixed `scripts/build-docs-reference.mjs` to aggregate all action enum variants across discriminated union branches so `github_action.action` lists all 6 actions in reference docs.
- Synchronized `docs-site/concepts.md`, `docs-site/how-it-works.md`, and `docs-site/security-model.md` with UID 10001, 3-zone storage, and operator privilege grant architecture.

## Linked Issues
Closes #82
