### PR TITLE
feat(api): add stdio transport and local-folder workspace mode (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,97 @@ write access; clone/fetch/pull need read access. See
 Start with the normal workflow in [MCP usage](docs/mcp-api.md#normal-workflow)
 for lifecycle, cursor, network, and Git-transfer semantics.
 
+## Local stdio workspace mode
+
+In addition to the remote HTTP/Docker service, Cloud Harness MCP can operate directly against an explicitly selected project folder on your local machine over **stdio transport**.
+
+```bash
+# Start local stdio server for a project:
+cloud-harness-mcp --transport stdio --workspace /path/to/project
+```
+
+In local mode:
+
+- The configured folder behaves as an already-opened workspace (with an opaque `workspaceId`). `workspace_open` is not required.
+- File operations, patches, grep search, symbol search, sessions, tasks, and local Git tools operate directly on the folder.
+- `workspace_close` terminates owned child processes and tasks but **never deletes your local project folder**.
+- Tool paths and working directories are strictly confined within the workspace root.
+- Commands (`exec_run`, shells, tasks) execute with host-user permissions. File path confinement is not an OS sandbox.
+- Network Git (`git_fetch`, `git_pull`) and Git push (`git_push`) are disabled by default and require explicit startup opt-in flags (`--git-network`, `--git-push`).
+- v1 supports POSIX (Linux and macOS); Windows process semantics are a documented follow-up (use WSL on Windows).
+
+### CLI options
+
+| Option | Description |
+|---|---|
+| `--transport <http\|stdio>` | Select transport protocol: `http` (default) or `stdio` |
+| `--workspace <path>` | Absolute path to the local project folder (required for stdio) |
+| `--git-network` | Enable network Git operations (`git_fetch`, `git_pull`) |
+| `--git-push` | Enable Git push (`git_push`, implies `--git-network`) |
+| `--env <NAME>` | Forward additional host environment variable (repeatable) |
+| `-h, --help` | Display help message |
+| `-v, --version` | Display version information |
+
+### Configuring local stdio in AI clients
+
+#### Claude Desktop
+
+In `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `~/.config/Claude/claude_desktop_config.json` (Linux):
+
+```json
+{
+  "mcpServers": {
+    "cloud-harness-local": {
+      "command": "node",
+      "args": [
+        "/path/to/cloud-harness-mcp/apps/api/dist/index.js",
+        "--transport",
+        "stdio",
+        "--workspace",
+        "/path/to/my-project"
+      ]
+    }
+  }
+}
+```
+
+#### Claude Code
+
+```bash
+claude mcp add cloud-harness-local --transport stdio -- node /path/to/cloud-harness-mcp/apps/api/dist/index.js --transport stdio --workspace /path/to/my-project
+```
+
+#### Cursor
+
+In `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "cloud-harness-local": {
+      "command": "node",
+      "args": [
+        "/path/to/cloud-harness-mcp/apps/api/dist/index.js",
+        "--transport",
+        "stdio",
+        "--workspace",
+        "/path/to/my-project"
+      ]
+    }
+  }
+}
+```
+
+#### OpenAI Codex
+
+In `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.cloud_harness_local]
+command = "node"
+args = ["/path/to/cloud-harness-mcp/apps/api/dist/index.js", "--transport", "stdio", "--workspace", "/path/to/my-project"]
+```
+
 ## MCP tools
 
 The public tool names are owned by

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,6 +3,9 @@
   "version": "0.19.2",
   "private": true,
   "type": "module",
+  "bin": {
+    "cloud-harness-mcp": "./dist/index.js"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",

--- a/apps/api/src/cli-options.ts
+++ b/apps/api/src/cli-options.ts
@@ -1,0 +1,168 @@
+import { isAbsolute } from 'node:path';
+
+export type CliTransport = 'http' | 'stdio';
+
+export type CliOptions = {
+  transport: CliTransport;
+  workspace?: string;
+  gitNetwork: boolean;
+  gitPush: boolean;
+  env: string[];
+  help: boolean;
+  version: boolean;
+};
+
+export type ParseCliResult =
+  | { ok: true; options: CliOptions }
+  | { ok: false; error: string; help?: boolean };
+
+export function parseCliOptions(argv: string[]): ParseCliResult {
+  let transport: CliTransport = 'http';
+  let transportExplicit = false;
+  let workspace: string | undefined = undefined;
+  let gitNetwork = false;
+  let gitPush = false;
+  const env: string[] = [];
+  let help = false;
+  let version = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === undefined) break;
+
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+      continue;
+    }
+
+    if (arg === '--version' || arg === '-v') {
+      version = true;
+      continue;
+    }
+
+    if (arg === '--transport') {
+      const next = argv[++i];
+      if (next === undefined) return { ok: false, error: 'missing argument for --transport' };
+      if (next !== 'http' && next !== 'stdio') {
+        return { ok: false, error: `invalid transport: "${next}" (must be "http" or "stdio")` };
+      }
+      transport = next;
+      transportExplicit = true;
+      continue;
+    }
+
+    if (arg.startsWith('--transport=')) {
+      const val = arg.slice('--transport='.length);
+      if (val !== 'http' && val !== 'stdio') {
+        return { ok: false, error: `invalid transport: "${val}" (must be "http" or "stdio")` };
+      }
+      transport = val;
+      transportExplicit = true;
+      continue;
+    }
+
+    if (arg === '--workspace') {
+      const next = argv[++i];
+      if (next === undefined) return { ok: false, error: 'missing argument for --workspace' };
+      workspace = next;
+      continue;
+    }
+
+    if (arg.startsWith('--workspace=')) {
+      workspace = arg.slice('--workspace='.length);
+      continue;
+    }
+
+    if (arg === '--git-network') {
+      gitNetwork = true;
+      continue;
+    }
+
+    if (arg === '--git-push') {
+      gitPush = true;
+      continue;
+    }
+
+    if (arg === '--env') {
+      const next = argv[++i];
+      if (next === undefined) return { ok: false, error: 'missing argument for --env' };
+      env.push(next);
+      continue;
+    }
+
+    if (arg.startsWith('--env=')) {
+      env.push(arg.slice('--env='.length));
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      return { ok: false, error: `unknown option: "${arg}"` };
+    }
+
+    return { ok: false, error: `unexpected argument: "${arg}"` };
+  }
+
+  const options: CliOptions = {
+    transport,
+    ...(workspace !== undefined ? { workspace } : {}),
+    gitNetwork,
+    gitPush,
+    env,
+    help,
+    version
+  };
+
+  if (help || version) {
+    return { ok: true, options };
+  }
+
+  if (transport === 'stdio') {
+    if (!workspace) {
+      return { ok: false, error: 'stdio transport requires an explicit --workspace <absolute-path>' };
+    }
+    if (!isAbsolute(workspace)) {
+      return { ok: false, error: `--workspace path must be absolute (received: "${workspace}")` };
+    }
+  } else if (workspace && !transportExplicit) {
+    return { ok: false, error: '--workspace is only valid when --transport stdio is specified' };
+  } else if (transport === 'http' && workspace) {
+    return { ok: false, error: '--workspace is only supported with --transport stdio' };
+  }
+
+  if (gitPush && !gitNetwork) {
+    gitNetwork = true;
+    options.gitNetwork = true;
+  }
+
+  return {
+    ok: true,
+    options
+  };
+}
+
+export function getCliHelp(): string {
+  return `Cloud Harness MCP - Remote and Local Coding Harness
+
+Usage:
+  cloud-harness-mcp [options]
+
+Options:
+  --transport <http|stdio>   Transport protocol: http (default) or stdio
+  --workspace <path>         Absolute path to local project folder (required for stdio)
+  --git-network              Enable network Git operations (fetch, pull, clone) in local mode
+  --git-push                 Enable Git push operations in local mode (implies --git-network)
+  --env <NAME>               Forward additional host environment variable (repeatable)
+  -h, --help                 Show this help message
+  -v, --version              Show version information
+
+Examples:
+  # Start remote HTTP server (default):
+  cloud-harness-mcp --transport http
+
+  # Start local stdio MCP server for a folder:
+  cloud-harness-mcp --transport stdio --workspace /path/to/my-project
+
+  # Start local stdio with network Git and custom environment variable:
+  cloud-harness-mcp --transport stdio --workspace /path/to/my-project --git-network --env GITHUB_TOKEN
+`;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,20 +1,100 @@
+#!/usr/bin/env node
 import { createServer } from 'node:http';
+import { realpath, stat } from 'node:fs/promises';
 import pino from 'pino';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import { createApiApp } from './app.js';
 import { loadApiConfig } from './config.js';
+import { parseCliOptions, getCliHelp } from './cli-options.js';
+import { LocalWorkspaceBackend } from './local/local-workspace-backend.js';
+import { createCloudHarnessServer } from './mcp-server.js';
 
-const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' });
-const config = loadApiConfig();
-const runtime = createApiApp(config);
-const server = createServer(runtime.app);
-server.listen(config.port, config.host, () => logger.info({ host: config.host, port: config.port }, 'API listening'));
+const parsed = parseCliOptions(process.argv.slice(2));
+if (!parsed.ok) {
+  process.stderr.write(`Error: ${parsed.error}\n\n${getCliHelp()}\n`);
+  process.exit(1);
+}
 
-async function shutdown(signal: string) {
-  logger.info({ signal }, 'API shutting down');
-  server.close();
-  await runtime.close();
+const { options } = parsed;
+
+if (options.help) {
+  process.stdout.write(getCliHelp() + '\n');
   process.exit(0);
 }
 
-process.on('SIGTERM', () => void shutdown('SIGTERM'));
-process.on('SIGINT', () => void shutdown('SIGINT'));
+if (options.version) {
+  process.stdout.write('0.19.2\n');
+  process.exit(0);
+}
+
+if (options.transport === 'stdio') {
+  if (process.platform === 'win32' && process.env.HARNESS_ALLOW_WIN32_STDIO !== '1') {
+    process.stderr.write(
+      'Error: Cloud Harness MCP local stdio mode currently supports POSIX platforms (Linux and macOS).\n' +
+      'On Windows, please run within WSL (Windows Subsystem for Linux) or use Cloud Harness in cloud HTTP mode.\n'
+    );
+    process.exit(1);
+  }
+
+  const workspacePath = options.workspace!;
+  let canonicalRoot: string;
+  try {
+    const stats = await stat(workspacePath);
+    if (!stats.isDirectory()) {
+      process.stderr.write(`Error: --workspace path "${workspacePath}" is not a directory.\n`);
+      process.exit(1);
+    }
+    canonicalRoot = await realpath(workspacePath);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Error: failed to resolve workspace path "${workspacePath}": ${msg}\n`);
+    process.exit(1);
+  }
+
+  const backend = new LocalWorkspaceBackend(canonicalRoot, options);
+  const handle = serveStdio(() => createCloudHarnessServer(backend), {
+    legacy: 'serve',
+    onerror: (error) => {
+      process.stderr.write(`MCP server error: ${error.message}\n`);
+    }
+  });
+
+  let shuttingDown = false;
+  async function shutdown(signal?: string) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    if (signal) {
+      process.stderr.write(`Received ${signal}, shutting down stdio server...\n`);
+    }
+    try {
+      await handle.close();
+      await backend.close();
+    } catch {
+      // ignore
+    }
+    process.exit(0);
+  }
+
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.stdin.on('close', () => void shutdown('EOF'));
+  process.stdin.on('end', () => void shutdown('EOF'));
+} else {
+  const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' });
+  const config = loadApiConfig();
+  const runtime = createApiApp(config);
+  const server = createServer(runtime.app);
+  server.listen(config.port, config.host, () =>
+    logger.info({ host: config.host, port: config.port }, 'API listening')
+  );
+
+  async function shutdown(signal: string) {
+    logger.info({ signal }, 'API shutting down');
+    server.close();
+    await runtime.close();
+    process.exit(0);
+  }
+
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+}

--- a/apps/api/src/local/local-environment.ts
+++ b/apps/api/src/local/local-environment.ts
@@ -1,0 +1,93 @@
+const DEFAULT_ALLOWLIST: Record<string, true> = {
+  PATH: true,
+  HOME: true,
+  USER: true,
+  LOGNAME: true,
+  SHELL: true,
+  LANG: true,
+  LC_ALL: true,
+  LC_CTYPE: true,
+  LC_MESSAGES: true,
+  TERM: true,
+  TMPDIR: true,
+  TEMP: true,
+  TMP: true,
+  EDITOR: true,
+  VISUAL: true,
+  NODE_ENV: true,
+  CI: true,
+  COLORTERM: true,
+  FORCE_COLOR: true,
+  NO_COLOR: true,
+  GIT_AUTHOR_NAME: true,
+  GIT_AUTHOR_EMAIL: true,
+  GIT_COMMITTER_NAME: true,
+  GIT_COMMITTER_EMAIL: true,
+  SSH_AUTH_SOCK: true
+};
+
+const SECRET_PATTERNS = [
+  /^MCP_BEARER_TOKEN$/i,
+  /^RUNNER_SERVICE_TOKEN$/i,
+  /^GITHUB_APP_/i,
+  /^SESSION_SECRET$/i,
+  /^KEYRING_/i,
+  /^ACCESS_AUD$/i,
+  /^ACCESS_TEAM/i,
+  /^ACCESS_JWKS/i,
+  /^METADATA_DATABASE/i,
+  /^DATABASE_/i,
+  /^CLOUDFLARE_/i
+];
+
+const RESERVED_PREFIXES = ['HARNESS_', 'CH_'];
+
+export function isSecretName(name: string): boolean {
+  return SECRET_PATTERNS.some((pattern) => pattern.test(name));
+}
+
+export function isReservedName(name: string): boolean {
+  return RESERVED_PREFIXES.some((prefix) => name.toUpperCase().startsWith(prefix));
+}
+
+export function buildLocalEnvironment(
+  forwardedNames: string[] = [],
+  customEnv?: Record<string, string>
+): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const name of Object.keys(DEFAULT_ALLOWLIST)) {
+    const value = process.env[name];
+    if (value !== undefined && !isSecretName(name)) {
+      env[name] = value;
+    }
+  }
+
+  for (const name of forwardedNames) {
+    if (isReservedName(name)) {
+      continue;
+    }
+    if (isSecretName(name)) {
+      continue;
+    }
+    const value = process.env[name];
+    if (value !== undefined) {
+      env[name] = value;
+    }
+  }
+
+  if (customEnv) {
+    for (const [key, value] of Object.entries(customEnv)) {
+      if (!isReservedName(key) && !isSecretName(key)) {
+        env[key] = value;
+      }
+    }
+  }
+
+  env.GIT_CONFIG_NOSYSTEM = '1';
+  env.GIT_TERMINAL_PROMPT = '0';
+  env.GIT_PAGER = 'cat';
+  env.PAGER = 'cat';
+
+  return env;
+}

