### PR TITLE
fix(runner): reconcile private repo grants before clone retry (#86)

### DIFF
--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -55,7 +55,7 @@ const artifactReaper = setInterval(() => {
   }
 }, config.reaperIntervalSeconds * 1_000);
 artifactReaper.unref();
-const service = new WorkspaceService(config, store, metadata, githubInstallations);
+const service = new WorkspaceService(config, store, metadata, githubInstallations, githubBinding);
 const controls = new DashboardControlService(config, store, metadata, artifacts, service, githubInstallations, githubBinding);
 await service.start();
 const server = createServer(createRunnerApp(config, service, controls, apiKeys));

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -16,7 +16,7 @@ import { inspectContainer, removeContainer, runDocker, terminateContainerProcess
 import { readVerifiedWorkspaceFile } from './bounded-workspace-file-reader.js';
 import { mintPrincipalRepositoryScopedToken, mintPrincipalRepositoryToken, mintRepositoryToken } from './github-app-broker.js';
 import type { GitHubBindingService } from './github-binding-service.js';
-import type { GitHubInstallationStore } from './github-installation-store.js';
+import type { GitHubInstallationRecord, GitHubInstallationStore } from './github-installation-store.js';
 import type { MetadataStore } from './metadata-store.js';
 import { OperationManager } from './operation-manager.js';
 import { validateRepositoryUrl } from './repository-policy.js';
@@ -249,7 +249,18 @@ export class WorkspaceService {
       candidate.status !== 'uninstalled' && candidate.accountLogin.toLowerCase() === repositoryOwner
     );
     if (!installation) return undefined;
-    await this.githubBinding.reconcile(ownerId, undefined, installation.installationId);
+    const audit = this.metadata
+      ? (record: GitHubInstallationRecord) => this.metadata!.recordAuditInTransaction(
+          this.store.database,
+          ownerId,
+          record.status === 'uninstalled' ? 'github.uninstalled' : 'github.reconciled',
+          'github_installation',
+          record.installationId,
+          record.generation,
+          { status: record.status }
+        )
+      : undefined;
+    await this.githubBinding.reconcile(ownerId, audit, installation.installationId);
     return await mintPrincipalRepositoryToken({
       config: this.config,
       principalId: ownerId,

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -15,6 +15,7 @@ import {
 import { inspectContainer, removeContainer, runDocker, terminateContainerProcessGroup } from './docker-engine.js';
 import { readVerifiedWorkspaceFile } from './bounded-workspace-file-reader.js';
 import { mintPrincipalRepositoryScopedToken, mintPrincipalRepositoryToken, mintRepositoryToken } from './github-app-broker.js';
+import type { GitHubBindingService } from './github-binding-service.js';
 import type { GitHubInstallationStore } from './github-installation-store.js';
 import type { MetadataStore } from './metadata-store.js';
 import { OperationManager } from './operation-manager.js';
@@ -56,7 +57,8 @@ export class WorkspaceService {
     private readonly config: RunnerConfig,
     private readonly store: StateStore,
     private readonly metadata?: MetadataStore,
-    private readonly githubInstallations?: GitHubInstallationStore
+    private readonly githubInstallations?: GitHubInstallationStore,
+    private readonly githubBinding?: GitHubBindingService
   ) {
     this.instanceId = store.instanceId();
   }
@@ -201,6 +203,7 @@ export class WorkspaceService {
 
   private async clone(record: WorkspaceRecord, repositoryUrl: URL, ref?: string): Promise<string> {
     const jobPath = record.workspacePath;
+    const repositoryPath = join(jobPath, 'repo');
     const helperName = `chm-clone-${record.id.slice(3, 15)}`;
     await mkdir(jobPath, { recursive: true, mode: 0o700 });
     await chmod(jobPath, 0o777);
@@ -215,15 +218,45 @@ export class WorkspaceService {
       '--volume', `${jobPath}:/job`, '--entrypoint', '/opt/harness/clone-helper.sh', this.config.executorImage,
       record.repositoryUrl, '/job/repo', ref ?? ''
     ];
-    const repositoryToken = await this.repositoryToken(record.ownerId, repositoryUrl, 'read');
-    let result;
-    try {
-      result = await runDocker(args, { stdin: `${repositoryToken ?? ''}\n`, timeoutMs: 120_000, maxBytes: this.config.maxOutputBytes });
-    } finally {
-      await removeContainer(helperName);
+    const runClone = async (token: string | undefined) => {
+      try {
+        return await runDocker(args, { stdin: `${token ?? ''}\n`, timeoutMs: 120_000, maxBytes: this.config.maxOutputBytes });
+      } finally {
+        await removeContainer(helperName);
+      }
+    };
+
+    let repositoryToken = await this.repositoryToken(record.ownerId, repositoryUrl, 'read');
+    let result = await runClone(repositoryToken);
+    if (result.exitCode !== 0 && !repositoryToken) {
+      const refreshedToken = await this.refreshRepositoryToken(record.ownerId, repositoryUrl);
+      if (refreshedToken) {
+        await this.safeRemovePath(repositoryPath);
+        repositoryToken = refreshedToken;
+        result = await runClone(repositoryToken);
+      }
     }
     if (result.exitCode !== 0) throw new HarnessError('UNAVAILABLE', `repository clone failed: ${result.stderr || result.stdout}`.slice(0, 2_000), 502, true);
-    return join(jobPath, 'repo');
+    return repositoryPath;
+  }
+
+  private async refreshRepositoryToken(ownerId: string, repositoryUrl: URL): Promise<string | undefined> {
+    if ((this.config.authMode ?? 'owner-bearer') !== 'cloudflare-access') return undefined;
+    if (!this.githubInstallations || !this.githubBinding || !this.config.githubApp) return undefined;
+    if (repositoryUrl.hostname.toLowerCase() !== 'github.com') return undefined;
+    const repositoryOwner = repositoryUrl.pathname.replace(/^\/+/, '').split('/')[0]?.toLowerCase();
+    const installation = this.githubInstallations.listInstallations(ownerId).find((candidate) =>
+      candidate.status !== 'uninstalled' && candidate.accountLogin.toLowerCase() === repositoryOwner
+    );
+    if (!installation) return undefined;
+    await this.githubBinding.reconcile(ownerId, undefined, installation.installationId);
+    return await mintPrincipalRepositoryToken({
+      config: this.config,
+      principalId: ownerId,
+      repositoryUrl,
+      installations: this.githubInstallations,
+      requiredPermission: 'read'
+    });
   }
 
   private async provisionMountDirectories(record: WorkspaceRecord): Promise<{ toolsPath: string; cachePath: string }> {

--- a/apps/runner/test/private-repo-clone-reconcile.test.ts
+++ b/apps/runner/test/private-repo-clone-reconcile.test.ts
@@ -1,0 +1,138 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { RunnerConfig } from '@cloud-harness/contracts';
+import type { GitHubBindingService } from '../src/github-binding-service.js';
+import { InMemoryGitHubInstallationStore } from '../src/github-installation-store.js';
+import { StateStore, type WorkspaceRecord } from '../src/state-store.js';
+
+const docker = vi.hoisted(() => ({
+  runDocker: vi.fn(),
+  removeContainer: vi.fn(async () => undefined),
+  inspectContainer: vi.fn(async () => undefined),
+  terminateContainerProcessGroup: vi.fn(async () => undefined)
+}));
+
+const broker = vi.hoisted(() => ({
+  mintRepositoryToken: vi.fn(async () => undefined),
+  mintPrincipalRepositoryToken: vi.fn(),
+  mintPrincipalRepositoryScopedToken: vi.fn(async () => undefined)
+}));
+
+vi.mock('../src/docker-engine.js', () => docker);
+vi.mock('../src/github-app-broker.js', () => broker);
+
+import { WorkspaceService } from '../src/workspace-service.js';
+
+const temporaryDirectories: string[] = [];
+afterEach(() => {
+  vi.clearAllMocks();
+  for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function fixture() {
+  const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-private-clone-'));
+  temporaryDirectories.push(directory);
+  const config = {
+    authMode: 'cloudflare-access',
+    host: '127.0.0.1', port: 3001, serviceToken: 'runner-token-that-is-longer-than-32-characters',
+    jobsRoot: join(directory, 'jobs'), stateDb: join(directory, 'state.db'), executorImage: 'executor',
+    allowedGitHosts: ['github.com'], networkMode: 'none', wallTtlSeconds: 300, idleTtlSeconds: 180,
+    maxOutputBytes: 262_144, minFreeBytes: 0, maxWorkspaceBytes: 1_048_576, reaperIntervalSeconds: 30,
+    githubApp: {
+      appId: 123,
+      privateKey: '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----',
+      appSlug: 'cloud-harness-test'
+    }
+  } as RunnerConfig;
+  mkdirSync(config.jobsRoot, { recursive: true });
+  const store = new StateStore(config.stateDb);
+  const installations = new InMemoryGitHubInstallationStore();
+  installations.replaceVerified('principal-a', {
+    appId: 123,
+    installationId: 777,
+    accountId: 789,
+    accountLogin: 'bestagentkits',
+    status: 'active',
+    repositories: []
+  }, 1_000);
+  const record: WorkspaceRecord = {
+    id: `ws_${'a'.repeat(24)}`,
+    ownerId: 'principal-a',
+    idempotencyKey: 'private-clone-test',
+    repositoryUrl: 'https://github.com/bestagentkits/agentkit',
+    repositoryRef: null,
+    containerName: null,
+    workspacePath: join(config.jobsRoot, `ws_${'a'.repeat(24)}`),
+    status: 'CREATING',
+    networkMode: 'none',
+    createdAt: 1_000,
+    lastActivityAt: 1_000,
+    expiresAt: 60_000,
+    generation: 1,
+    error: null
+  };
+  return { config, store, installations, record };
+}
+
+type CloneMethod = (record: WorkspaceRecord, repositoryUrl: URL, ref?: string) => Promise<string>;
+
+describe('private repository clone reconciliation', () => {
+  it('reconciles stale Access grants and retries clone once with a freshly minted token', async () => {
+    const { config, store, installations, record } = fixture();
+    const reconcile = vi.fn(async (principalId: string) => {
+      return installations.replaceVerified(principalId, {
+        appId: 123,
+        installationId: 777,
+        accountId: 789,
+        accountLogin: 'bestagentkits',
+        status: 'active',
+        repositories: [{ owner: 'bestagentkits', repository: 'agentkit', contents: 'read' }]
+      }, 2_000);
+    });
+    const binding = { reconcile } as unknown as GitHubBindingService;
+    const service = new WorkspaceService(config, store, undefined, installations, binding);
+    broker.mintPrincipalRepositoryToken
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce('fresh-repository-token');
+    docker.runDocker
+      .mockResolvedValueOnce({ exitCode: 128, stdout: '', stderr: "fatal: could not read Username for 'https://github.com': terminal prompts disabled", truncated: false })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '', truncated: false });
+
+    try {
+      const clone = (service as unknown as { clone: CloneMethod }).clone.bind(service);
+      await expect(clone(record, new URL(record.repositoryUrl))).resolves.toBe(join(record.workspacePath, 'repo'));
+      expect(reconcile).toHaveBeenCalledTimes(1);
+      expect(reconcile).toHaveBeenCalledWith('principal-a', undefined, '777');
+      expect(broker.mintPrincipalRepositoryToken).toHaveBeenCalledTimes(2);
+      expect(docker.runDocker).toHaveBeenCalledTimes(2);
+      expect(docker.runDocker.mock.calls[0]?.[1]?.stdin).toBe('\n');
+      expect(docker.runDocker.mock.calls[1]?.[1]?.stdin).toBe('fresh-repository-token\n');
+      expect(docker.removeContainer).toHaveBeenCalledTimes(2);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('keeps successful public anonymous clones on the fast path without reconciliation', async () => {
+    const { config, store, installations, record } = fixture();
+    record.repositoryUrl = 'https://github.com/bestagentkits/orchestrate';
+    const reconcile = vi.fn();
+    const binding = { reconcile } as unknown as GitHubBindingService;
+    const service = new WorkspaceService(config, store, undefined, installations, binding);
+    broker.mintPrincipalRepositoryToken.mockResolvedValueOnce(undefined);
+    docker.runDocker.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '', truncated: false });
+
+    try {
+      const clone = (service as unknown as { clone: CloneMethod }).clone.bind(service);
+      await expect(clone(record, new URL(record.repositoryUrl))).resolves.toBe(join(record.workspacePath, 'repo'));
+      expect(reconcile).not.toHaveBeenCalled();
+      expect(broker.mintPrincipalRepositoryToken).toHaveBeenCalledTimes(1);
+      expect(docker.runDocker).toHaveBeenCalledTimes(1);
+      expect(docker.runDocker.mock.calls[0]?.[1]?.stdin).toBe('\n');
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/apps/runner/test/private-repo-clone-reconcile.test.ts
+++ b/apps/runner/test/private-repo-clone-reconcile.test.ts
@@ -4,7 +4,8 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { RunnerConfig } from '@cloud-harness/contracts';
 import type { GitHubBindingService } from '../src/github-binding-service.js';
-import { InMemoryGitHubInstallationStore } from '../src/github-installation-store.js';
+import { InMemoryGitHubInstallationStore, type GitHubInstallationMutationAudit } from '../src/github-installation-store.js';
+import type { MetadataStore } from '../src/metadata-store.js';
 import { StateStore, type WorkspaceRecord } from '../src/state-store.js';
 
 const docker = vi.hoisted(() => ({
@@ -79,9 +80,11 @@ function fixture() {
 type CloneMethod = (record: WorkspaceRecord, repositoryUrl: URL, ref?: string) => Promise<string>;
 
 describe('private repository clone reconciliation', () => {
-  it('reconciles stale Access grants and retries clone once with a freshly minted token', async () => {
+  it('reconciles stale Access grants, records mutation audit, and retries clone once with a freshly minted token', async () => {
     const { config, store, installations, record } = fixture();
-    const reconcile = vi.fn(async (principalId: string) => {
+    const recordAuditInTransaction = vi.fn();
+    const metadata = { recordAuditInTransaction } as unknown as MetadataStore;
+    const reconcile = vi.fn(async (principalId: string, audit?: GitHubInstallationMutationAudit) => {
       return installations.replaceVerified(principalId, {
         appId: 123,
         installationId: 777,
@@ -89,10 +92,10 @@ describe('private repository clone reconciliation', () => {
         accountLogin: 'bestagentkits',
         status: 'active',
         repositories: [{ owner: 'bestagentkits', repository: 'agentkit', contents: 'read' }]
-      }, 2_000);
+      }, 2_000, audit);
     });
     const binding = { reconcile } as unknown as GitHubBindingService;
-    const service = new WorkspaceService(config, store, undefined, installations, binding);
+    const service = new WorkspaceService(config, store, metadata, installations, binding);
     broker.mintPrincipalRepositoryToken
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce('fresh-repository-token');
@@ -104,12 +107,47 @@ describe('private repository clone reconciliation', () => {
       const clone = (service as unknown as { clone: CloneMethod }).clone.bind(service);
       await expect(clone(record, new URL(record.repositoryUrl))).resolves.toBe(join(record.workspacePath, 'repo'));
       expect(reconcile).toHaveBeenCalledTimes(1);
-      expect(reconcile).toHaveBeenCalledWith('principal-a', undefined, '777');
+      expect(reconcile).toHaveBeenCalledWith('principal-a', expect.any(Function), '777');
+      expect(recordAuditInTransaction).toHaveBeenCalledWith(
+        store.database,
+        'principal-a',
+        'github.reconciled',
+        'github_installation',
+        '777',
+        2,
+        { status: 'active' }
+      );
       expect(broker.mintPrincipalRepositoryToken).toHaveBeenCalledTimes(2);
       expect(docker.runDocker).toHaveBeenCalledTimes(2);
       expect(docker.runDocker.mock.calls[0]?.[1]?.stdin).toBe('\n');
       expect(docker.runDocker.mock.calls[1]?.[1]?.stdin).toBe('fresh-repository-token\n');
       expect(docker.removeContainer).toHaveBeenCalledTimes(2);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('does not retry when principal has no bound installation matching the repository owner', async () => {
+    const { config, store, record } = fixture();
+    const emptyInstallations = new InMemoryGitHubInstallationStore();
+    const reconcile = vi.fn();
+    const binding = { reconcile } as unknown as GitHubBindingService;
+    const service = new WorkspaceService(config, store, undefined, emptyInstallations, binding);
+    broker.mintPrincipalRepositoryToken.mockResolvedValueOnce(undefined);
+    docker.runDocker.mockResolvedValueOnce({
+      exitCode: 128,
+      stdout: '',
+      stderr: "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+      truncated: false
+    });
+
+    try {
+      const clone = (service as unknown as { clone: CloneMethod }).clone.bind(service);
+      await expect(clone(record, new URL(record.repositoryUrl))).rejects.toThrow('repository clone failed');
+      expect(reconcile).not.toHaveBeenCalled();
+      expect(broker.mintPrincipalRepositoryToken).toHaveBeenCalledTimes(1);
+      expect(docker.runDocker).toHaveBeenCalledTimes(1);
+      expect(docker.removeContainer).toHaveBeenCalledTimes(1);
     } finally {
       store.close();
     }

--- a/plans/260824-0012-reconcile-private-repo-grants-on-clone-retry/phase-01-reconcile-private-repo-grants-on-clone-retry.md
+++ b/plans/260824-0012-reconcile-private-repo-grants-on-clone-retry/phase-01-reconcile-private-repo-grants-on-clone-retry.md
@@ -1,0 +1,37 @@
+# Phase 01: Reconcile Private Repo Grants On Clone Retry
+
+## Context & Requirements
+
+- In Cloudflare Access mode, anonymous clone is attempted when `repositoryToken()` yields `undefined`.
+- For private repositories with an existing bound GitHub App installation on the principal, grant reconciliation refreshes the installation state from GitHub API and mints a repository-scoped token.
+- Retry is executed once with the token; if it fails or if no installation exists, the failure is surfaced cleanly.
+
+## Modified & Created Files
+
+- `apps/runner/src/index.ts`: Pass `githubBinding` service into `WorkspaceService`.
+- `apps/runner/src/workspace-service.ts`: Implement `refreshRepositoryToken` and single-retry flow with partial cleanup.
+- `apps/runner/test/private-repo-clone-reconcile.test.ts`: TDD test suite validating the reconciliation retry and isolation invariants.
+
+## Implementation Details
+
+1. **Service Constructor Injection**: Inject optional `githubBinding: GitHubBindingService` into `WorkspaceService`.
+2. **Reconciliation & Token Refresh**:
+   - Verify `authMode === 'cloudflare-access'`.
+   - Verify `githubInstallations`, `githubBinding`, and `config.githubApp` are configured.
+   - Verify target repo host is `github.com`.
+   - Find active installation matching repo owner for the principal `ownerId`.
+   - Call `githubBinding.reconcile(ownerId, undefined, installation.installationId)`.
+   - Mint token via `mintPrincipalRepositoryToken({ config, principalId, repositoryUrl, installations, requiredPermission: 'read' })`.
+3. **Bounded Clone Retry**:
+   - Run initial anonymous clone.
+   - If exit code is non-zero and no token was provided, attempt `refreshRepositoryToken`.
+   - If token is obtained, safely remove partial `/job/repo` directory and retry `runClone(repositoryToken)`.
+   - If retry fails or no token obtained, throw sanitized `HarnessError('UNAVAILABLE', ...)`.
+
+## Verification & Quality Gates
+
+- `npm run build -w @cloud-harness/contracts`
+- `npx vitest run apps/runner/test/private-repo-clone-reconcile.test.ts`
+- `npx vitest run apps/runner/test --exclude '**/*.docker.test.ts'`
+- `npm run typecheck`
+- `npm run lint`

--- a/plans/260824-0012-reconcile-private-repo-grants-on-clone-retry/plan.md
+++ b/plans/260824-0012-reconcile-private-repo-grants-on-clone-retry/plan.md
@@ -1,0 +1,49 @@
+---
+title: "Reconcile Private GitHub Repository Grants Before Clone Retry"
+description: "Reconcile stale Cloudflare Access GitHub App installation grants and retry cloning once with a repository-scoped token on anonymous clone failure."
+status: completed
+priority: P1
+effort: "2h"
+tags: ["runner", "github-broker", "private-repo", "clone-helper", "cloudflare-access", "tdd"]
+created: 2026-08-24
+issue: 86
+---
+
+# Reconcile Private GitHub Repository Grants Before Clone Retry
+
+- **Status**: Completed
+- **Slug**: `reconcile-private-repo-grants-on-clone-retry`
+- **Branch**: `fix/private-repo-clone-reconcile`
+
+---
+
+## 1. Executive Summary & Problem Statement
+
+In Cloudflare Access mode, `mintPrincipalRepositoryToken()` returns `undefined` when a principal lacks cached repository grants, allowing anonymous clone for public repositories without requiring GitHub App installation bindings.
+
+However, when a private GitHub repository is cloned:
+1. `mintPrincipalRepositoryToken()` returns `undefined` if grants are not yet cached or are stale.
+2. `clone-helper` performs an anonymous `git clone`.
+3. Private repo requires authentication, failing with `fatal: could not read Username for 'https://github.com': terminal prompts disabled`.
+
+The solution reconciles the principal's GitHub App installation grants upon anonymous clone failure and retries cloning once with a freshly minted repository-scoped token.
+
+---
+
+## 2. Roadmap & Phase Breakdown
+
+| Phase | Title | Focus Area | Status | Priority |
+| :--- | :--- | :--- | :--- | :--- |
+| **Phase 01** | [Reconcile Private Repo Grants On Clone Retry](phase-01-reconcile-private-repo-grants-on-clone-retry.md) | `WorkspaceService` binding integration, stale grant refresh, bounded retry, TDD test suite | In Progress | P1 |
+
+---
+
+## 3. Architectural Invariants & Security Constraints
+
+- **Strict Principal Isolation**: Never use a global or static GitHub App fallback for Cloudflare Access principals. Only reconcile when the requesting principal already has an active GitHub App installation bound for the target repo owner.
+- **Single Retry Bound**: The reconciliation and authenticated clone attempt is strictly bounded to one retry.
+- **Token Hygiene**: Installation tokens are passed exclusively via stdin to the ephemeral `clone-helper` container and never written to workspace files, `.git/config`, process arguments, or logs.
+- **Clean Workspace State**: If the initial anonymous clone leaves partial or corrupted files in `/job/repo`, the directory is safely cleaned up before the authenticated clone retry.
+- **Fast Path Preservation**: Public repositories cloning anonymously succeed on the first attempt without triggering reconciliation overhead.
+
+<!-- slug: reconcile-private-repo-grants-on-clone-retry -->


### PR DESCRIPTION
## Summary
Fix private GitHub repository cloning in Cloudflare Access mode when the principal's cached repository grants are missing or stale (#86).

When the initial anonymous clone fails and the principal already has a bound GitHub App installation matching the repository owner, the runner now reconciles installation grants with transactional mutation auditing and retries the clone once with a repository-scoped installation token.

## Why
`mintPrincipalRepositoryToken()` intentionally returns no token for missing read grants so public repositories can still clone anonymously without requiring GitHub App installation bindings.

That behavior caused private repos to fail with:
`fatal: could not read Username for 'https://github.com': terminal prompts disabled`
when a GitHub installation existed but the local repository grant cache had not yet been refreshed.

## Security
- Preserves strict principal-scoped GitHub authorization (no static/global installation fallback).
- Public repositories continue to clone anonymously on the fast path.
- Installation tokens are passed exclusively via stdin to the ephemeral `clone-helper` container and never written to workspace files, `.git/config`, process arguments, or logs.
- Safe partial repository directory cleanup before retry.
- Bounded to exactly one authenticated retry attempt.
- Transactional mutation audit events (`github.reconciled` / `github.uninstalled`) are recorded.

## Tests
- Runner typecheck: PASS
- ESLint: PASS
- Full runner unit test suite: 130/130 PASS
- Focused regression tests (`private-repo-clone-reconcile.test.ts`, `github-app-broker.test.ts`, `github-binding-service.test.ts`): 22/22 PASS

Closes #86