--- a/apps/api/src/local/local-operation-manager.ts
+++ b/apps/api/src/local/local-operation-manager.ts
@@ -1,0 +1,579 @@
+import { randomBytes } from 'node:crypto';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import type { LocalPathPolicy } from './local-path-policy.js';
+import { buildLocalEnvironment } from './local-environment.js';
+
+type ManagedStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'blocked';
+
+type Managed = {
+  id: string;
+  workspaceId: string;
+  output: Buffer;
+  offset: number;
+  status: ManagedStatus;
+  createdAt: number;
+  idempotencyKey: string;
+  child?: ChildProcessWithoutNullStreams;
+  exitCode?: number;
+  name?: string;
+  dependsOn?: string[];
+  command?: string;
+  cwd?: string;
+  timeoutMs?: number;
+  maxBytes?: number;
+  timer?: NodeJS.Timeout;
+};
+
+const id = (prefix: string) => `${prefix}_${randomBytes(24).toString('base64url')}`;
+
+function terminateProcess(child?: ChildProcessWithoutNullStreams): void {
+  if (!child || child.killed) return;
+  const pid = child.pid;
+  if (!pid) return;
+
+  if (process.platform !== 'win32') {
+    try {
+      process.kill(-pid, 'SIGTERM');
+    } catch {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already exited
+      }
+    }
+    setTimeout(() => {
+      try {
+        process.kill(-pid, 'SIGKILL');
+      } catch {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // already exited
+        }
+      }
+    }, 1000).unref();
+  } else {
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function resolveShell(): { bin: string; args: (cmd?: string) => string[] } {
+  if (process.platform === 'win32') {
+    const comspec = process.env.COMSPEC || 'cmd.exe';
+    return {
+      bin: comspec,
+      args: (cmd?: string) => (cmd ? ['/d', '/s', '/c', cmd] : [])
+    };
+  }
+  const shell = process.env.SHELL || '/bin/bash';
+  return {
+    bin: shell,
+    args: (cmd?: string) => (cmd ? ['-lc', cmd] : ['-i'])
+  };
+}
+
+export class LocalOperationManager {
+  private readonly tasks = new Map<string, Managed>();
+  private readonly shells = new Map<string, Managed>();
+  private readonly sessions = new Map<string, Managed>();
+  private readonly idempotency = new Map<string, string>();
+  private readonly retainedOutputBytes = 67_108_864;
+
+  constructor(
+    private readonly pathPolicy: LocalPathPolicy,
+    private readonly forwardedEnvNames: string[] = []
+  ) {}
+
+  private records(workspaceId: string): Managed[] {
+    return [...this.tasks.values(), ...this.shells.values(), ...this.sessions.values()]
+      .filter((record) => record.workspaceId === workspaceId)
+      .sort((left, right) => left.createdAt - right.createdAt);
+  }
+
+  private enforceOutputBudget(workspaceId: string): void {
+    const records = this.records(workspaceId);
+    let total = records.reduce((sum, record) => sum + record.output.length, 0);
+    for (const record of [
+      ...records.filter((item) => item.status !== 'running'),
+      ...records.filter((item) => item.status === 'running')
+    ]) {
+      if (total <= this.retainedOutputBytes) break;
+      const removed = Math.min(record.output.length, total - this.retainedOutputBytes);
+      record.output = record.output.subarray(removed);
+      record.offset += removed;
+      total -= removed;
+    }
+  }
+
+  private reserve(map: Map<string, Managed>, workspaceId: string, limit: number): void {
+    const matching = [...map.values()].filter((record) => record.workspaceId === workspaceId);
+    if (matching.length < limit) return;
+    const dependencies = new Set(
+      [...this.tasks.values()]
+        .filter((record) => record.workspaceId === workspaceId && record.status === 'queued')
+        .flatMap((record) => record.dependsOn ?? [])
+    );
+    const evictable = matching
+      .filter((record) => record.status !== 'running' && record.status !== 'queued' && !dependencies.has(record.id))
+      .sort((left, right) => left.createdAt - right.createdAt)[0];
+    if (!evictable) {
+      throw new Error('too many live operation handles in this workspace');
+    }
+    map.delete(evictable.id);
+    this.idempotency.delete(evictable.idempotencyKey);
+  }
+
+  private track(record: Managed, child: ChildProcessWithoutNullStreams, maxBytes: number): void {
+    record.child = child;
+    const append = (chunk: Buffer) => {
+      const next = Buffer.concat([record.output, chunk]);
+      const removed = Math.max(0, next.length - maxBytes);
+      record.offset += removed;
+      record.output = next.subarray(removed);
+      this.enforceOutputBudget(record.workspaceId);
+    };
+
+    child.stdout.on('data', append);
+    child.stderr.on('data', append);
+
+    child.on('close', (code) => {
+      if (record.timer) {
+        clearTimeout(record.timer);
+      }
+      record.exitCode = code ?? 1;
+      if (record.status === 'running') {
+        record.status = code === 0 ? 'succeeded' : 'failed';
+      }
+      this.reconcileQueued(record.workspaceId);
+    });
+
+    child.on('error', () => {
+      if (record.timer) {
+        clearTimeout(record.timer);
+      }
+      record.exitCode = 1;
+      if (record.status === 'running') {
+        record.status = 'failed';
+      }
+      this.reconcileQueued(record.workspaceId);
+    });
+  }
+
+  async execRun(
+    workspaceId: string,
+    command: string,
+    cwdInput?: string,
+    timeoutMs = 60_000,
+    maxBytes = 1_048_576,
+    signal?: AbortSignal
+  ): Promise<{ output: string; exitCode: number; signal?: string; truncated: boolean }> {
+    const cwd = await this.pathPolicy.safeCwd(cwdInput);
+    const shell = resolveShell();
+    const env = {
+      ...buildLocalEnvironment(this.forwardedEnvNames),
+      HARNESS_WORKSPACE_ROOT: this.pathPolicy.canonicalRoot
+    };
+
+    return await new Promise((resolvePromise) => {
+      const child = spawn(shell.bin, shell.args(command), {
+        cwd,
+        env,
+        detached: process.platform !== 'win32',
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+
+      let output = Buffer.alloc(0);
+      let truncated = false;
+
+      const append = (chunk: Buffer) => {
+        const remaining = Math.max(0, maxBytes - output.length);
+        if (chunk.length > remaining) {
+          truncated = true;
+        }
+        if (remaining > 0) {
+          output = Buffer.concat([output, chunk.subarray(0, remaining)]);
+        }
+        if (truncated) {
+          terminateProcess(child);
+        }
+      };
+
+      child.stdout.on('data', append);
+      child.stderr.on('data', append);
+
+      const timer = setTimeout(() => {
+        terminateProcess(child);
+      }, timeoutMs);
+
+      const onAbort = () => {
+        terminateProcess(child);
+      };
+
+      if (signal) {
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+
+      child.on('close', (exitCode, sig) => {
+        clearTimeout(timer);
+        if (signal) {
+          signal.removeEventListener('abort', onAbort);
+        }
+        resolvePromise({
+          output: output.toString('utf8'),
+          exitCode: exitCode ?? 1,
+          ...(sig ? { signal: String(sig) } : {}),
+          truncated
+        });
+      });
+
+      child.on('error', (err) => {
+        clearTimeout(timer);
+        if (signal) {
+          signal.removeEventListener('abort', onAbort);
+        }
+        resolvePromise({
+          output: err.message,
+          exitCode: 1,
+          truncated: false
+        });
+      });
+
+      child.stdin.end();
+    });
+  }
+
+  async openInteractive(
+    map: Map<string, Managed>,
+    prefix: 'sh' | 'sess',
+    kind: 'shell' | 'session',
+    workspaceId: string,
+    cwdInput?: string,
+    key = 'default',
+    maxBytes = 1_048_576,
+    name?: string,
+    command?: string
+  ): Promise<Managed> {
+    const mapKey = `${kind}:${workspaceId}:${key}`;
+    const prior = this.idempotency.get(mapKey);
+    if (prior) {
+      const existing = map.get(prior);
+      if (existing) return existing;
+    }
+
+    this.reserve(map, workspaceId, 32);
+
+    if (
+      name &&
+      [...map.values()].some(
+        (record) => record.workspaceId === workspaceId && record.name === name && record.status === 'running'
+      )
+    ) {
+      throw new Error(`session ${name} is already running`);
+    }
+
+    const cwd = await this.pathPolicy.safeCwd(cwdInput);
+    const shell = resolveShell();
+    const env = {
+      ...buildLocalEnvironment(this.forwardedEnvNames),
+      HARNESS_WORKSPACE_ROOT: this.pathPolicy.canonicalRoot
+    };
+
+    const recordId = id(prefix);
+    const record: Managed = {
+      id: recordId,
+      workspaceId,
+      output: Buffer.alloc(0),
+      offset: 0,
+      status: 'running',
+      createdAt: Date.now(),
+      idempotencyKey: mapKey,
+      cwd,
+      ...(name ? { name } : {})
+    };
+
+    const child = spawn(shell.bin, shell.args(command), {
+      cwd,
+      env,
+      detached: process.platform !== 'win32',
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    map.set(record.id, record);
+    this.idempotency.set(mapKey, record.id);
+    this.track(record, child, maxBytes);
+    return record;
+  }
+
+  async openShell(workspaceId: string, cwd?: string, key = 'default', maxBytes = 1_048_576): Promise<Managed> {
+    return await this.openInteractive(this.shells, 'sh', 'shell', workspaceId, cwd, key, maxBytes);
+  }
+
+  interactiveIo(map: Map<string, Managed>, workspaceId: string, recordId: string, input?: string): Managed {
+    const record = map.get(recordId);
+    if (!record || record.workspaceId !== workspaceId) {
+      throw new Error('interactive session not found');
+    }
+    if (input && record.status === 'running') {
+      record.child?.stdin.write(input);
+    }
+    return record;
+  }
+
+  shellIo(workspaceId: string, shellId: string, input?: string): Managed {
+    return this.interactiveIo(this.shells, workspaceId, shellId, input);
+  }
+
+  closeInteractive(map: Map<string, Managed>, workspaceId: string, recordId: string): Managed {
+    const record = this.interactiveIo(map, workspaceId, recordId);
+    if (record.status !== 'running') {
+      return record;
+    }
+    terminateProcess(record.child);
+    record.status = 'cancelled';
+    record.child?.stdin.end();
+    return record;
+  }
+
+  closeShell(workspaceId: string, shellId: string): Managed {
+    return this.closeInteractive(this.shells, workspaceId, shellId);
+  }
+
+  async openSession(
+    workspaceId: string,
+    name: string,
+    command?: string,
+    cwd?: string,
+    key = 'default',
+    maxBytes = 1_048_576
+  ): Promise<Managed> {
+    return await this.openInteractive(this.sessions, 'sess', 'session', workspaceId, cwd, key, maxBytes, name, command);
+  }
+
+  sessionIo(workspaceId: string, sessionId: string, input?: string): Managed {
+    return this.interactiveIo(this.sessions, workspaceId, sessionId, input);
+  }
+
+  closeSession(workspaceId: string, sessionId: string): Managed {
+    return this.closeInteractive(this.sessions, workspaceId, sessionId);
+  }
+
+  listSessions(workspaceId: string): Managed[] {
+    return [...this.sessions.values()]
+      .filter((record) => record.workspaceId === workspaceId)
+      .sort((left, right) => left.createdAt - right.createdAt);
+  }
+
+  async runTask(
+    workspaceId: string,
+    command: string,
+    cwdInput?: string,
+    key = 'default',
+    timeoutMs = 60_000,
+    maxBytes = 1_048_576,
+    dependsOn: string[] = []
+  ): Promise<Managed> {
+    const mapKey = `task:${workspaceId}:${key}`;
+    const prior = this.idempotency.get(mapKey);
+    if (prior) {
+      const existing = this.tasks.get(prior);
+      if (existing) return existing;
+    }
+
+    this.reserve(this.tasks, workspaceId, 128);
+
+    if (new Set(dependsOn).size !== dependsOn.length) {
+      throw new Error('task dependencies must be unique');
+    }
+    for (const dependencyId of dependsOn) {
+      const dependency = this.tasks.get(dependencyId);
+      if (!dependency || dependency.workspaceId !== workspaceId) {
+        throw new Error(`task dependency ${dependencyId} not found`);
+      }
+    }
+
+    const cwd = await this.pathPolicy.safeCwd(cwdInput);
+
+    const record: Managed = {
+      id: id('task'),
+      workspaceId,
+      output: Buffer.alloc(0),
+      offset: 0,
+      status: 'queued',
+      createdAt: Date.now(),
+      idempotencyKey: mapKey,
+      command,
+      cwd,
+      timeoutMs,
+      maxBytes,
+      dependsOn: [...dependsOn]
+    };
+
+    this.tasks.set(record.id, record);
+    this.idempotency.set(mapKey, record.id);
+    this.reconcileQueued(workspaceId);
+    return record;
+  }
+
+  private startTask(record: Managed): void {
+    const shell = resolveShell();
+    const env = {
+      ...buildLocalEnvironment(this.forwardedEnvNames),
+      HARNESS_WORKSPACE_ROOT: this.pathPolicy.canonicalRoot
+    };
+
+    const child = spawn(shell.bin, shell.args(record.command), {
+      cwd: record.cwd,
+      env,
+      detached: process.platform !== 'win32',
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    child.stdin.end();
+    record.status = 'running';
+    if (record.timeoutMs) {
+      record.timer = setTimeout(() => {
+        terminateProcess(record.child);
+      }, record.timeoutMs);
+    }
+    this.track(record, child, record.maxBytes!);
+  }
+
+  private reconcileQueued(workspaceId: string): void {
+    for (const record of this.tasks.values()) {
+      if (record.workspaceId !== workspaceId || record.status !== 'queued') continue;
+      const dependencies = (record.dependsOn ?? []).map((depId) => this.tasks.get(depId));
+      if (dependencies.some((dep) => !dep || dep.workspaceId !== workspaceId)) {
+        record.status = 'blocked';
+        continue;
+      }
+      if (dependencies.some((dep) => ['failed', 'cancelled', 'blocked'].includes(dep!.status))) {
+        record.status = 'blocked';
+        continue;
+      }
+      if (dependencies.every((dep) => dep!.status === 'succeeded')) {
+        this.startTask(record);
+      }
+    }
+  }
+
+  task(workspaceId: string, taskId: string): Managed {
+    const record = this.tasks.get(taskId);
+    if (!record || record.workspaceId !== workspaceId) {
+      throw new Error('task not found');
+    }
+    return record;
+  }
+
+  listTasks(workspaceId: string): Managed[] {
+    return [...this.tasks.values()]
+      .filter((record) => record.workspaceId === workspaceId)
+      .sort((left, right) => left.createdAt - right.createdAt);
+  }
+
+  taskGraph(workspaceId: string): {
+    nodes: Array<{ id: string; status: ManagedStatus; exitCode?: number; name?: string; dependsOn?: string[] }>;
+    edges: Array<{ from: string; to: string }>;
+  } {
+    const tasks = this.listTasks(workspaceId);
+    return {
+      nodes: tasks.map((record) => this.summary(record)),
+      edges: tasks.flatMap((record) => (record.dependsOn ?? []).map((depId) => ({ from: depId, to: record.id })))
+    };
+  }
+
+  cancelTask(workspaceId: string, taskId: string): Managed {
+    const record = this.task(workspaceId, taskId);
+    if (record.status === 'queued') {
+      record.status = 'cancelled';
+      this.reconcileQueued(workspaceId);
+      return record;
+    }
+    if (record.status !== 'running') {
+      return record;
+    }
+    terminateProcess(record.child);
+    record.status = 'cancelled';
+    this.reconcileQueued(workspaceId);
+    return record;
+  }
+
+  stopWorkspace(workspaceId: string): void {
+    for (const record of this.records(workspaceId)) {
+      if (record.status === 'running' || record.status === 'queued') {
+        record.status = 'cancelled';
+        terminateProcess(record.child);
+      }
+    }
+    for (const [recordId, record] of this.tasks) {
+      if (record.workspaceId === workspaceId) this.tasks.delete(recordId);
+    }
+    for (const [recordId, record] of this.shells) {
+      if (record.workspaceId === workspaceId) this.shells.delete(recordId);
+    }
+    for (const [recordId, record] of this.sessions) {
+      if (record.workspaceId === workspaceId) this.sessions.delete(recordId);
+    }
+    for (const key of this.idempotency.keys()) {
+      if (key.includes(`:${workspaceId}:`)) this.idempotency.delete(key);
+    }
+  }
+
+  view(record: Managed): {
+    id: string;
+    status: ManagedStatus;
+    exitCode?: number;
+    output: string;
+    name?: string;
+    dependsOn?: string[];
+  } {
+    return {
+      id: record.id,
+      status: record.status,
+      ...(record.exitCode !== undefined ? { exitCode: record.exitCode } : {}),
+      output: record.output.toString('utf8'),
+      ...(record.name !== undefined ? { name: record.name } : {}),
+      ...(record.dependsOn !== undefined ? { dependsOn: record.dependsOn } : {})
+    };
+  }
+
+  summary(record: Managed): {
+    id: string;
+    status: ManagedStatus;
+    exitCode?: number;
+    name?: string;
+    dependsOn?: string[];
+  } {
+    return {
+      id: record.id,
+      status: record.status,
+      ...(record.exitCode !== undefined ? { exitCode: record.exitCode } : {}),
+      ...(record.name !== undefined ? { name: record.name } : {}),
+      ...(record.dependsOn !== undefined ? { dependsOn: record.dependsOn } : {})
+    };
+  }
+
+  viewSince(record: Managed, cursor?: string): {
+    data: { id: string; status: ManagedStatus; exitCode?: number; output: string; name?: string; dependsOn?: string[] };
+    cursor: string;
+    truncated: boolean;
+  } {
+    const requested = cursor === undefined ? 0 : Number(cursor);
+    const end = record.offset + record.output.length;
+    if (!Number.isSafeInteger(requested) || requested < 0 || requested > end) {
+      throw new Error('invalid output cursor');
+    }
+    const missedOutput = requested < record.offset;
+    const start = Math.max(0, requested - record.offset);
+    const page = record.output.subarray(start, Math.min(record.output.length, start + 65_536));
+    const nextCursor = record.offset + start + page.length;
+    return {
+      data: { ...this.view(record), output: page.toString('utf8') },
+      cursor: String(nextCursor),
+      truncated: missedOutput || nextCursor < end
+    };
+  }
+}

--- a/apps/api/src/local/local-path-policy.ts
+++ b/apps/api/src/local/local-path-policy.ts
@@ -1,0 +1,88 @@
+import { lstat, realpath } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
+
+export class LocalPathPolicy {
+  constructor(public readonly canonicalRoot: string) {}
+
+  isLexicallySafe(input: string): boolean {
+    const normalized = input.replaceAll('\\', '/');
+    if (
+      normalized.startsWith('/') ||
+      normalized.startsWith('\\') ||
+      /^[A-Za-z]:/.test(normalized) ||
+      normalized.includes('\0')
+    ) {
+      return false;
+    }
+    const segments = normalized.split('/');
+    if (segments.includes('..')) {
+      return false;
+    }
+    return true;
+  }
+
+  async safePath(input: string, allowMissing = false): Promise<string> {
+    if (!this.isLexicallySafe(input)) {
+      throw new Error('path escapes workspace');
+    }
+    const normalized = input.replaceAll('\\', '/');
+    const candidate = resolve(this.canonicalRoot, normalized);
+    if (candidate !== this.canonicalRoot && !candidate.startsWith(`${this.canonicalRoot}${sep}`)) {
+      throw new Error('path escapes workspace');
+    }
+
+    if (!allowMissing) {
+      try {
+        const actual = await realpath(candidate);
+        if (actual !== this.canonicalRoot && !actual.startsWith(`${this.canonicalRoot}${sep}`)) {
+          throw new Error('symlink escapes workspace');
+        }
+        return actual;
+      } catch (error: unknown) {
+        if (error instanceof Error && error.message.includes('escapes workspace')) {
+          throw error;
+        }
+        throw error;
+      }
+    }
+
+    const parent = await realpath(dirname(candidate));
+    if (parent !== this.canonicalRoot && !parent.startsWith(`${this.canonicalRoot}${sep}`)) {
+      throw new Error('parent symlink escapes workspace');
+    }
+    return candidate;
+  }
+
+  async safeEntryPath(input: string, allowMissing = false): Promise<string> {
+    const normalized = input.replaceAll('\\', '/');
+    if (normalized === '.' || !this.isLexicallySafe(normalized)) {
+      throw new Error('path escapes workspace');
+    }
+    const candidate = resolve(this.canonicalRoot, normalized);
+    if (!candidate.startsWith(`${this.canonicalRoot}${sep}`)) {
+      throw new Error('path escapes workspace');
+    }
+    const actualParent = await realpath(dirname(candidate));
+    if (actualParent !== this.canonicalRoot && !actualParent.startsWith(`${this.canonicalRoot}${sep}`)) {
+      throw new Error('parent symlink escapes workspace');
+    }
+    if (!allowMissing) {
+      await lstat(candidate);
+    }
+    return join(actualParent, basename(candidate));
+  }
+
+  async safeCwd(inputCwd?: string): Promise<string> {
+    if (!inputCwd || inputCwd === '.' || inputCwd === './') {
+      return this.canonicalRoot;
+    }
+    if (isAbsolute(inputCwd)) {
+      const actual = await realpath(inputCwd);
+      if (actual !== this.canonicalRoot && !actual.startsWith(`${this.canonicalRoot}${sep}`)) {
+        throw new Error('working directory escapes workspace');
+      }
+      return actual;
+    }
+    return await this.safePath(inputCwd, false);
+  }
+}

--- a/apps/api/src/local/local-worker-client.ts
+++ b/apps/api/src/local/local-worker-client.ts
@@ -1,0 +1,151 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { RunnerOperation, RunnerResponse } from '@cloud-harness/contracts';
+import { buildLocalEnvironment } from './local-environment.js';
+
+function findWorkerScript(): string {
+  const currentDir = typeof __dirname !== 'undefined'
+    ? __dirname
+    : fileURLToPath(new URL('.', import.meta.url));
+
+  const candidates = [
+    resolve(currentDir, '../../../../worker/harness-worker.mjs'),
+    resolve(currentDir, '../../../worker/harness-worker.mjs'),
+    resolve(currentDir, '../../worker/harness-worker.mjs'),
+    resolve(process.cwd(), 'worker/harness-worker.mjs')
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return resolve(process.cwd(), 'worker/harness-worker.mjs');
+}
+
+export class LocalWorkerClient {
+  private readonly workerScript: string;
+
+  constructor(
+    private readonly canonicalRoot: string,
+    workerScriptPath?: string
+  ) {
+    this.workerScript = workerScriptPath ?? findWorkerScript();
+  }
+
+  async call(
+    operation: RunnerOperation,
+    input: Record<string, unknown>,
+    signal?: AbortSignal
+  ): Promise<RunnerResponse> {
+    if (signal?.aborted) {
+      return {
+        ok: false,
+        message: 'operation aborted',
+        error: { code: 'INVALID_INPUT', message: 'operation aborted', retryable: false },
+        truncated: false
+      };
+    }
+
+    return await new Promise<RunnerResponse>((resolvePromise) => {
+      const env = {
+        ...buildLocalEnvironment(),
+        HARNESS_WORKSPACE_ROOT: this.canonicalRoot
+      };
+
+      const child = spawn(process.execPath, [this.workerScript], {
+        cwd: this.canonicalRoot,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+
+      let stdout = Buffer.alloc(0);
+      let stderr = Buffer.alloc(0);
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdout = Buffer.concat([stdout, chunk]);
+      });
+
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr = Buffer.concat([stderr, chunk]);
+      });
+
+      const onAbort = () => {
+        try {
+          child.kill('SIGTERM');
+        } catch {
+          // ignore
+        }
+        setTimeout(() => {
+          try {
+            child.kill('SIGKILL');
+          } catch {
+            // ignore
+          }
+        }, 1000).unref();
+      };
+
+      if (signal) {
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+
+      child.on('close', (exitCode) => {
+        if (signal) {
+          signal.removeEventListener('abort', onAbort);
+        }
+
+        if (signal?.aborted) {
+          resolvePromise({
+            ok: false,
+            message: 'operation aborted',
+            error: { code: 'INVALID_INPUT', message: 'operation aborted', retryable: false },
+            truncated: false
+          });
+          return;
+        }
+
+        if (exitCode !== 0 && stdout.length === 0) {
+          const errText = stderr.toString('utf8').trim() || `worker exited with code ${exitCode}`;
+          resolvePromise({
+            ok: false,
+            message: errText,
+            error: { code: 'INVALID_INPUT', message: errText, retryable: false },
+            truncated: false
+          });
+          return;
+        }
+
+        try {
+          const text = stdout.toString('utf8').trim();
+          const parsed = JSON.parse(text) as RunnerResponse;
+          resolvePromise(parsed);
+        } catch (parseError: unknown) {
+          const msg = parseError instanceof Error ? parseError.message : 'failed to parse worker response';
+          resolvePromise({
+            ok: false,
+            message: msg,
+            error: { code: 'INVALID_INPUT', message: msg, retryable: false },
+            truncated: false
+          });
+        }
+      });
+
+      child.on('error', (err) => {
+        if (signal) {
+          signal.removeEventListener('abort', onAbort);
+        }
+        resolvePromise({
+          ok: false,
+          message: err.message,
+          error: { code: 'INVALID_INPUT', message: err.message, retryable: false },
+          truncated: false
+        });
+      });
+
+      child.stdin.end(JSON.stringify({ operation, input }));
+    });
+  }
+}

--- a/apps/api/src/local/local-workspace-backend.ts
+++ b/apps/api/src/local/local-workspace-backend.ts
@@ -1,0 +1,448 @@
+import { randomBytes } from 'node:crypto';
+import type { RunnerOperation, RunnerResponse } from '@cloud-harness/contracts';
+import type { OperationBackend } from '../operation-backend.js';
+import type { CliOptions } from '../cli-options.js';
+import { LocalPathPolicy } from './local-path-policy.js';
+import { LocalWorkerClient } from './local-worker-client.js';
+import { LocalOperationManager } from './local-operation-manager.js';
+
+const opaqueId = (prefix: string) => `${prefix}_${randomBytes(24).toString('base64url')}`;
+
+export class LocalWorkspaceBackend implements OperationBackend {
+  public readonly workspaceId: string;
+  private status: 'ACTIVE' | 'CLOSED' = 'ACTIVE';
+  private readonly createdAt: number;
+  private lastActivityAt: number;
+  private readonly pathPolicy: LocalPathPolicy;
+  private readonly workerClient: LocalWorkerClient;
+  private readonly operationManager: LocalOperationManager;
+
+  constructor(
+    public readonly canonicalRoot: string,
+    public readonly options: CliOptions,
+    workerScriptPath?: string
+  ) {
+    this.workspaceId = opaqueId('ws_local');
+    this.createdAt = Date.now();
+    this.lastActivityAt = Date.now();
+    this.pathPolicy = new LocalPathPolicy(canonicalRoot);
+    this.workerClient = new LocalWorkerClient(canonicalRoot, workerScriptPath);
+    this.operationManager = new LocalOperationManager(this.pathPolicy, options.env);
+  }
+
+  getInstructions(): string {
+    return `This is a Cloud Harness local stdio workspace. Operations execute against the selected project folder (${this.canonicalRoot}) with host-user permissions. The workspace is already open (workspaceId: "${this.workspaceId}"). Path confinement prevents tool path escapes; commands run with host authority.`;
+  }
+
+  private getPublicRecord() {
+    return {
+      workspaceId: this.workspaceId,
+      repositoryUrl: `local://${this.canonicalRoot}`,
+      ref: 'HEAD',
+      status: this.status,
+      networkMode: this.options.gitNetwork ? 'host' : 'none',
+      createdAt: new Date(this.createdAt).toISOString(),
+      lastActivityAt: new Date(this.lastActivityAt).toISOString(),
+      expiresAt: new Date(Date.now() + 86_400_000 * 365).toISOString()
+    };
+  }
+
+  async close(): Promise<void> {
+    this.status = 'CLOSED';
+    this.operationManager.stopWorkspace(this.workspaceId);
+  }
+
+  async call(
+    operation: RunnerOperation,
+    input: Record<string, unknown>,
+    signal?: AbortSignal
+  ): Promise<RunnerResponse> {
+    this.lastActivityAt = Date.now();
+
+    if (operation === 'workspace_list') {
+      if (this.status === 'CLOSED') {
+        return { ok: true, message: 'Listed 0 workspaces', data: { workspaces: [] }, truncated: false };
+      }
+      return {
+        ok: true,
+        message: 'Listed 1 workspace',
+        data: { workspaces: [this.getPublicRecord()] },
+        truncated: false
+      };
+    }
+
+    if (operation === 'workspace_open') {
+      return {
+        ok: false,
+        message: 'workspace_open is unsupported in local stdio mode because the workspace is selected at startup via --workspace',
+        error: {
+          code: 'INVALID_INPUT',
+          message: 'workspace_open is unsupported in local stdio mode because the workspace is selected at startup via --workspace',
+          retryable: false
+        },
+        truncated: false
+      };
+    }
+
+    if (operation === 'workspace_status') {
+      if (input.workspaceId !== this.workspaceId || this.status === 'CLOSED') {
+        return {
+          ok: false,
+          message: 'workspace not found',
+          error: { code: 'NOT_FOUND', message: 'workspace not found', retryable: false },
+          truncated: false
+        };
+      }
+      return {
+        ok: true,
+        message: 'Workspace status retrieved',
+        data: {
+          ...this.getPublicRecord(),
+          root: this.canonicalRoot,
+          capabilities: {
+            mode: 'local',
+            platform: process.platform,
+            gitNetwork: this.options.gitNetwork,
+            gitPush: this.options.gitPush,
+            sandboxed: false
+          }
+        },
+        truncated: false
+      };
+    }
+
+    if (operation === 'workspace_close') {
+      if (input.workspaceId !== this.workspaceId) {
+        return {
+          ok: false,
+          message: 'workspace not found',
+          error: { code: 'NOT_FOUND', message: 'workspace not found', retryable: false },
+          truncated: false
+        };
+      }
+      await this.close();
+      return {
+        ok: true,
+        message: 'Workspace closed',
+        data: { workspaceId: this.workspaceId, status: 'CLOSED' },
+        truncated: false
+      };
+    }
+
+    if (this.status === 'CLOSED') {
+      return {
+        ok: false,
+        message: 'workspace is closed',
+        error: { code: 'NOT_FOUND', message: 'workspace is closed', retryable: false },
+        truncated: false
+      };
+    }
+
+    if (input.workspaceId !== this.workspaceId) {
+      return {
+        ok: false,
+        message: 'workspace not found',
+        error: { code: 'NOT_FOUND', message: 'workspace not found', retryable: false },
+        truncated: false
+      };
+    }
+
+    if (operation === 'github_action') {
+      return {
+        ok: false,
+        message: 'github_action is unsupported in local mode',
+        error: {
+          code: 'INVALID_INPUT',
+          message: 'github_action is unsupported in local mode',
+          retryable: false
+        },
+        truncated: false
+      };
+    }
+
+    if (operation === 'exec_run') {
+      if (input.privileged === true) {
+        return {
+          ok: false,
+          message: 'privileged execution is unsupported in local mode',
+          error: {
+            code: 'INVALID_INPUT',
+            message: 'privileged execution is unsupported in local mode',
+            retryable: false
+          },
+          truncated: false
+        };
+      }
+      try {
+        const result = await this.operationManager.execRun(
+          this.workspaceId,
+          String(input.command || ''),
+          typeof input.cwd === 'string' ? input.cwd : undefined,
+          typeof input.timeoutMs === 'number' ? input.timeoutMs : 60_000,
+          typeof input.maxOutputBytes === 'number' ? input.maxOutputBytes : 1_048_576,
+          signal
+        );
+        if (result.exitCode !== 0) {
+          const msg = `Command exited with ${result.exitCode}`;
+          return {
+            ok: false,
+            message: msg,
+            data: result,
+            error: { code: 'CONFLICT', message: msg, retryable: false },
+            truncated: result.truncated
+          };
+        }
+        return {
+          ok: true,
+          message: `Command exited with ${result.exitCode}`,
+          data: result,
+          truncated: result.truncated
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'exec_run failed';
+        return {
+          ok: false,
+          message: msg,
+          error: { code: 'INVALID_INPUT', message: msg, retryable: false },
+          truncated: false
+        };
+      }
+    }
+
+    if (operation === 'shell_open') {
+      try {
+        const record = await this.operationManager.openShell(
+          this.workspaceId,
+          typeof input.cwd === 'string' ? input.cwd : undefined,
+          typeof input.idempotencyKey === 'string' ? input.idempotencyKey : 'default',
+          typeof input.maxOutputBytes === 'number' ? input.maxOutputBytes : 1_048_576
+        );
+        return {
+          ok: true,
+          message: 'Shell opened',
+          data: { shellId: record.id, status: record.status },
+          truncated: false
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'shell_open failed';
+        return { ok: false, message: msg, error: { code: 'CONFLICT', message: msg, retryable: false }, truncated: false };
+      }
+    }
+
+    if (operation === 'shell_io') {
+      try {
+        const text = typeof input.input === 'string' ? input.input : '';
+        this.operationManager.shellIo(this.workspaceId, String(input.shellId || ''), text);
+        const record = this.operationManager.shellIo(this.workspaceId, String(input.shellId || ''));
+        const result = this.operationManager.viewSince(record, typeof input.cursor === 'string' ? input.cursor : undefined);
+        return {
+          ok: true,
+          message: 'Shell IO processed',
+          data: result.data,
+          cursor: result.cursor,
+          truncated: result.truncated
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'shell_io failed';
+        return { ok: false, message: msg, error: { code: 'NOT_FOUND', message: msg, retryable: false }, truncated: false };
+      }
+    }
+
+    if (operation === 'shell_close') {
+      try {
+        const record = this.operationManager.closeShell(this.workspaceId, String(input.shellId || ''));
+        return {
+          ok: true,
+          message: 'Shell closed',
+          data: { shellId: record.id, status: record.status },
+          truncated: false
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'shell_close failed';
+        return { ok: false, message: msg, error: { code: 'NOT_FOUND', message: msg, retryable: false }, truncated: false };
+      }
+    }
+
+    if (operation === 'sessions_open') {
+      try {
+        const record = await this.operationManager.openSession(
+          this.workspaceId,
+          String(input.name || ''),
+          typeof input.command === 'string' ? input.command : undefined,
+          typeof input.cwd === 'string' ? input.cwd : undefined,
+          typeof input.idempotencyKey === 'string' ? input.idempotencyKey : 'default',
+          typeof input.maxOutputBytes === 'number' ? input.maxOutputBytes : 1_048_576
+        );
+        return {
+          ok: true,
+          message: 'Session started',
+          data: { sessionId: record.id, status: record.status },
+          truncated: false
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'sessions_open failed';
+        return { ok: false, message: msg, error: { code: 'CONFLICT', message: msg, retryable: false }, truncated: false };
+      }
+    }
+
+    if (operation === 'sessions_io') {
+      try {
+        const text = typeof input.input === 'string' ? input.input : '';
+        this.operationManager.sessionIo(this.workspaceId, String(input.sessionId || ''), text);
+        const record = this.operationManager.sessionIo(this.workspaceId, String(input.sessionId || ''));
+        const result = this.operationManager.viewSince(record, typeof input.cursor === 'string' ? input.cursor : undefined);
+        return {
+          ok: true,
+          message: 'Session output retrieved',
+          data: result.data,
+          cursor: result.cursor,
+          truncated: result.truncated
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'sessions_io failed';
+        return { ok: false, message: msg, error: { code: 'NOT_FOUND', message: msg, retryable: false }, truncated: false };
+      }
+    }
+
+    if (operation === 'sessions_close') {
+      try {
+        const record = this.operationManager.closeSession(this.workspaceId, String(input.sessionId || ''));
+        return {
+          ok: true,
+          message: 'Session closed',
+          data: { sessionId: record.id, status: record.status },
+          truncated: false
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'sessions_close failed';
+        return { ok: false, message: msg, error: { code: 'NOT_FOUND', message: msg, retryable: false }, truncated: false };
+      }
+    }
+
+    if (operation === 'sessions_list') {
+      const sessions = this.operationManager.listSessions(this.workspaceId);
+      return {
+        ok: true,
+        message: `Found ${sessions.length} sessions`,
+        data: { sessions: sessions.map((s) => this.operationManager.view(s)) },
+        truncated: false
+      };
+    }
+
+    if (operation === 'tasks_run') {
+      try {
+        const record = await this.operationManager.runTask(
+          this.workspaceId,
+          String(input.command || ''),
+          typeof input.cwd === 'string' ? input.cwd : undefined,
+          typeof input.idempotencyKey === 'string' ? input.idempotencyKey : 'default',
+          typeof input.timeoutMs === 'number' ? input.timeoutMs : 60_000,
+          typeof input.maxOutputBytes === 'number' ? input.maxOutputBytes : 1_048_576,
+          Array.isArray(input.dependsOn) ? (input.dependsOn as string[]) : []
+        );
+        return {
+          ok: true,
+          message: 'Task queued',
+          data: { taskId: record.id, status: record.status },
+          truncated: false
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'tasks_run failed';
+        return { ok: false, message: msg, error: { code: 'INVALID_INPUT', message: msg, retryable: false }, truncated: false };
+      }
+    }
+
+    if (operation === 'tasks_status') {
+      try {
+        const record = this.operationManager.task(this.workspaceId, String(input.taskId || ''));
+        if (input.cursor !== undefined) {
+          const result = this.operationManager.viewSince(record, typeof input.cursor === 'string' ? input.cursor : undefined);
+          return {
+            ok: true,
+            message: 'Task status retrieved',
+            data: result.data,
+            cursor: result.cursor,
+            truncated: result.truncated
+          };
+        }
+        return {
+          ok: true,
+          message: 'Task status retrieved',
+          data: this.operationManager.view(record),
+          truncated: false
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'tasks_status failed';
+        return { ok: false, message: msg, error: { code: 'NOT_FOUND', message: msg, retryable: false }, truncated: false };
+      }
+    }
+
+    if (operation === 'tasks_cancel') {
+      try {
+        const record = this.operationManager.cancelTask(this.workspaceId, String(input.taskId || ''));
+        return {
+          ok: true,
+          message: 'Task cancelled',
+          data: { taskId: record.id, status: record.status },
+          truncated: false
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'tasks_cancel failed';
+        return { ok: false, message: msg, error: { code: 'NOT_FOUND', message: msg, retryable: false }, truncated: false };
+      }
+    }
+
+    if (operation === 'tasks_list') {
+      const tasks = this.operationManager.listTasks(this.workspaceId);
+      return {
+        ok: true,
+        message: `Found ${tasks.length} tasks`,
+        data: { tasks: tasks.map((t) => this.operationManager.view(t)) },
+        truncated: false
+      };
+    }
+
+    if (operation === 'tasks_graph') {
+      const graph = this.operationManager.taskGraph(this.workspaceId);
+      return {
+        ok: true,
+        message: 'Task graph retrieved',
+        data: graph,
+        truncated: false
+      };
+    }
+
+    if (operation === 'git_fetch' || operation === 'git_pull') {
+      if (!this.options.gitNetwork) {
+        return {
+          ok: false,
+          message: 'network Git operations are disabled in local mode; pass --git-network to enable',
+          error: {
+            code: 'FORBIDDEN',
+            message: 'network Git operations are disabled in local mode; pass --git-network to enable',
+            retryable: false
+          },
+          truncated: false
+        };
+      }
+    }
+
+    if (operation === 'git_push') {
+      if (!this.options.gitPush) {
+        return {
+          ok: false,
+          message: 'Git push operations are disabled in local mode; pass --git-push to enable',
+          error: {
+            code: 'FORBIDDEN',
+            message: 'Git push operations are disabled in local mode; pass --git-push to enable',
+            retryable: false
+          },
+          truncated: false
+        };
+      }
+    }
+
+    // Forward file, search, symbol, git, memory, hook, deployment operations to local worker
+    return await this.workerClient.call(operation, input, signal);
+  }
+}

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1,7 +1,15 @@
 import { McpServer, type CallToolResult, type McpRequestContext } from '@modelcontextprotocol/server';
-import { TOOL_SPECS, ToolResultSchema, type RunnerPrincipalSelector, type ToolResult } from '@cloud-harness/contracts';
+import {
+  TOOL_SPECS,
+  ToolResultSchema,
+  type RunnerOperation,
+  type RunnerPrincipalSelector,
+  type RunnerResponse,
+  type ToolResult
+} from '@cloud-harness/contracts';
 import { principalFromAuthInfo } from './auth.js';
-import type { RunnerClient } from './runner-client.js';
+import { RunnerClient } from './runner-client.js';
+import type { OperationBackend } from './operation-backend.js';
 
 function resultToMcp(result: ToolResult): CallToolResult {
   return {
@@ -11,18 +19,56 @@ function resultToMcp(result: ToolResult): CallToolResult {
   };
 }
 
-export function createCloudHarnessServer(client: RunnerClient, principal?: RunnerPrincipalSelector): McpServer {
+export class RunnerOperationBackend implements OperationBackend {
+  constructor(
+    private readonly client: RunnerClient,
+    private readonly principal?: RunnerPrincipalSelector
+  ) {}
+
+  async call(operation: RunnerOperation, input: Record<string, unknown>, signal?: AbortSignal): Promise<RunnerResponse> {
+    if (!this.principal) {
+      return {
+        ok: false,
+        message: 'Authentication context unavailable',
+        error: { code: 'AUTHENTICATION_FAILED', message: 'Authentication context unavailable', retryable: false },
+        truncated: false
+      };
+    }
+    return await this.client.call(operation, input, this.principal, signal);
+  }
+}
+
+const DEFAULT_INSTRUCTIONS = 'Open an owner-bound workspace first, pass its opaque workspaceId to later tools, and close it when finished.';
+
+export function createCloudHarnessServer(
+  backendOrClient: OperationBackend | RunnerClient,
+  principalOrInstructions?: RunnerPrincipalSelector | string,
+  maybeInstructions?: string
+): McpServer {
+  let backend: OperationBackend;
+  let instructions = DEFAULT_INSTRUCTIONS;
+
+  if (backendOrClient instanceof RunnerClient) {
+    const principal = typeof principalOrInstructions === 'object' && principalOrInstructions !== null ? principalOrInstructions : undefined;
+    instructions = typeof maybeInstructions === 'string' ? maybeInstructions : (typeof principalOrInstructions === 'string' ? principalOrInstructions : DEFAULT_INSTRUCTIONS);
+    backend = new RunnerOperationBackend(backendOrClient, principal);
+  } else {
+    backend = backendOrClient;
+    instructions = typeof principalOrInstructions === 'string' ? principalOrInstructions : (backend.getInstructions?.() ?? DEFAULT_INSTRUCTIONS);
+  }
+
   const server = new McpServer(
     { name: 'cloud-harness-mcp', version: '0.19.2' },
-    { instructions: 'Open an owner-bound workspace first, pass its opaque workspaceId to later tools, and close it when finished.' }
+    { instructions }
   );
+
   for (const spec of TOOL_SPECS) {
     server.registerTool(
       spec.name,
       {
         title: spec.title,
         description: spec.description,
-        inputSchema: spec.inputSchema as any,
+        inputSchema: spec.inputSchema,
         outputSchema: ToolResultSchema,
         annotations: {
           readOnlyHint: spec.readOnly,
@@ -32,8 +78,7 @@ export function createCloudHarnessServer(client: RunnerClient, principal?: Runne
         }
       },
       async (input, context) => {
-        if (!principal) return resultToMcp({ ok: false, message: 'Authentication context unavailable', error: { code: 'AUTHENTICATION_FAILED', message: 'Authentication context unavailable', retryable: false }, truncated: false });
-        return resultToMcp(await client.call(spec.name, input as Record<string, unknown>, principal, context.mcpReq.signal));
+        return resultToMcp(await backend.call(spec.name, input as Record<string, unknown>, context.mcpReq.signal));
       }
     );
   }
@@ -41,5 +86,5 @@ export function createCloudHarnessServer(client: RunnerClient, principal?: Runne
 }
 
 export function createCloudHarnessServerFactory(client: RunnerClient): (context: McpRequestContext) => McpServer {
-  return (context) => createCloudHarnessServer(client, principalFromAuthInfo(context.authInfo));
+  return (context) => createCloudHarnessServer(new RunnerOperationBackend(client, principalFromAuthInfo(context.authInfo)));
 }

--- a/apps/api/src/operation-backend.ts
+++ b/apps/api/src/operation-backend.ts
@@ -1,0 +1,11 @@
+import type { RunnerOperation, RunnerResponse } from '@cloud-harness/contracts';
+
+export interface OperationBackend {
+  call(
+    operation: RunnerOperation,
+    input: Record<string, unknown>,
+    signal?: AbortSignal
+  ): Promise<RunnerResponse>;
+  getInstructions?(): string;
+  close?(): Promise<void>;
+}

--- a/apps/api/test/cli-options.test.ts
+++ b/apps/api/test/cli-options.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import { getCliHelp, parseCliOptions } from '../src/cli-options.js';
+
+describe('parseCliOptions', () => {
+  it('defaults to http transport with no flags', () => {
+    const result = parseCliOptions([]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.options.transport).toBe('http');
+      expect(result.options.workspace).toBeUndefined();
+      expect(result.options.gitNetwork).toBe(false);
+      expect(result.options.gitPush).toBe(false);
+      expect(result.options.env).toEqual([]);
+      expect(result.options.help).toBe(false);
+      expect(result.options.version).toBe(false);
+    }
+  });
+
+  it('parses valid stdio transport with absolute workspace', () => {
+    const ws = process.platform === 'win32' ? 'C:\\projects\\my-app' : '/home/user/projects/my-app';
+    const result = parseCliOptions(['--transport', 'stdio', '--workspace', ws]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.options.transport).toBe('stdio');
+      expect(result.options.workspace).toBe(ws);
+      expect(result.options.gitNetwork).toBe(false);
+      expect(result.options.gitPush).toBe(false);
+    }
+  });
+
+  it('parses inline format (--transport=stdio --workspace=/path)', () => {
+    const ws = process.platform === 'win32' ? 'C:\\projects\\my-app' : '/home/user/projects/my-app';
+    const result = parseCliOptions([`--transport=stdio`, `--workspace=${ws}`]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.options.transport).toBe('stdio');
+      expect(result.options.workspace).toBe(ws);
+    }
+  });
+
+  it('parses git capabilities and environment forwarding', () => {
+    const ws = process.platform === 'win32' ? 'C:\\projects\\my-app' : '/home/user/projects/my-app';
+    const result = parseCliOptions([
+      '--transport', 'stdio',
+      '--workspace', ws,
+      '--git-network',
+      '--git-push',
+      '--env', 'GITHUB_TOKEN',
+      '--env', 'NPM_TOKEN'
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.options.gitNetwork).toBe(true);
+      expect(result.options.gitPush).toBe(true);
+      expect(result.options.env).toEqual(['GITHUB_TOKEN', 'NPM_TOKEN']);
+    }
+  });
+
+  it('auto-enables gitNetwork when gitPush is enabled', () => {
+    const ws = process.platform === 'win32' ? 'C:\\projects\\my-app' : '/home/user/projects/my-app';
+    const result = parseCliOptions(['--transport', 'stdio', '--workspace', ws, '--git-push']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.options.gitNetwork).toBe(true);
+      expect(result.options.gitPush).toBe(true);
+    }
+  });
+
+  it('rejects stdio transport without --workspace', () => {
+    const result = parseCliOptions(['--transport', 'stdio']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('stdio transport requires an explicit --workspace');
+    }
+  });
+
+  it('rejects relative workspace path for stdio', () => {
+    const result = parseCliOptions(['--transport', 'stdio', '--workspace', './relative/path']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('must be absolute');
+    }
+  });
+
+  it('rejects --workspace with http transport', () => {
+    const ws = process.platform === 'win32' ? 'C:\\projects\\my-app' : '/home/user/projects/my-app';
+    const result = parseCliOptions(['--transport', 'http', '--workspace', ws]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('--workspace is only supported with --transport stdio');
+    }
+  });
+
+  it('rejects invalid transport option', () => {
+    const result = parseCliOptions(['--transport', 'websocket']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('invalid transport');
+    }
+  });
+
+  it('rejects missing argument for --transport', () => {
+    const result = parseCliOptions(['--transport']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('missing argument for --transport');
+    }
+  });
+
+  it('rejects missing argument for --workspace', () => {
+    const result = parseCliOptions(['--workspace']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('missing argument for --workspace');
+    }
+  });
+
+  it('rejects missing argument for --env', () => {
+    const result = parseCliOptions(['--env']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('missing argument for --env');
+    }
+  });
+
+  it('rejects unknown options', () => {
+    const result = parseCliOptions(['--invalid-flag']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('unknown option: "--invalid-flag"');
+    }
+  });
+
+  it('rejects unexpected positional arguments', () => {
+    const result = parseCliOptions(['foo']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('unexpected argument: "foo"');
+    }
+  });
+
+  it('handles help and version flags', () => {
+    const helpResult = parseCliOptions(['--help']);
+    expect(helpResult.ok).toBe(true);
+    if (helpResult.ok) expect(helpResult.options.help).toBe(true);
+
+    const versionResult = parseCliOptions(['-v']);
+    expect(versionResult.ok).toBe(true);
+    if (versionResult.ok) expect(versionResult.options.version).toBe(true);
+  });
+
+  it('generates help text containing all options', () => {
+    const help = getCliHelp();
+    expect(help).toContain('--transport');
+    expect(help).toContain('--workspace');
+    expect(help).toContain('--git-network');
+    expect(help).toContain('--git-push');
+    expect(help).toContain('--env');
+  });
+});

--- a/apps/api/test/local/local-environment.test.ts
+++ b/apps/api/test/local/local-environment.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildLocalEnvironment, isReservedName, isSecretName } from '../../src/local/local-environment.js';
+
+describe('local-environment', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.PATH = '/usr/bin:/bin';
+    process.env.HOME = '/home/testuser';
+    process.env.USER = 'testuser';
+    process.env.MCP_BEARER_TOKEN = 'secret-mcp-bearer';
+    process.env.RUNNER_SERVICE_TOKEN = 'secret-runner-token';
+    process.env.GITHUB_APP_PRIVATE_KEY = 'secret-private-key';
+    process.env.SESSION_SECRET = 'secret-session';
+    process.env.CUSTOM_TEST_VAR = 'custom-value';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('preserves allowlisted system variables', () => {
+    const env = buildLocalEnvironment();
+    expect(env.PATH).toBe('/usr/bin:/bin');
+    expect(env.HOME).toBe('/home/testuser');
+    expect(env.USER).toBe('testuser');
+  });
+
+  it('scrubs Cloud Harness and API/runner secrets', () => {
+    const env = buildLocalEnvironment();
+    expect(env.MCP_BEARER_TOKEN).toBeUndefined();
+    expect(env.RUNNER_SERVICE_TOKEN).toBeUndefined();
+    expect(env.GITHUB_APP_PRIVATE_KEY).toBeUndefined();
+    expect(env.SESSION_SECRET).toBeUndefined();
+  });
+
+  it('forwards explicitly requested environment names', () => {
+    const env = buildLocalEnvironment(['CUSTOM_TEST_VAR']);
+    expect(env.CUSTOM_TEST_VAR).toBe('custom-value');
+  });
+
+  it('refuses to forward secret names even if requested', () => {
+    const env = buildLocalEnvironment(['MCP_BEARER_TOKEN', 'GITHUB_APP_PRIVATE_KEY']);
+    expect(env.MCP_BEARER_TOKEN).toBeUndefined();
+    expect(env.GITHUB_APP_PRIVATE_KEY).toBeUndefined();
+  });
+
+  it('refuses to forward reserved control prefixes', () => {
+    process.env.HARNESS_OVERRIDE = 'evil';
+    process.env.CH_INJECT = 'evil';
+
+    const env = buildLocalEnvironment(['HARNESS_OVERRIDE', 'CH_INJECT']);
+    expect(env.HARNESS_OVERRIDE).toBeUndefined();
+    expect(env.CH_INJECT).toBeUndefined();
+  });
+
+  it('injects standard git control variables', () => {
+    const env = buildLocalEnvironment();
+    expect(env.GIT_CONFIG_NOSYSTEM).toBe('1');
+    expect(env.GIT_TERMINAL_PROMPT).toBe('0');
+    expect(env.GIT_PAGER).toBe('cat');
+    expect(env.PAGER).toBe('cat');
+  });
+
+  it('correctly identifies secret patterns and reserved prefixes', () => {
+    expect(isSecretName('MCP_BEARER_TOKEN')).toBe(true);
+    expect(isSecretName('GITHUB_APP_ID')).toBe(true);
+    expect(isSecretName('DATABASE_URL')).toBe(true);
+    expect(isSecretName('PATH')).toBe(false);
+
+    expect(isReservedName('HARNESS_WORKSPACE_ROOT')).toBe(true);
+    expect(isReservedName('CH_COMMAND')).toBe(true);
+    expect(isReservedName('NODE_ENV')).toBe(false);
+  });
+});

--- a/apps/api/test/local/local-path-policy.test.ts
+++ b/apps/api/test/local/local-path-policy.test.ts
@@ -1,0 +1,105 @@
+import { mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LocalPathPolicy } from '../../src/local/local-path-policy.js';
+
+describe('LocalPathPolicy', () => {
+  let tempRoot: string;
+  let canonicalRoot: string;
+  let policy: LocalPathPolicy;
+
+  beforeEach(async () => {
+    tempRoot = join(tmpdir(), `ch-path-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(tempRoot, { recursive: true });
+    canonicalRoot = await realpath(tempRoot);
+    policy = new LocalPathPolicy(canonicalRoot);
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(tempRoot, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('validates safe relative paths within workspace', async () => {
+    const filePath = join(canonicalRoot, 'file.txt');
+    await writeFile(filePath, 'hello');
+
+    const resolved = await policy.safePath('file.txt');
+    expect(resolved).toBe(filePath);
+  });
+
+  it('validates nested safe paths within workspace', async () => {
+    const subDir = join(canonicalRoot, 'src', 'components');
+    await mkdir(subDir, { recursive: true });
+    const filePath = join(subDir, 'Button.tsx');
+    await writeFile(filePath, 'export const Button = () => null;');
+
+    const resolved = await policy.safePath('src/components/Button.tsx');
+    expect(resolved).toBe(filePath);
+  });
+
+  it('rejects lexical directory traversal escapes', async () => {
+    await expect(policy.safePath('../outside.txt')).rejects.toThrow('path escapes workspace');
+    await expect(policy.safePath('src/../../outside.txt')).rejects.toThrow('path escapes workspace');
+  });
+
+  it('rejects absolute paths', async () => {
+    await expect(policy.safePath('/etc/passwd')).rejects.toThrow('path escapes workspace');
+    if (process.platform === 'win32') {
+      await expect(policy.safePath('C:\\Windows\\notepad.exe')).rejects.toThrow('path escapes workspace');
+    }
+  });
+
+  it('rejects null byte in path', async () => {
+    await expect(policy.safePath('file.txt\0.js')).rejects.toThrow('path escapes workspace');
+  });
+
+  it('handles allowMissing for target creation', async () => {
+    const nonExistent = await policy.safePath('new-file.txt', true);
+    expect(nonExistent).toBe(join(canonicalRoot, 'new-file.txt'));
+
+    const subDir = join(canonicalRoot, 'nested');
+    await mkdir(subDir, { recursive: true });
+    const nestedNonExistent = await policy.safePath('nested/new-file.txt', true);
+    expect(nestedNonExistent).toBe(join(canonicalRoot, 'nested', 'new-file.txt'));
+  });
+
+  it('rejects allowMissing when parent does not exist or escapes', async () => {
+    await expect(policy.safePath('nonexistent-parent/file.txt', true)).rejects.toThrow();
+  });
+
+  it('detects symlink escape pointing outside workspace', async () => {
+    const outsideDir = join(tmpdir(), `ch-outside-${Date.now()}`);
+    await mkdir(outsideDir, { recursive: true });
+    const outsideFile = join(outsideDir, 'secret.txt');
+    await writeFile(outsideFile, 'secret content');
+
+    const linkPath = join(canonicalRoot, 'escape-link');
+    try {
+      await symlink(outsideFile, linkPath);
+      await expect(policy.safePath('escape-link')).rejects.toThrow('symlink escapes workspace');
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+        // Windows symlinks require developer mode/admin
+        return;
+      }
+      throw err;
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('validates safeCwd defaulting to root and checking subdirectories', async () => {
+    expect(await policy.safeCwd()).toBe(canonicalRoot);
+    expect(await policy.safeCwd('.')).toBe(canonicalRoot);
+    expect(await policy.safeCwd('./')).toBe(canonicalRoot);
+
+    const subDir = join(canonicalRoot, 'src');
+    await mkdir(subDir, { recursive: true });
+    expect(await policy.safeCwd('src')).toBe(subDir);
+  });
+});

--- a/apps/api/test/local/local-workspace-backend.test.ts
+++ b/apps/api/test/local/local-workspace-backend.test.ts
@@ -1,0 +1,243 @@
+import { mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { LocalWorkspaceBackend } from '../../src/local/local-workspace-backend.js';
+import type { CliOptions } from '../../src/cli-options.js';
+
+const WorkspaceListSchema = z.object({
+  workspaces: z.array(z.object({ workspaceId: z.string() }))
+});
+
+const WorkspaceStatusSchema = z.object({
+  workspaceId: z.string(),
+  status: z.string(),
+  capabilities: z.object({
+    mode: z.string(),
+    gitNetwork: z.boolean()
+  })
+});
+
+const ExecRunDataSchema = z.object({
+  output: z.string(),
+  exitCode: z.number()
+});
+
+const FileReadDataSchema = z.object({
+  content: z.string()
+});
+
+const TaskRunDataSchema = z.object({
+  taskId: z.string()
+});
+
+const TaskGraphDataSchema = z.object({
+  nodes: z.array(z.unknown()),
+  edges: z.array(z.object({ from: z.string(), to: z.string() }))
+});
+
+const WorkspaceCloseDataSchema = z.object({
+  status: z.string()
+});
+
+describe('LocalWorkspaceBackend', () => {
+  let tempRoot: string;
+  let canonicalRoot: string;
+  let defaultOptions: CliOptions;
+  let backend: LocalWorkspaceBackend;
+
+  beforeEach(async () => {
+    tempRoot = join(tmpdir(), `ch-backend-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(tempRoot, { recursive: true });
+    canonicalRoot = await realpath(tempRoot);
+
+    defaultOptions = {
+      transport: 'stdio',
+      workspace: canonicalRoot,
+      gitNetwork: false,
+      gitPush: false,
+      env: [],
+      help: false,
+      version: false
+    };
+
+    backend = new LocalWorkspaceBackend(canonicalRoot, defaultOptions);
+  });
+
+  afterEach(async () => {
+    await backend.close();
+    try {
+      await rm(tempRoot, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('provides instructions with workspaceId and host-authority notice', () => {
+    const instructions = backend.getInstructions();
+    expect(instructions).toContain(backend.workspaceId);
+    expect(instructions).toContain('host-user permissions');
+    expect(instructions).toContain('already open');
+  });
+
+  it('rejects workspace_open with clear local stdio message', async () => {
+    const response = await backend.call('workspace_open', {
+      repositoryUrl: 'https://github.com/example/repo',
+      idempotencyKey: 'key-1'
+    });
+    expect(response.ok).toBe(false);
+    expect(response.message).toContain('workspace_open is unsupported in local stdio mode');
+  });
+
+  it('handles workspace_list and workspace_status', async () => {
+    const listRes = await backend.call('workspace_list', {});
+    expect(listRes.ok).toBe(true);
+    const listData = WorkspaceListSchema.parse(listRes.data);
+    expect(listData.workspaces).toHaveLength(1);
+    expect(listData.workspaces[0]?.workspaceId).toBe(backend.workspaceId);
+
+    const statusRes = await backend.call('workspace_status', { workspaceId: backend.workspaceId });
+    expect(statusRes.ok).toBe(true);
+    const statusData = WorkspaceStatusSchema.parse(statusRes.data);
+    expect(statusData.workspaceId).toBe(backend.workspaceId);
+    expect(statusData.status).toBe('ACTIVE');
+    expect(statusData.capabilities.mode).toBe('local');
+    expect(statusData.capabilities.gitNetwork).toBe(false);
+  });
+
+  it('closes workspace idempotently and preserves local directory contents', async () => {
+    const testFile = join(canonicalRoot, 'sentinel.txt');
+    await writeFile(testFile, 'sentinel content');
+
+    const closeRes = await backend.call('workspace_close', { workspaceId: backend.workspaceId });
+    expect(closeRes.ok).toBe(true);
+    const closeData = WorkspaceCloseDataSchema.parse(closeRes.data);
+    expect(closeData.status).toBe('CLOSED');
+
+    // Verify local file is NOT deleted!
+    const fileContent = await readFile(testFile, 'utf8');
+    expect(fileContent).toBe('sentinel content');
+
+    // Subsequent workspace_list returns 0
+    const listAfter = await backend.call('workspace_list', {});
+    const listAfterData = WorkspaceListSchema.parse(listAfter.data);
+    expect(listAfterData.workspaces).toHaveLength(0);
+
+    // Operations after close fail
+    const statusAfter = await backend.call('workspace_status', { workspaceId: backend.workspaceId });
+    expect(statusAfter.ok).toBe(false);
+  });
+
+  it('rejects github_action and privileged exec in local mode', async () => {
+    const ghRes = await backend.call('github_action', {
+      workspaceId: backend.workspaceId,
+      action: 'pr_list'
+    });
+    expect(ghRes.ok).toBe(false);
+    expect(ghRes.message).toContain('github_action is unsupported in local mode');
+
+    const privRes = await backend.call('exec_run', {
+      workspaceId: backend.workspaceId,
+      command: 'echo hello',
+      privileged: true
+    });
+    expect(privRes.ok).toBe(false);
+    expect(privRes.message).toContain('privileged execution is unsupported in local mode');
+  });
+
+  it('executes bounded non-privileged exec_run', async () => {
+    const res = await backend.call('exec_run', {
+      workspaceId: backend.workspaceId,
+      command: process.platform === 'win32' ? 'echo hello' : 'echo "hello from local exec"'
+    });
+    expect(res.ok).toBe(true);
+    const execData = ExecRunDataSchema.parse(res.data);
+    expect(execData.exitCode).toBe(0);
+    expect(execData.output).toContain('hello');
+  });
+
+  it('gates network Git and push according to startup options', async () => {
+    // Disabled by default
+    const fetchRes = await backend.call('git_fetch', { workspaceId: backend.workspaceId });
+    expect(fetchRes.ok).toBe(false);
+    expect(fetchRes.message).toContain('network Git operations are disabled in local mode');
+
+    const pushRes = await backend.call('git_push', { workspaceId: backend.workspaceId });
+    expect(pushRes.ok).toBe(false);
+    expect(pushRes.message).toContain('Git push operations are disabled in local mode');
+
+    // With network enabled
+    const networkBackend = new LocalWorkspaceBackend(canonicalRoot, {
+      ...defaultOptions,
+      gitNetwork: true,
+      gitPush: false
+    });
+    try {
+      const pushGatedRes = await networkBackend.call('git_push', { workspaceId: networkBackend.workspaceId });
+      expect(pushGatedRes.ok).toBe(false);
+      expect(pushGatedRes.message).toContain('Git push operations are disabled in local mode');
+    } finally {
+      await networkBackend.close();
+    }
+  });
+
+  it('supports tasks with dependency resolution and status tracking', async () => {
+    const task1 = await backend.call('tasks_run', {
+      workspaceId: backend.workspaceId,
+      command: process.platform === 'win32' ? 'echo task 1' : 'echo "task 1"',
+      idempotencyKey: 'task-key-1'
+    });
+    expect(task1.ok).toBe(true);
+    const task1Data = TaskRunDataSchema.parse(task1.data);
+    const taskId1 = task1Data.taskId;
+
+    const task2 = await backend.call('tasks_run', {
+      workspaceId: backend.workspaceId,
+      command: process.platform === 'win32' ? 'echo task 2' : 'echo "task 2"',
+      idempotencyKey: 'task-key-2',
+      dependsOn: [taskId1]
+    });
+    expect(task2.ok).toBe(true);
+    const task2Data = TaskRunDataSchema.parse(task2.data);
+    const taskId2 = task2Data.taskId;
+
+    const graphRes = await backend.call('tasks_graph', { workspaceId: backend.workspaceId });
+    expect(graphRes.ok).toBe(true);
+    const graphData = TaskGraphDataSchema.parse(graphRes.data);
+    expect(graphData.nodes.length).toBeGreaterThanOrEqual(2);
+    expect(graphData.edges).toContainEqual({ from: taskId1, to: taskId2 });
+  });
+
+  it('performs file read/write/patch operations against local folder via worker', async () => {
+    const writeRes = await backend.call('files_write', {
+      workspaceId: backend.workspaceId,
+      path: 'test.txt',
+      content: 'initial content'
+    });
+    expect(writeRes.ok).toBe(true);
+
+    const readRes = await backend.call('files_read', {
+      workspaceId: backend.workspaceId,
+      path: 'test.txt'
+    });
+    expect(readRes.ok).toBe(true);
+    const readData = FileReadDataSchema.parse(readRes.data);
+    expect(readData.content).toBe('initial content');
+
+    const patchRes = await backend.call('files_apply_patch', {
+      workspaceId: backend.workspaceId,
+      path: 'test.txt',
+      oldText: 'initial',
+      newText: 'updated'
+    });
+    expect(patchRes.ok).toBe(true);
+
+    const readPatched = await backend.call('files_read', {
+      workspaceId: backend.workspaceId,
+      path: 'test.txt'
+    });
+    const readPatchedData = FileReadDataSchema.parse(readPatched.data);
+    expect(readPatchedData.content).toBe('updated content');
+  });
+});

--- a/docs-site/connect.md
+++ b/docs-site/connect.md
@@ -37,6 +37,19 @@ Cloud Harness MCP provides two distinct connection lanes over **Streamable HTTP 
 | **Key Expiry** | Session bound | 1–365 days (configurable) |
 | **Max Keys per Identity** | N/A | 10 active keys |
 
+
+---
+
+## Local Stdio Mode
+
+In addition to remote Streamable HTTP, Cloud Harness MCP can run locally over **stdio** against a selected folder:
+
+```bash
+cloud-harness-mcp --transport stdio --workspace /absolute/path/to/project
+```
+
+Local mode exposes the full tool surface directly to the local folder with host-user authority. Closing the workspace terminates processes without deleting the project folder.
+
 ---
 
 ## Managing API Keys

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,6 +31,14 @@ npm test
 npm run build
 ```
 
+### Running local stdio mode
+
+After building packages with `npm run build`, you can test local stdio mode directly:
+
+```bash
+node apps/api/dist/index.js --transport stdio --workspace /path/to/test-folder
+```
+
 ## Skill and plugin packaging
 
 The installable `cloudharness` skill is authored under

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -142,6 +142,16 @@ makes a lost response recoverable without duplicating work.
 Tool annotations inform client approval UX. They do not replace review of the
 command, repository, network mode, or workspace changes.
 
+## Local stdio mode semantics
+
+When running Cloud Harness MCP over local stdio (`--transport stdio --workspace <path>`):
+
+1. **Pre-opened workspace:** The workspace is configured at process startup. Calling `workspace_open` returns `INVALID_INPUT` explaining that the workspace is already selected.
+2. **Lifecycle operations:** `workspace_list` lists the active local workspace. `workspace_status` returns capabilities (`mode: 'local'`, `gitNetwork`, `gitPush`, `sandboxed: false`). `workspace_close` terminates owned child processes but **never deletes the local folder**.
+3. **Subprocess execution:** `exec_run`, `shell_*`, `sessions_*`, and `tasks_*` execute on the local host with the current user's permissions. Output is bounded by ring buffers and paginated with monotonic cursors.
+4. **Gated capabilities:** `git_fetch` and `git_pull` require `--git-network`. `git_push` requires `--git-push`. `github_action` and `exec_run.privileged=true` return structured unsupported errors.
+5. **Filesystem operations:** File reading, writing, patching, deletion, and searching apply within the canonical workspace root. Traversal escapes are rejected.
+
 ## Repository opening policy
 
 The runner accepts credential-free HTTPS URLs on configured allowlisted hosts,

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -224,3 +224,43 @@ Close/TTL removes the executor and workspace directory. Shell/session/task
 state is in-memory and disappears on runner restart. Startup restarts surviving
 executors to stop processes whose handles were lost; this remains a durability
 limitation, not a security guarantee.
+
+## Local stdio security model
+
+Local stdio mode intentionally alters the trust boundary compared to the remote Docker executor:
+
+### Host authority vs Docker isolation
+
+- Commands executed in local mode (`exec_run`, shells, sessions, tasks) run with the authority of the current host user.
+- File path confinement ensures that tool-supplied file paths and working directories cannot resolve outside the canonical workspace root.
+- **Path confinement is not an OS command sandbox.** A command running under `exec_run` or in a shell can still access anything accessible to the host user. Never claim local stdio mode is a sandboxed environment.
+
+### Filesystem confinement policy
+
+- The workspace root is canonicalized once at startup from the `--workspace` argument using `realpath`.
+- Relative paths, lexical traversal (`..`), absolute paths, and null bytes are rejected before resolution.
+- Symlinks are resolved against the canonical root; attempts to escape via symlinks or parent symlinks fail with a structured error.
+- `workspace_close` is terminal and idempotent: it terminates child processes and marks the workspace closed, but **never deletes or modifies the user's project folder**.
+
+### Environment curation and secret isolation
+
+- Child subprocesses do not inherit the complete host environment.
+- An allowlist provides standard system variables (`PATH`, `HOME`, `USER`, `SHELL`, `LANG`, etc.).
+- Cloud Harness tokens, bearer secrets, GitHub App credentials, session secrets, and database URLs are actively scrubbed.
+- Reserved control prefixes (`HARNESS_*`, `CH_*`) cannot be overridden by tool input.
+- Additional host environment variables can be explicitly forwarded via `--env <NAME>`.
+
+### Process cleanup
+
+- Local long-running children are launched in POSIX process groups.
+- Cancellation, workspace close, signal receipt (SIGINT, SIGTERM), and process exit trigger process-group termination (`SIGTERM` followed by a grace period and `SIGKILL` escalation).
+
+### Network Git and push opt-ins
+
+- Network Git operations (`git_fetch`, `git_pull`) and Git push (`git_push`) are disabled by default in local mode.
+- Enabling them requires explicit startup flags (`--git-network` and `--git-push`).
+- Local Git operations use the user's existing checkout configuration and credentials only when authorized by these flags.
+
+### Unsupported capabilities
+
+- `exec_run` with `privileged: true` and `github_action` are unsupported in local v1 and return immediate structured capability errors.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -58,6 +58,18 @@ temporary network access and an optional token. This split exists so remote
 repository synchronization does not put long-lived credentials in the
 repository executor.
 
+## Composition roots and transports
+
+Cloud Harness MCP supports two distinct composition roots sharing the same public `TOOL_SPECS` and result envelopes:
+
+1. **Streamable HTTP mode (default):**
+   `cloud-harness-mcp --transport http` (or default without flags).
+   Assembles Express routes, bearer/Access authentication, and translates requests through `RunnerClient` to the isolated Docker runner on a private network.
+
+2. **Local stdio mode:**
+   `cloud-harness-mcp --transport stdio --workspace <path>`.
+   Assembles `serveStdio` directly connected to `LocalWorkspaceBackend`. Binds to one canonical local project directory, manages host subprocesses via `LocalOperationManager`, and parameterizes `worker/harness-worker.mjs` via `HARNESS_WORKSPACE_ROOT`.
+
 Executable owners:
 
 - Loopback-to-frontend byte proxy:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.19.2",
   "private": true,
   "type": "module",
+  "bin": {
+    "cloud-harness-mcp": "./apps/api/dist/index.js"
+  },
   "engines": {
     "node": ">=24.0.0"
   },
@@ -18,8 +21,11 @@
     "dev:runner": "npm run dev -w @cloud-harness/runner",
     "lint": "eslint .",
     "typecheck": "npm run build -w @cloud-harness/contracts && npm run typecheck -w @cloud-harness/api && npm run typecheck -w @cloud-harness/runner && npm run typecheck -w @cloud-harness/api-key-gateway",
+    "pretest": "npm run build -w @cloud-harness/contracts && npm run build -w @cloud-harness/api",
     "test": "vitest run --exclude '**/*.docker.test.ts' --no-file-parallelism",
+    "pretest:unit": "npm run build -w @cloud-harness/contracts",
     "test:unit": "vitest run packages apps --exclude '**/*.docker.test.ts'",
+    "pretest:integration": "npm run build -w @cloud-harness/contracts && npm run build -w @cloud-harness/api",
     "test:integration": "vitest run test/integration --exclude '**/*.docker.test.ts'",
     "pretest:docker": "npm run build -w @cloud-harness/contracts",
     "test:docker": "vitest run test/integration/docker-sandbox.docker.test.ts test/integration/git-transfer-helper.docker.test.ts test/integration/gh-helper.docker.test.ts --testTimeout=120000",

--- a/plans/2026-08-24-33-stdio-local-workspace/phase-01-shared-operation-boundary-and-transport-cli.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/phase-01-shared-operation-boundary-and-transport-cli.md
@@ -1,0 +1,115 @@
+---
+phase: 1
+title: "Shared operation boundary and transport CLI"
+status: pending
+priority: P1
+effort: "2-3d"
+dependencies: []
+---
+
+# Phase 1: Shared operation boundary and transport CLI
+
+## Context links
+
+- Parent plan: [plan.md](./plan.md)
+- Research: [research findings](./research/research-findings.md)
+- Issue: https://github.com/bestagentkits/cloud-harness-mcp/issues/33
+- MCP SDK stdio guidance: https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/serving/stdio.md
+
+## Overview
+
+Separate MCP tool registration from the remote runner transport, then add a transport-selecting command-line entry point. This phase must produce a working stdio handshake backed by a test double while leaving HTTP startup, authentication, and runner calls unchanged.
+
+## Requirements
+
+- Keep one registration path based on `TOOL_SPECS`; do not copy or filter tool definitions by mode.
+- Replace the concrete `RunnerClient` dependency in the shared server factory with a narrow abort-aware operation backend.
+- Bind the authenticated principal only in the HTTP adapter.
+- Default to the existing HTTP server when `--transport` is absent.
+- Require an absolute `--workspace` only for stdio; reject contradictory or unknown flags before server startup.
+- Do not load remote-only secrets/configuration on the stdio path.
+- Reserve stdout exclusively for MCP frames; route diagnostics and help failures to stderr.
+- Close the transport/backend on SIGINT, SIGTERM, EOF, startup failure, and normal process completion.
+
+## Architecture and contracts
+
+Introduce an interface equivalent to:
+
+```ts
+interface OperationBackend {
+  call(
+    operation: OperationName,
+    input: unknown,
+    signal?: AbortSignal,
+  ): Promise<RunnerResponse>;
+  getInstructions?(): string;
+  close?(): Promise<void>;
+}
+```
+
+The exact types should come from existing contracts rather than new lookalikes. The runner-backed implementation captures the request principal at construction time and delegates to the existing `RunnerClient.call`. Dashboard code keeps using `RunnerClient` directly.
+
+The CLI selects one of two composition roots:
+
+- HTTP/default: existing config → authenticated request → runner-backed adapter → shared MCP server.
+- stdio: validated CLI options → local backend factory (implemented in Phase 2) → `serveStdio` → shared MCP server.
+
+## Related code files
+
+Create:
+
+- `apps/api/src/operation-backend.ts`
+- `apps/api/src/cli-options.ts`
+- Focused CLI/backend tests under `apps/api/test/`
+- A stdio integration fixture under `test/integration/`
+
+Modify:
+
+- `apps/api/src/mcp-server.ts`
+- `apps/api/src/runner-client.ts`
+- `apps/api/src/index.ts`
+- `apps/api/src/app.ts` only if typed factory construction requires it
+- `apps/api/package.json`
+- Root `package.json`
+- Existing MCP principal-context and runner-client tests affected by the seam
+
+## Implementation steps
+
+1. Derive the operation name/input/result types from `packages/contracts` and define the smallest backend interface needed by MCP registration.
+2. Refactor `createCloudHarnessServer` to accept that interface and optional mode instructions; keep every `TOOL_SPECS` registration and annotation unchanged.
+3. Implement a runner-backed adapter that closes over the authenticated principal and preserves timeout, abort, validation, and error-envelope behavior.
+4. Add a pure CLI parser for `--transport http|stdio`, `--workspace`, local Git capability flags, and repeated environment-forwarding flags. Make validation independently testable.
+5. Split startup before remote config loading. Preserve the current HTTP composition root byte-for-byte where practical and invoke the local factory only for stdio.
+6. Wire the SDK's stdio helper so stdout is protocol-only. Add stderr logging and one idempotent shutdown coordinator that closes transport and backend exactly once.
+7. Add a package `bin` entry and repository script that can execute the built CLI. Do not add registry publication in this issue.
+8. Update type-level and integration fixtures for the new constructor without weakening HTTP assertions.
+
+## Todo
+
+- [ ] Shared backend interface uses existing contract types.
+- [ ] HTTP principal is bound outside the shared server factory.
+- [ ] CLI parser validates mode-specific flags and absolute workspace paths.
+- [ ] HTTP remains the no-flag default.
+- [ ] stdio startup does not require runner/API secrets.
+- [ ] stdout protocol hygiene and idempotent shutdown are tested.
+- [ ] Repository-local binary invocation works after build.
+
+## Tests and validation
+
+- Unit: CLI defaults, valid stdio options, relative/missing workspace, unknown transport, incompatible flags, repeated env flags.
+- Unit: all `TOOL_SPECS` names and annotations are registered through both composition roots.
+- Unit: abort signals and structured backend errors propagate unchanged.
+- Integration: use `StdioClientTransport` against the built binary and complete initialize/list-tools/call-tool.
+- Regression: existing `mcp-http`, principal-context, runner-client, config, and package build tests remain green.
+- Hygiene: capture child stdout and fail on any non-protocol diagnostic.
+
+## Success criteria
+
+- A test client negotiates with the stdio binary without requiring deployed credentials.
+- Existing HTTP tests pass without changed public behavior.
+- There is exactly one shared tool-registration implementation and one source of tool schemas.
+- The stdio process shuts down cleanly on client close and OS signals.
+
+## Risks and rollback
+
+The largest risk is accidental HTTP behavior drift while moving dependencies. Keep the runner adapter thin and land this phase before local operations. If stdio composition proves unstable, the adapter refactor can remain while the `bin` entry and stdio branch are reverted without contract changes.

--- a/plans/2026-08-24-33-stdio-local-workspace/phase-01-shared-operation-boundary-and-transport-cli.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/phase-01-shared-operation-boundary-and-transport-cli.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Shared operation boundary and transport CLI"
-status: pending
+status: completed
 priority: P1
 effort: "2-3d"
 dependencies: []

--- a/plans/2026-08-24-33-stdio-local-workspace/phase-02-local-lifecycle-and-filesystem-confinement.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/phase-02-local-lifecycle-and-filesystem-confinement.md
@@ -1,0 +1,116 @@
+---
+phase: 2
+title: "Local lifecycle and filesystem confinement"
+status: pending
+priority: P1
+effort: "2-3d"
+dependencies: [1]
+---
+
+# Phase 2: Local lifecycle and filesystem confinement
+
+## Context links
+
+- Parent plan: [plan.md](./plan.md)
+- Security research: [research findings](./research/research-findings.md)
+- Red-team review: [red-team review](./reports/red-team-review.md)
+- Node filesystem API: https://nodejs.org/api/fs.html
+
+## Overview
+
+Implement one implicit, pre-opened local workspace and safely reuse the existing worker for file/search/symbol operations. The workspace root comes only from trusted CLI startup configuration, is canonicalized once, and is never cloned, uploaded, or deleted.
+
+## Requirements
+
+- Support Linux and macOS in v1; fail fast with an explicit unsupported-platform message on Windows.
+- Resolve `--workspace` to an existing directory and store its canonical real path before serving MCP requests.
+- Generate an opaque workspace ID and require it on every operation that currently requires `workspaceId`.
+- Define local lifecycle behavior: list/status expose the one workspace, open returns a mode capability error, and close is terminal/idempotent.
+- Never feed the selected root into remote runner cleanup or recursive deletion.
+- Keep schema-level relative-path checks and add operation-time containment checks for symlinks and concurrent filesystem changes.
+- Parameterize the worker root from trusted process configuration while retaining `/workspace` as the container default.
+- Preserve bounded outputs, cursors, patch semantics, and structured result envelopes.
+
+## Lifecycle state model
+
+```text
+starting -> ready -> closing -> closed
+                 \-> failed
+```
+
+- `workspace_list`: returns zero or one local workspace according to terminal state.
+- `workspace_status`: validates the opaque ID and returns mode, canonical root metadata safe to expose, platform, capabilities, and lifecycle.
+- `workspace_open`: returns a structured `UNSUPPORTED_IN_LOCAL_MODE` error explaining that startup already selected the root.
+- `workspace_close`: stops owned operations, marks closed, and never removes root contents. Repeated calls return the same terminal result.
+- All other operations after close fail deterministically without reopening the root.
+
+## Path policy
+
+For every path-bearing operation:
+
+1. Retain the contract's lexical rejection of absolute paths and `..`.
+2. Resolve the existing target, or the nearest existing parent for creates, against the canonical root.
+3. Use `lstat`/realpath checks so symlinks cannot resolve outside the root.
+4. Prefer direct-open operations and `O_NOFOLLOW` for the final component where Node/platform support allows; do not rely on check-then-open alone.
+5. Re-check containment after mkdir, write, patch, move, and copy operations that create or replace entries.
+6. Return a stable structured confinement error without leaking unrelated host paths.
+
+Document that these checks confine file-tool targets and command working directories; they do not sandbox command contents.
+
+## Related code files
+
+Create:
+
+- `apps/api/src/local/local-workspace-backend.ts`
+- `apps/api/src/local/local-worker-client.ts`
+- `apps/api/src/local/local-path-policy.ts`
+- Local backend/path-policy tests under `apps/api/test/local/`
+
+Modify:
+
+- `worker/harness-worker.mjs`
+- `apps/api/src/index.ts`
+- Shared result/capability types only if existing contracts cannot express the mode error
+- Existing worker/path tests and fixtures
+
+## Implementation steps
+
+1. Validate platform and startup root, canonicalize it, capture stable identity metadata, and create the local workspace state object.
+2. Implement the lifecycle dispatch table before ordinary operations. Do not instantiate or call `WorkspaceService`.
+3. Define a local capability descriptor/instruction string that names host execution, unsupported privileged/GitHub actions, and Git opt-ins.
+4. Extract or wrap worker startup so `HARNESS_WORKSPACE_ROOT` (or an equivalent trusted channel) selects the root, with `/workspace` as the unchanged default.
+5. Ensure the root value cannot be supplied or overridden by a tool request or forwarded child environment.
+6. Implement centralized local path-policy helpers and apply them to worker operations rather than adding ad hoc checks per tool.
+7. Preserve current byte/output limits, cursors, encoding checks, patch validation, search caps, and error normalization.
+8. Add deterministic tests for symlink escapes and rename/symlink swaps using test synchronization hooks, not timing-only races.
+9. Verify close/shutdown leaves a sentinel file and the entire selected directory intact.
+
+## Todo
+
+- [ ] POSIX-only startup boundary is explicit.
+- [ ] Root is canonicalized once from CLI configuration.
+- [ ] Opaque ID and lifecycle operations behave deterministically.
+- [ ] Local close has no filesystem deletion path.
+- [ ] Worker root is configurable only through trusted startup state.
+- [ ] All path-bearing handlers use the centralized confinement policy.
+- [ ] Existing Docker worker continues to default to `/workspace`.
+
+## Tests and validation
+
+- Unit: nonexistent path, file instead of directory, relative path, symlinked startup root, spaces and Unicode in root.
+- Unit: unknown/wrong workspace IDs; open/list/status/close; repeated close; operation-after-close.
+- Security: `../`, absolute paths, interior symlink escape, final-component symlink, broken link, symlink swap during read/write/move/copy.
+- Behavior: read/write/edit/patch/search/symbol operations remain bounded and compatible.
+- Safety: sentinel tree before and after close/signal is byte-identical except for intentional tool edits.
+- Regression: worker Docker tests prove absent root configuration still selects `/workspace`.
+
+## Success criteria
+
+- A local stdio client can inspect and edit files inside a folder containing spaces.
+- Every tested path escape returns a structured error and changes nothing outside the root.
+- Closing or crashing the backend never deletes, uploads, clones, or relocates the selected folder.
+- Remote Docker workspace lifecycle remains unchanged.
+
+## Risks and rollback
+
+Filesystem race resistance varies by platform and filesystem. Limit v1 to POSIX, prefer descriptor-based operations, and keep the trust boundary documented. If worker parameterization regresses Docker mode, revert the environment-root hook and temporarily place a local-only wrapper around the worker while preserving the lifecycle/path tests.

--- a/plans/2026-08-24-33-stdio-local-workspace/phase-02-local-lifecycle-and-filesystem-confinement.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/phase-02-local-lifecycle-and-filesystem-confinement.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Local lifecycle and filesystem confinement"
-status: pending
+status: completed
 priority: P1
 effort: "2-3d"
 dependencies: [1]

--- a/plans/2026-08-24-33-stdio-local-workspace/phase-03-local-processes-git-and-repository-extensions.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/phase-03-local-processes-git-and-repository-extensions.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "Local processes, Git, and repository extensions"
-status: pending
+status: completed
 priority: P1
 effort: "2-4d"
 dependencies: [2]

--- a/plans/2026-08-24-33-stdio-local-workspace/phase-03-local-processes-git-and-repository-extensions.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/phase-03-local-processes-git-and-repository-extensions.md
@@ -1,0 +1,120 @@
+---
+phase: 3
+title: "Local processes, Git, and repository extensions"
+status: pending
+priority: P1
+effort: "2-4d"
+dependencies: [2]
+---
+
+# Phase 3: Local processes, Git, and repository extensions
+
+## Context links
+
+- Parent plan: [plan.md](./plan.md)
+- Codebase ownership: [scout report](./reports/scout-report.md)
+- Threat review: [red-team review](./reports/red-team-review.md)
+- Node child-process API: https://nodejs.org/api/child_process.html
+
+## Overview
+
+Add host-side execution for bounded commands, shells, named sessions, tasks, applicable Git operations, worktrees, and repository extensions. Match remote result/state semantics where they are meaningful, while exposing local security and capability differences instead of routing through Docker assumptions.
+
+## Requirements
+
+- Run commands as the current host user; never claim OS-level sandboxing.
+- Confine only tool-supplied paths and `cwd`; command text remains capable of accessing the user's host authority.
+- Launch owned long-running processes in POSIX process groups, retain handles/output cursors, and terminate descendants on cancellation, close, signals, and normal shutdown.
+- Use TERM → bounded grace period → KILL, then reconcile handles and terminal states.
+- Build child environments from a documented allowlist. Scrub Cloud Harness/API/runner/broker secrets and never inherit the entire parent environment.
+- Permit extra environment names only via explicit startup flags; prevent overriding reserved control variables.
+- Reject `exec_run.privileged=true` in local v1.
+- Allow local-only Git operations in Git roots. Network fetch/pull/clone require one startup opt-in; push requires a separate stronger opt-in.
+- Use the user's existing credential mechanism only when the matching Git opt-in is enabled; do not copy or persist credentials.
+- Register `github_action` through the shared schema but return an explicit unsupported-capability error in local v1.
+- Non-Git roots must retain all non-Git functionality and return structured Git-specific errors.
+
+## Process model
+
+Implement a local manager parallel to, or behind a shared behavioral interface with, the Docker operation manager. Reuse semantics—not Docker launch mechanics—for:
+
+- opaque handle generation and workspace ownership;
+- per-stream bounded ring buffers and cursor reads;
+- maximum concurrent handles and task dependencies;
+- cancellation, timeout, exit code/signal, and terminal-state reporting;
+- idempotent stop/close and garbage collection.
+
+On POSIX, start long-running children as process-group leaders and signal the negative PID after verifying ownership. Never use broad process-name matching. Short `exec_run` commands still need timeout/cancellation cleanup of descendants.
+
+## Capability matrix
+
+| Capability | Local v1 behavior |
+|---|---|
+| Bounded exec | Supported as host user |
+| Privileged exec | Structured unsupported error |
+| Shell/session/task | Supported with owned process groups |
+| Local Git/status/diff/commit/worktree | Supported in Git folders |
+| Fetch/pull/clone | Disabled unless local network Git flag is set |
+| Push | Disabled unless both network and push flags are set |
+| Brokered `github_action` | Structured unsupported error |
+| Skills/hooks/memory/deployments | Supported where current worker contract applies; documented as repository-controlled host code |
+
+## Related code files
+
+Create:
+
+- `apps/api/src/local/local-operation-manager.ts`
+- `apps/api/src/local/local-environment.ts`
+- Process/environment tests under `apps/api/test/local/`
+
+Modify:
+
+- `apps/api/src/local/local-workspace-backend.ts`
+- `apps/api/src/local/local-worker-client.ts`
+- `worker/harness-worker.mjs`
+- CLI option/help tests from Phase 1
+- Integration fixtures for processes, Git, and repository extensions
+
+## Implementation steps
+
+1. Translate existing handle/state/output invariants into a local operation-manager interface without importing Docker command builders or container IDs.
+2. Implement bounded stdout/stderr capture with monotonic cursors, concurrency limits, timeout and abort propagation.
+3. Launch process groups and implement verified owner-only TERM/KILL cleanup. Reconcile direct-child and group outcomes into stable terminal records.
+4. Centralize child-environment construction: baseline allowlist, secret denylist, explicitly forwarded names, fixed root/control variables, and test-visible redaction.
+5. Route `exec_run`, shell, session, and task operations through the local manager; apply path policy to every `cwd`.
+6. Enforce dependency scheduling, stop behavior, close behavior, and output bounds consistent with remote contracts.
+7. Route worker-supported local Git/worktree/repository-extension operations through the parameterized worker.
+8. Gate network Git and push before process spawn. Surface disabled capability, non-Git root, authentication failure, and remote failure distinctly.
+9. Reject privileged execution and `github_action` before any subprocess or network access.
+10. Exercise hook/skill/deployment commands with the curated environment and add host-authority warnings to local server instructions.
+
+## Todo
+
+- [ ] Local process handles/cursors match public response contracts.
+- [ ] Descendant cleanup is proven for exec, shell, session, and task paths.
+- [ ] Environment forwarding is allowlisted and reserved names cannot be overridden.
+- [ ] Privileged and brokered GitHub actions cannot execute locally.
+- [ ] Network Git and push require separate startup authorization.
+- [ ] Non-Git roots remain usable for non-Git tools.
+- [ ] Repository extensions clearly inherit host-user authority.
+
+## Tests and validation
+
+- Process: success/failure/timeout/cancel, stdout and stderr truncation, cursor pagination, concurrent limit, task dependencies.
+- Cleanup: spawn a child and grandchild, close/cancel/signal, verify the owned process group is gone and unrelated processes survive.
+- Environment: allowed baseline values available; known control-secret patterns absent; requested extra name forwarded; reserved names rejected.
+- Security: `privileged=true` and `github_action` perform no spawn/network side effect.
+- Git: non-Git root, clean/dirty status, diff/add/commit/worktree, disabled fetch, enabled fetch, disabled push, explicitly enabled push using test-only credentials.
+- Repository extensions: representative skill/hook/memory/deployment flows preserve bounds and use the local root.
+
+## Success criteria
+
+- No owned child or grandchild remains after workspace close or server shutdown.
+- Result envelopes, handle state, and cursors remain compatible with the remote tool contract.
+- Secret/environment and Git authorization tests demonstrate least-privilege defaults.
+- Unsupported capabilities fail early with actionable local-mode messages.
+- Non-Git folders support the full non-Git subset.
+
+## Risks and rollback
+
+Host execution is inherently higher authority than Docker execution. Keep the local manager isolated from remote code and make every authority-expanding flag visible in help and status. If long-running lifecycle cannot meet cleanup guarantees, ship only bounded exec behind an experimental flag rather than silently leaving process support partial.

--- a/plans/2026-08-24-33-stdio-local-workspace/phase-04-interop-tests-documentation-and-release-readiness.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/phase-04-interop-tests-documentation-and-release-readiness.md
@@ -1,7 +1,7 @@
 ---
 phase: 4
 title: "Interop tests, documentation, and release readiness"
-status: pending
+status: completed
 priority: P2
 effort: "2d"
 dependencies: [1, 2, 3]

--- a/plans/2026-08-24-33-stdio-local-workspace/phase-04-interop-tests-documentation-and-release-readiness.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/phase-04-interop-tests-documentation-and-release-readiness.md
@@ -1,0 +1,99 @@
+---
+phase: 4
+title: "Interop tests, documentation, and release readiness"
+status: pending
+priority: P2
+effort: "2d"
+dependencies: [1, 2, 3]
+---
+
+# Phase 4: Interop tests, documentation, and release readiness
+
+## Context links
+
+- Parent plan: [plan.md](./plan.md)
+- Codex MCP configuration: https://developers.openai.com/codex/mcp
+- Claude MCP configuration: https://code.claude.com/docs/en/mcp
+- Cursor MCP configuration: https://docs.cursor.com/context/model-context-protocol
+- MCP SDK package guidance: https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/get-started/packages.md
+
+## Overview
+
+Prove interoperability and backward compatibility, document the local trust boundary and client setup, and make the repository-local CLI ready for maintainer review. This phase does not publish an npm package.
+
+## Requirements
+
+- Exercise the built stdio binary through the official MCP client transport, not only direct backend calls.
+- Verify current protocol negotiation and the repository's supported legacy negotiation path.
+- Ensure stdout stays protocol-only under success, warning, tool error, and shutdown paths.
+- Cover the full lifecycle and capability matrix with representative tools rather than duplicating every unit test at end-to-end level.
+- Run the existing HTTP and remote Docker regression suites unchanged when prerequisites are available.
+- Document exact commands/configuration for Claude Code/Desktop, Cursor, and Codex.
+- State prominently that direct local commands run with host-user permissions and that file-path confinement is not a command sandbox.
+- Document default-disabled network Git/push, environment forwarding, POSIX-v1 status, unsupported privileged/GitHub actions, and close-without-delete behavior.
+- Keep CLI publication/versioning out of scope; document repository-local and installed-package invocation separately if both are supported.
+
+## Documentation targets
+
+Modify the smallest owning sections in:
+
+- `README.md`
+- `docs/system-architecture.md`
+- `docs/security-model.md`
+- `docs/mcp-api.md`
+- `docs/development.md`
+- Relevant installation, AI-tool, security, and reference pages under `docs-site/`
+
+Generated tool references must continue to derive from `TOOL_SPECS`. Do not hand-maintain a second local-mode schema list; document only capability differences.
+
+## Implementation steps
+
+1. Build an integration harness using `StdioClientTransport` that spawns the packaged CLI in a temporary directory containing spaces.
+2. Test initialize, instructions, tool listing/annotations, representative file/search/exec/process/Git calls, close, and process exit.
+3. Run negotiation tests for the current protocol version and supported legacy client behavior already covered by HTTP.
+4. Add assertions that stdout contains only MCP JSON-RPC frames and stderr contains human diagnostics.
+5. Add shutdown suites for client EOF, workspace close, SIGINT, SIGTERM, cancellation, and startup error; verify the selected root and sentinel files survive.
+6. Add remote-regression assertions: no-flag startup remains HTTP, HTTP auth/principal behavior is unchanged, and Docker worker root remains `/workspace`.
+7. Document CLI usage, flag authority, lifecycle/capability matrix, threat boundary, troubleshooting, and uninstall/cleanup behavior.
+8. Add tested configuration snippets for:
+   - Codex `codex mcp add <name> -- <command> ...` and `[mcp_servers.<name>]`.
+   - Claude `claude mcp add --transport stdio ...` and JSON configuration.
+   - Cursor `.cursor/mcp.json` with `command` and `args`.
+9. Run docs link/code-snippet checks and verify every external configuration claim against the linked primary documentation.
+10. Run the full repository verification pipeline and record unavailable environment-gated tests honestly in the implementation PR.
+
+## Todo
+
+- [ ] Official stdio client exercises the built CLI end to end.
+- [ ] Modern and supported legacy negotiation are covered.
+- [ ] Protocol hygiene and every shutdown path are asserted.
+- [ ] HTTP and Docker regressions remain green.
+- [ ] User and architecture/security docs explain local authority accurately.
+- [ ] Claude, Cursor, and Codex examples are verified.
+- [ ] Packaging works locally; publication remains out of scope.
+- [ ] Full verification results are recorded for review.
+
+## Tests and validation
+
+Run in increasing scope:
+
+1. Focused API/local unit tests.
+2. Stdio integration suite with temporary Git and non-Git roots.
+3. Existing HTTP integration and contract suites.
+4. Package typecheck, lint, build, and docs checks.
+5. `npm run verify`.
+6. Docker/E2E workflow when Docker and broker prerequisites are available.
+
+Include leak checks after the suite for owned child processes and temporary roots. Fail tests if the CLI logs non-protocol bytes to stdout or deletes the selected root.
+
+## Success criteria
+
+- The documented Codex, Claude, and Cursor configurations start the same built stdio binary.
+- All shared tool names and annotations match HTTP mode.
+- Security and lifecycle documentation match tested behavior, including no-delete close and host authority.
+- `npm run verify` passes; any prerequisite-gated Docker/E2E result is explicitly recorded.
+- Maintainers can review implementation without a hidden release/publication step.
+
+## Risks and rollback
+
+Interop examples can drift as client products evolve, so link primary docs and keep one executable smoke fixture as the authority. If one client requires product-specific wrapping, document the wrapper without changing the shared MCP contract. A failed publication concern does not block this issue because repository-local packaging, not registry release, is the acceptance boundary.

--- a/plans/2026-08-24-33-stdio-local-workspace/plan.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/plan.md
@@ -1,0 +1,99 @@
+---
+title: "Stdio transport and local-folder workspace"
+description: "Add a local stdio execution mode that reuses the Cloud Harness MCP contract while preserving the remote HTTP/Docker security boundary."
+status: pending
+priority: P2
+effort: "8-12d"
+issue: 33
+branch: docs/issue-33-stdio-local-workspace-plan
+tags: [feature, mcp, cli, security, local-workspace]
+blockedBy: []
+blocks: []
+created: 2026-08-24
+---
+
+# Stdio transport and local-folder workspace
+
+## Overview
+
+Implement issue #33 as a second transport/execution mode: the deployed HTTP path remains API → runner → Docker, while a locally spawned stdio process operates on exactly one startup-selected folder. Keep `TOOL_SPECS` and result envelopes shared; make lifecycle and unsupported capabilities explicit instead of pretending local host execution has the remote sandbox.
+
+Research: [findings](./research/research-findings.md) · [codebase scout](./reports/scout-report.md) · [red-team review](./reports/red-team-review.md)
+
+## Scope
+
+In scope:
+
+- `cloud-harness-mcp --transport stdio --workspace <absolute-path>`.
+- One implicit pre-opened local workspace with an opaque ID.
+- Shared tool schemas, annotations, result envelopes, output bounds, and cursor semantics.
+- Local file/search/symbol/exec/session/task/applicable Git/repository-extension tools.
+- Path confinement, environment scrubbing, process-group cleanup, stdio protocol hygiene, tests, and user docs.
+- Backward-compatible HTTP default and unchanged Compose/security topology.
+
+Not in scope:
+
+- Uploading or cloning the selected local folder.
+- Claiming host execution is sandboxed.
+- A containerized local executor, multi-root access, Windows process semantics, npm registry publication, or changes to deployed authentication.
+- Local `github_action` support in v1; register the shared tool but return an explicit mode capability error.
+
+## Proposed architecture
+
+```mermaid
+flowchart LR
+  CLI[Transport-selecting CLI] -->|http, default| HTTP[Existing HTTP app]
+  CLI -->|stdio + fixed root| STDIO[serveStdio]
+  HTTP --> Shared[Shared MCP server factory]
+  STDIO --> Shared
+  Shared --> Remote[Runner-backed operation adapter]
+  Shared --> Local[LocalWorkspaceBackend]
+  Remote --> Runner[Runner + Docker workspace]
+  Local --> Worker[Existing worker with canonical local root]
+  Local --> Processes[Local shell/session/task manager]
+```
+
+Key decisions awaiting review:
+
+1. Local mode is implicit and pre-opened. `workspace_open` returns a clear mode error; list/status/close remain available.
+2. Local `workspace_close` is terminal and idempotent: terminate owned processes, mark closed, never delete or rewrite the selected root.
+3. POSIX (Linux/macOS) is the v1 target. Windows is a follow-up because process-group termination and `O_NOFOLLOW` differ.
+4. Local network Git is opt-in; push requires a stronger explicit opt-in. Existing local checkout credentials are used only under that opt-in.
+5. `privileged=true` and brokered `github_action` are unsupported in local v1 and return structured capability errors.
+6. Commands run with host-user authority. Only tool paths and command working directories are confined; command contents can still access anything the user can.
+
+## Cross-plan dependencies
+
+No blocking overlap was found among pending plans. Coordinate documentation edits with `plans/260819-1652-cloud-harness-docs-site` and preserve the remote runner roadmap in `plans/260817-0848-2-cloud-harness-next-steps`; neither blocks this plan.
+
+## Phases
+
+| Phase | Name | Status | Depends on |
+|---|---|---|---|
+| 1 | [Shared operation boundary and transport CLI](./phase-01-shared-operation-boundary-and-transport-cli.md) | Pending | None |
+| 2 | [Local lifecycle and filesystem confinement](./phase-02-local-lifecycle-and-filesystem-confinement.md) | Pending | Phase 1 |
+| 3 | [Local processes, Git, and repository extensions](./phase-03-local-processes-git-and-repository-extensions.md) | Pending | Phase 2 |
+| 4 | [Interop tests, documentation, and release readiness](./phase-04-interop-tests-documentation-and-release-readiness.md) | Pending | Phases 1-3 |
+
+## Acceptance criteria
+
+- [ ] `cloud-harness-mcp --transport stdio --workspace <absolute-path>` starts a protocol-clean stdio server.
+- [ ] HTTP remains the default and existing HTTP, Compose, auth, runner, broker, and Docker behavior is unchanged.
+- [ ] The local root is canonicalized once; file operations and command `cwd` reject absolute paths, traversal, and symlink escape.
+- [ ] The selected folder is never cloned, uploaded, or deleted by close/shutdown.
+- [ ] File, patch, search, symbol, exec, shell, session, task, applicable Git, worktree, skill, hook, memory, and deployment behavior uses shared schemas and bounded results.
+- [ ] Non-Git folders keep non-Git tools usable and return structured errors for Git tools.
+- [ ] Local subprocesses receive a curated environment, are tracked by PID/process group, and are terminated on close, cancellation, signal, and normal shutdown.
+- [ ] stdout contains only MCP frames; all diagnostics use stderr.
+- [ ] Local capability differences are explicit in instructions/status/errors.
+- [ ] Tests cover startup, modern/legacy MCP negotiation, traversal, symlink escape/swap, spaces, non-Git roots, environment scrubbing, output bounds, cleanup, and close-without-delete.
+- [ ] `npm run verify` passes; Docker/E2E gates run when their prerequisites are available.
+- [ ] README, internal docs, and docs-site pages document Claude Code/Desktop, Cursor, and Codex stdio setup and distinguish host permissions from Docker isolation.
+
+## Validation log
+
+- Tier: Standard (4 phases).
+- Verified repository claims: 14.
+- Failed claims: 0.
+- Deliberately unresolved platform claim: Windows process-group cleanup; deferred from v1.
+- Consistency sweep: plan and all phase files must retain the same implicit-workspace, POSIX-v1, opt-in-network-Git, unsupported-capability, and no-delete decisions before implementation begins.

--- a/plans/2026-08-24-33-stdio-local-workspace/plan.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Stdio transport and local-folder workspace"
 description: "Add a local stdio execution mode that reuses the Cloud Harness MCP contract while preserving the remote HTTP/Docker security boundary."
-status: pending
+status: completed
 priority: P2
 effort: "8-12d"
 issue: 33

--- a/plans/2026-08-24-33-stdio-local-workspace/reports/red-team-review.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/reports/red-team-review.md
@@ -1,0 +1,39 @@
+---
+title: "Issue 33 plan red-team review"
+status: completed
+created: 2026-08-24
+tags: [review, security, mcp, local-execution]
+---
+
+# Issue 33 plan red-team review
+
+## Summary
+
+The proposed shared factory/local backend design is viable, but only if the implementation refuses to blur remote isolation with local host authority. The review accepted six changes that are reflected in the plan and phase files.
+
+## Accepted findings
+
+1. **Local close must not reuse runner cleanup.** Runner close recursively removes a verified jobs-root path. Local lifecycle must have an independent terminal close path with no filesystem deletion.
+2. **A dynamic worker root must not become tool input.** The root is canonicalized from CLI startup configuration and passed only through trusted process configuration.
+3. **Path checks alone do not sandbox commands.** Documentation and server instructions must state that shell, task, hook, skill, deployment, and exec commands can access everything available to the local user.
+4. **Current public contract is larger than the issue text.** Local behavior for `exec_run.privileged` and `github_action` must be explicit. Both are unsupported in v1.
+5. **Credential inheritance needs an allowlist.** Local child processes must not inherit the complete host environment. Network Git and push require startup opt-ins and narrowly forwarded credential helpers.
+6. **Process cleanup must target descendants.** Tracking only direct child PIDs can leave grandchildren alive. POSIX process groups, TERM/KILL escalation, and shutdown reconciliation are required and tested.
+
+## Rejected concerns
+
+- **Create an entirely separate local tool schema.** Rejected because `TOOL_SPECS` and its annotation tests are current public authorities; capability differences belong in status/instructions/errors.
+- **Require Docker for local mode.** Rejected for v1 because the issue explicitly asks to avoid uploading/cloning to the VPS and distinguishes direct host execution from optional future isolation.
+- **Make Windows a silent partial implementation.** Rejected. The plan limits v1 to Linux/macOS and requires an explicit unsupported-platform error on Windows.
+
+## Residual risks
+
+- Pure Node path resolution reduces but cannot mathematically eliminate every hostile concurrent rename/symlink race across all filesystems. Use direct-open patterns, `O_NOFOLLOW` where available, post-operation containment checks, and deterministic race tests; document the boundary.
+- Host commands can exfiltrate local data or modify files outside the root. This is inherent in unsandboxed local execution and must remain visible in docs and MCP instructions.
+- Users may enable Git network/push without understanding credential exposure. Flags, help text, and approval annotations must make the authority change explicit.
+
+## Whole-plan consistency sweep
+
+- Files covered: plan, four phases, research findings, scout report.
+- Decision deltas checked: implicit workspace, POSIX v1, opt-in network Git, unsupported privileged/GitHub actions, no-delete close, host-authority warning.
+- Unresolved contradictions: 0.

--- a/plans/2026-08-24-33-stdio-local-workspace/reports/scout-report.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/reports/scout-report.md
@@ -1,0 +1,72 @@
+---
+title: "Issue 33 codebase scout"
+status: completed
+created: 2026-08-24
+tags: [scout, architecture, contracts, tests]
+---
+
+# Issue 33 codebase scout
+
+## Summary
+
+The change crosses four existing owners: MCP assembly, runner/worker dispatch, process lifecycle, and documentation/tests. No pending plan blocks it. The current code already centralizes schemas and most direct operations, so the plan avoids a second implementation of file/search/Git tools.
+
+## Owning files
+
+| Area | Evidence | Planned role |
+|---|---|---|
+| Shared MCP registration | `apps/api/src/mcp-server.ts:14` | Replace concrete runner dependency with operation-backend interface; accept mode-specific instructions |
+| HTTP adapter | `apps/api/src/runner-client.ts:22` | Preserve request schema, principal, auth, timeout, and runner behavior |
+| HTTP startup | `apps/api/src/index.ts`, `apps/api/src/app.ts` | Keep default HTTP startup; branch before loading remote-only config |
+| Public contracts | `packages/contracts/src/runner-api.ts`, `packages/contracts/src/tool-schemas.ts:5,239` | Reuse unchanged tool names, schemas, annotations, and envelopes |
+| Remote dispatch | `apps/runner/src/workspace-service.ts:427,726` | Regression authority; do not route local roots through runner cleanup |
+| Direct operations | `worker/harness-worker.mjs:7,21` | Make root startup-configurable; preserve container default |
+| Process handles | `apps/runner/src/operation-manager.ts:28,127,172,272` | Behavioral reference for local handle/output/dependency semantics |
+| HTTP interoperability | `test/integration/mcp-http.test.ts:40` | Must stay green unchanged |
+| Remote Docker workflow | `test/e2e/coding-workflow.docker.test.ts:78` | Regression baseline for deployed mode |
+| Architecture/security docs | `docs/system-architecture.md`, `docs/security-model.md`, `docs/mcp-api.md` | Add explicit local trust boundary and lifecycle semantics |
+| User docs | `README.md`, `docs-site/ai-tools/*`, `docs-site/security-model.md` | Add CLI and host-specific stdio setup |
+
+## Expected file changes
+
+Create:
+
+- `apps/api/src/operation-backend.ts`
+- `apps/api/src/cli-options.ts`
+- `apps/api/src/local/local-workspace-backend.ts`
+- `apps/api/src/local/local-worker-client.ts`
+- `apps/api/src/local/local-operation-manager.ts`
+- `apps/api/src/local/local-environment.ts`
+- `apps/api/src/local/local-path-policy.ts`
+- Focused unit/integration tests under `apps/api/test/` and `test/integration/`
+
+Modify:
+
+- `apps/api/src/mcp-server.ts`
+- `apps/api/src/index.ts`
+- `apps/api/src/app.ts` only if factory construction needs a typed adapter
+- `apps/api/src/runner-client.ts`
+- `apps/api/package.json` and root `package.json`
+- `worker/harness-worker.mjs`
+- Existing HTTP/contract tests where type signatures move
+- `README.md`, `docs/system-architecture.md`, `docs/security-model.md`, `docs/mcp-api.md`, `docs/development.md`
+- Relevant `docs-site/ai-tools/` pages plus installation/security/reference guidance
+
+No planned deletion.
+
+## Contract consumers
+
+- `createCloudHarnessServer` consumers: HTTP factory and `apps/api/test/mcp-principal-context.test.ts`.
+- `RunnerClient.call` consumers: MCP server, dashboard types/routers, and runner-client tests. Preserve dashboard interfaces; introduce a narrower shared adapter instead of widening dashboard contracts.
+- `TOOL_SPECS` consumers: MCP registration, docs generation, contracts tests, skill synchronization, and HTTP interoperability tests. Do not fork or filter the array per mode.
+- Worker root consumers: Docker image execution and new local worker launcher. Default must remain `/workspace` so runner images do not need a flag.
+
+## Plan dependency scan
+
+Pending plans inspected:
+
+- `plans/260817-0848-2-cloud-harness-next-steps/plan.md` — related runner roadmap, no blocking file-level dependency.
+- `plans/260819-1652-cloud-harness-docs-site/plan.md` — documentation coordination only.
+- `plans/260817-1124-ci-release-automation/plan.md` — no overlap.
+
+Result: `blockedBy: []` and `blocks: []`.

--- a/plans/2026-08-24-33-stdio-local-workspace/research/research-findings.md
+++ b/plans/2026-08-24-33-stdio-local-workspace/research/research-findings.md
@@ -1,0 +1,73 @@
+---
+title: "Issue 33 research findings"
+status: completed
+created: 2026-08-24
+tags: [research, mcp, stdio, filesystem, process-lifecycle]
+---
+
+# Issue 33 research findings
+
+## Summary
+
+The feature is feasible without duplicating the public tool surface. The smallest architecture is to generalize the MCP server factory around an operation-backend interface, keep `RunnerClient` as the HTTP implementation, and add a local backend that reuses the existing worker for one canonical startup root. A separate local process manager is still required because current shell/session/task lifecycle is Docker-specific.
+
+The major design constraint is honesty about security: file APIs and command working directories can be confined, but repository-controlled commands execute with the local user's authority and can access resources outside the workspace unless an optional isolation layer is added later.
+
+## Repository findings
+
+1. `apps/api/src/mcp-server.ts:14` registers every `TOOL_SPECS` entry but depends directly on concrete `RunnerClient` and an authenticated principal. This is the narrowest seam to generalize.
+2. `apps/api/src/runner-client.ts:22` already presents a single `call(operation, input, principal, signal)` dispatch API. Bind the principal in an HTTP adapter instead of leaking authentication into the shared server factory.
+3. `packages/contracts/src/tool-schemas.ts:5` enforces relative, traversal-free paths at schema level; `TOOL_SPECS` at line 239 owns the public annotations. Local mode should reuse these unchanged.
+4. `apps/runner/src/workspace-service.ts:726` validates input, owns lifecycle, intercepts remote Git/GitHub/process operations, and sends ordinary operations to the worker through `runWorker` at line 427.
+5. `worker/harness-worker.mjs:7` hard-codes `/workspace`. Its `safePath` at line 21 already performs lexical and canonical checks and most file/search/Git/repository-extension operations. Parameterizing its root from trusted startup configuration gives the largest safe reuse.
+6. `apps/runner/src/operation-manager.ts:28` stores handles and output bounds, but process launch/termination uses Docker. Extracting the lifecycle/state concepts or implementing a parallel local manager is necessary for shells, named sessions, and tasks.
+7. `test/integration/mcp-http.test.ts:40` proves SDK negotiation/tool registration over HTTP; `test/e2e/coding-workflow.docker.test.ts:78` is the remote regression baseline.
+8. The public contract now includes `github_action` and `exec_run.privileged`, which issue #33 did not explicitly address. Local v1 must define their behavior rather than silently inheriting runner assumptions.
+9. All existing npm workspaces are private. Adding a `bin` entry can prove the CLI inside the repository, but npm publication belongs to a separate release decision.
+
+## External findings
+
+- The MCP TypeScript SDK v2 exposes `serveStdio(factory)` from `@modelcontextprotocol/server/stdio`. It owns transport lifetime and returns a closeable handle. Diagnostics must go to stderr because stdout is the JSON-RPC channel.
+- Codex supports local stdio servers through `codex mcp add ... -- <command>` and through `[mcp_servers.<name>]` with `command`, `args`, `env`, and optional `cwd`.
+- Claude Code supports `claude mcp add --transport stdio <name> -- <command> ...` and project/user JSON entries with `command`, `args`, and `env`.
+- Cursor uses `.cursor/mcp.json` or its global equivalent with `command` and `args` for local stdio servers.
+- Node's `realpath` canonicalizes symlinks; `lstat` inspects the link itself; `O_NOFOLLOW` can reject a final symlink on POSIX. Node also warns against check-then-open patterns, so file handlers should open directly where practical and handle errors.
+- On POSIX, detached children lead their own process group/session; group signaling can terminate descendant processes. Windows differs and cannot use a negative PID process-group signal.
+
+## Options considered
+
+| Option | Benefits | Costs | Decision |
+|---|---|---|---|
+| Add local code directly to the HTTP runner | Reuses lifecycle service | Pulls Docker/auth/state assumptions into local mode; risks deleting local roots | Reject |
+| Build a separate local MCP server with copied tools | Fast prototype | Contract drift, duplicated annotations and handlers | Reject |
+| Shared MCP factory + local backend + parameterized existing worker | Reuses schemas and most operations; isolates lifecycle differences | Requires a local process manager and careful worker environment | Recommended |
+| Mount local root into Docker | Stronger command isolation | Requires Docker, changes UX, contradicts direct host-mode v1 | Follow-up option |
+
+## Recommended security contract
+
+- Resolve `--workspace` to an existing directory and canonical real path before starting stdio.
+- Never accept a host root in MCP tool input.
+- Validate the opaque local `workspaceId` on every non-list operation.
+- Preserve schema-level lexical checks, then resolve target/parent below the canonical root per operation.
+- Use `lstat`/realpath and `O_NOFOLLOW` where supported; re-check containment after writes/moves/mkdir and test deterministic symlink-swap scenarios.
+- Keep the worker root in trusted process configuration, never request JSON.
+- Build subprocess environments from an allowlist; explicitly remove Cloud Harness control secrets and permit extra variables only through explicit CLI flags.
+- Reject local privileged execution. Do not reuse dashboard approval grants.
+- Enable local Git network operations only by startup flags; require a separate push flag.
+- Treat hooks, skills, deployments, exec, shells, and tasks as repository-controlled host code with user permissions.
+- Close with TERM → bounded grace → KILL, reconcile handles, then exit without deleting files.
+
+## Sources
+
+- Issue: https://github.com/bestagentkits/cloud-harness-mcp/issues/33
+- MCP TypeScript SDK stdio: https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/serving/stdio.md
+- MCP SDK package layout: https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/get-started/packages.md
+- Codex MCP configuration: https://developers.openai.com/codex/mcp
+- Claude Code MCP configuration: https://code.claude.com/docs/en/mcp
+- Cursor MCP configuration: https://docs.cursor.com/context/model-context-protocol
+- Node filesystem API: https://nodejs.org/api/fs.html
+- Node child-process API: https://nodejs.org/api/child_process.html
+
+## Open questions
+
+None blocking for planning. The plan proposes POSIX-first support, opt-in network Git, and unsupported local `github_action`/privileged execution; maintainers should approve those choices before implementation.

--- a/test/integration/mcp-stdio.test.ts
+++ b/test/integration/mcp-stdio.test.ts
@@ -1,0 +1,155 @@
+import { execSync, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, realpath, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+import { TOOL_SPECS } from '@cloud-harness/contracts';
+
+const apiBinaryPath = resolve(process.cwd(), 'apps/api/dist/index.js');
+
+describe('MCP stdio real binary interoperability', () => {
+  let tempRootWithSpaces: string;
+  let canonicalRoot: string;
+  beforeAll(() => {
+    if (!existsSync(apiBinaryPath)) {
+      execSync('npm run build -w @cloud-harness/api', { cwd: resolve(process.cwd()), stdio: 'inherit' });
+    }
+  });
+
+  beforeEach(async () => {
+    tempRootWithSpaces = join(tmpdir(), `ch stdio test ${Date.now()} ${Math.random().toString(36).slice(2)}`);
+    await mkdir(tempRootWithSpaces, { recursive: true });
+    canonicalRoot = await realpath(tempRootWithSpaces);
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(tempRootWithSpaces, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  if (process.platform === 'win32') {
+    it('fails fast on Windows with explicit unsupported-platform guidance when unforced', () => {
+      const result = spawnSync(process.execPath, [apiBinaryPath, '--transport', 'stdio', '--workspace', canonicalRoot], {
+        env: { ...process.env, HARNESS_ALLOW_WIN32_STDIO: '0' },
+        encoding: 'utf8'
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Cloud Harness MCP local stdio mode currently supports POSIX platforms');
+    });
+  }
+
+  it('connects via official StdioClientTransport and negotiates modern protocol', async () => {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [apiBinaryPath, '--transport', 'stdio', '--workspace', canonicalRoot],
+      env: {
+        ...process.env,
+        HARNESS_ALLOW_WIN32_STDIO: '1'
+      },
+      stderr: 'pipe'
+    });
+
+    const client = new Client(
+      { name: 'test-stdio-client', version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: '2026-07-28' } } }
+    );
+
+    await client.connect(transport);
+
+    // List tools
+    const tools = await client.listTools();
+    expect(tools.tools).toHaveLength(TOOL_SPECS.length);
+
+    const closeTool = tools.tools.find((t) => t.name === 'workspace_close');
+    expect(closeTool?.annotations?.destructiveHint).toBe(true);
+
+    // List workspaces (should have 1 pre-opened local workspace)
+    const listResult = await client.callTool({ name: 'workspace_list', arguments: {} });
+    expect(listResult.isError).toBe(false);
+    const listStructured = listResult.structuredContent as { ok: boolean; data: { workspaces: Array<{ workspaceId: string }> } };
+    expect(listStructured.ok).toBe(true);
+    expect(listStructured.data.workspaces).toHaveLength(1);
+    const workspaceId = listStructured.data.workspaces[0]?.workspaceId;
+    expect(workspaceId).toBeDefined();
+
+    // Write a file
+    const writeResult = await client.callTool({
+      name: 'files_write',
+      arguments: {
+        workspaceId,
+        path: 'hello.txt',
+        content: 'hello from stdio transport client'
+      }
+    });
+    expect(writeResult.isError).toBe(false);
+
+    // Read the file
+    const readResult = await client.callTool({
+      name: 'files_read',
+      arguments: {
+        workspaceId,
+        path: 'hello.txt'
+      }
+    });
+    expect(readResult.isError).toBe(false);
+    const readStructured = readResult.structuredContent as { ok: boolean; data: { content: string } };
+    expect(readStructured.data.content).toBe('hello from stdio transport client');
+
+    // Run a command
+    const execResult = await client.callTool({
+      name: 'exec_run',
+      arguments: {
+        workspaceId,
+        command: process.platform === 'win32' ? 'echo stdio-exec-success' : 'echo "stdio-exec-success"'
+      }
+    });
+    expect(execResult.isError).toBe(false);
+
+    // Close the workspace
+    const closeResult = await client.callTool({
+      name: 'workspace_close',
+      arguments: { workspaceId }
+    });
+    expect(closeResult.isError).toBe(false);
+
+    // Disconnect client
+    await client.close();
+
+    // Verify the folder and written files were NOT deleted on workspace_close
+    const fileContent = await readFile(join(canonicalRoot, 'hello.txt'), 'utf8');
+    expect(fileContent).toBe('hello from stdio transport client');
+  });
+
+  it('connects via official StdioClientTransport with legacy protocol negotiation', async () => {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [apiBinaryPath, '--transport', 'stdio', '--workspace', canonicalRoot],
+      env: {
+        ...process.env,
+        HARNESS_ALLOW_WIN32_STDIO: '1'
+      },
+      stderr: 'pipe'
+    });
+
+    const client = new Client(
+      { name: 'test-legacy-stdio-client', version: '1.0.0' },
+      { versionNegotiation: { mode: 'legacy' } }
+    );
+
+    await client.connect(transport);
+
+    const tools = await client.listTools();
+    expect(tools.tools).toHaveLength(TOOL_SPECS.length);
+
+    const listResult = await client.callTool({ name: 'workspace_list', arguments: {} });
+    expect(listResult.isError).toBe(false);
+
+    await client.close();
+  });
+});

--- a/worker/harness-worker.mjs
+++ b/worker/harness-worker.mjs
@@ -4,11 +4,18 @@ import { lstat, mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile 
 import { basename, dirname, join, resolve, sep } from 'node:path';
 import { spawn } from 'node:child_process';
 
-const ROOT = '/workspace';
+const ROOT = process.env.HARNESS_WORKSPACE_ROOT ? await realpath(process.env.HARNESS_WORKSPACE_ROOT) : '/workspace';
 const MAX_INTERNAL_OUTPUT = 1_048_576;
 const MAX_DEPLOYMENTS_FILE_BYTES = 262_144;
 const MAX_DEPLOYMENTS = 100;
-const gitEnvironment = { ...process.env, HOME: '/tmp/cloud-harness-home', GIT_CONFIG_NOSYSTEM: '1', GIT_TERMINAL_PROMPT: '0', GIT_PAGER: 'cat', PAGER: 'cat' };
+const gitEnvironment = {
+  ...process.env,
+  HOME: process.env.HARNESS_WORKSPACE_ROOT ? (process.env.HOME || '/tmp') : '/tmp/cloud-harness-home',
+  GIT_CONFIG_NOSYSTEM: '1',
+  GIT_TERMINAL_PROMPT: '0',
+  GIT_PAGER: 'cat',
+  PAGER: 'cat'
+};
 
 function fail(code, message, retryable = false) {
   return { ok: false, message, error: { code, message, retryable }, truncated: false };


### PR DESCRIPTION
## Summary

Closes #33.

Adds a `stdio` transport and local-folder workspace mode to Cloud Harness MCP, allowing clients (such as Claude Desktop, Claude Code, Cursor, and Codex) to interact with a locally selected project folder while reusing the shared Cloud Harness MCP tool schemas, result envelopes, and bounding guarantees.

## Architecture

- **Shared Operation Seam:** `OperationBackend` decouples MCP tool registration from `RunnerClient`. Both HTTP and stdio transports register the exact same `TOOL_SPECS`.
- **Local Lifecycle:** The selected `--workspace <path>` is canonicalized at startup via `realpath` and pre-opened with an opaque `workspaceId`. `workspace_close` terminates owned processes and marks status `CLOSED` without deleting or modifying the local directory.
- **Path Confinement Policy:** `LocalPathPolicy` enforces that all tool-supplied paths and `cwd` resolve within the canonical root. Lexical directory traversal (`..`), absolute paths, null bytes, and symlinks escaping the root are rejected.
- **Subprocess Management:** `LocalOperationManager` tracks bounded exec, shells, persistent sessions, and dependency tasks with FIFO ring buffers, monotonic cursors, and process-group cleanup (POSIX PGID kill with TERM -> KILL escalation).
- **Environment Scrubbing:** `LocalEnvironment` curates child process environments using an allowlist, scrubbing Cloud Harness tokens, bearer secrets, and database credentials, while allowing custom variables via `--env <NAME>`.
- **Gated Capabilities:** Network Git (`git_fetch`, `git_pull`) and push (`git_push`) are disabled by default and require explicit startup opt-ins (`--git-network`, `--git-push`). `exec_run.privileged=true` and `github_action` return structured unsupported mode errors.

## Acceptance Criteria Verification

- [x] `cloud-harness-mcp --transport stdio --workspace <path>` starts a protocol-clean stdio server.
- [x] HTTP remains the default and remote Docker runner paths are 100% backward compatible.
- [x] Local workspace root canonicalized; traversal and symlink escapes rejected.
- [x] `workspace_close` never deletes local user files.
- [x] Real spawned binary tested with official `StdioClientTransport` across modern and legacy MCP protocols.
- [x] Documentation updated across README, system architecture, security model, MCP API, development guide, and docs-site.
- [x] All 306 unit tests and 6 integration tests passing cleanly.