### PR TITLE
feat(ux): implement atomic batch writes, finalize, lease recovery, and extended operations

### DIFF
--- a/.agents/skills/cloudharness/references/execution-and-tasks.md
+++ b/.agents/skills/cloudharness/references/execution-and-tasks.md
@@ -129,6 +129,44 @@ only ASCII letters, digits, `.`, `_`, and `-`, with length 1–80.
 - Required: `workspaceId`.
 - Returns the current task/dependency graph for diagnosing blocked work.
 
+## Long-running operations
+
+<!-- cloudharness-tool:operation_status -->
+### `operation_status`
+
+Query status, progress, and terminal result of a long-running operation.
+
+- Required: `operationId`. Optional: `cursor`.
+- Returns status (`queued`, `running`, `completed`, `failed`, `cancelled`), progress, and retained output.
+
+<!-- cloudharness-example:operation_status
+{"operationId":"op_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
+<!-- cloudharness-tool:operation_cancel -->
+### `operation_cancel`
+
+Cancel an in-flight long-running operation.
+
+- Required: `operationId`.
+- Terminates the underlying process group and marks the operation cancelled.
+
+<!-- cloudharness-example:operation_cancel
+{"operationId":"op_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
+<!-- cloudharness-tool:operation_wait -->
+### `operation_wait`
+
+Wait for an operation to reach a terminal state with a server timeout.
+
+- Required: `operationId`. Optional: `timeoutMs` (100–300,000).
+- Returns terminal result or timed-out status with resumption hint.
+
+<!-- cloudharness-example:operation_wait
+{"operationId":"op_aaaaaaaaaaaaaaaaaaaa","timeoutMs":30000}
+-->
+
 ## Recovery and cleanup
 
 1. For a lost create response, reuse its original idempotency key.

--- a/.agents/skills/cloudharness/references/files-and-search.md
+++ b/.agents/skills/cloudharness/references/files-and-search.md
@@ -47,6 +47,19 @@ Atomically replace or create a file.
 - This replaces the complete file. Re-read and use the current hash before
   overwriting a file that another actor may edit.
 
+
+<!-- cloudharness-tool:files_write_batch -->
+### `files_write_batch`
+
+Atomically create or update multiple workspace files in one operation with parent directory creation.
+
+- Required: `files` array of 1–100 path/content objects.
+- Optional: `workspaceId`, `createParents` (default true), `atomic` (default true), `idempotencyKey`.
+- Returns created/updated counts, hashes, and per-file write details.
+
+<!-- cloudharness-example:files_write_batch
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","files":[{"path":"plans/plan.md","content":"# Plan"}],"createParents":true}
+-->
 <!-- cloudharness-tool:files_apply_patch -->
 ### `files_apply_patch`
 

--- a/.agents/skills/cloudharness/references/git-and-worktrees.md
+++ b/.agents/skills/cloudharness/references/git-and-worktrees.md
@@ -59,6 +59,43 @@ Read branch, index, and working-tree status for `workspaceId`.
   as tracked modifications/deletions. Inspect status for secrets and unrelated
   files first. The tool creates a local commit and does not sign or push it.
 
+<!-- cloudharness-tool:git_identity_status -->
+### `git_identity_status`
+
+Read configured or default Git author identity for the workspace.
+
+- Optional: `workspaceId`.
+- Returns author name, email, and source (`workspace`, `principal`, or `default`).
+
+<!-- cloudharness-example:git_identity_status
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
+<!-- cloudharness-tool:git_identity_set -->
+### `git_identity_set`
+
+Configure default Git author name and email for commits.
+
+- Required: `name`, `email`. Optional: `workspaceId`.
+- Returns updated Git author identity settings.
+
+<!-- cloudharness-example:git_identity_set
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","name":"Agent Developer","email":"agent@example.com"}
+-->
+
+<!-- cloudharness-tool:workspace_finalize -->
+### `workspace_finalize`
+
+Transactionally stage changes, run preflights, commit, and push to origin in one call.
+
+- Required: `commitMessage` (1–10,000 characters).
+- Optional: `workspaceId`, `paths`, `all` (default true), `branch`, `push` (default true), `authorName`, `authorEmail`, `preflight`, `idempotencyKey`.
+- Returns commit SHA, target branch, push result, and final workspace status.
+
+<!-- cloudharness-example:workspace_finalize
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","commitMessage":"feat(core): implement feature","push":true}
+-->
+
 ## Origin transfer and history integration
 
 The trusted runner brokers repository credentials when configured. Credentials

--- a/.agents/skills/cloudharness/references/workspace-lifecycle-and-results.md
+++ b/.agents/skills/cloudharness/references/workspace-lifecycle-and-results.md
@@ -102,6 +102,54 @@ Terminate the executor and remove the workspace directory.
 {"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa"}
 -->
 
+<!-- cloudharness-tool:workspace_lease_renew -->
+### `workspace_lease_renew`
+
+Explicitly renew the active workspace idle lease.
+
+- Optional: `workspaceId`, `extensionSeconds` (60–86,400).
+- Returns refreshed lease metadata with remaining lease time.
+
+<!-- cloudharness-example:workspace_lease_renew
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","extensionSeconds":3600}
+-->
+
+<!-- cloudharness-tool:workspace_recover -->
+### `workspace_recover`
+
+Inspect or recover unpushed commits and working tree from an active or recoverable expired workspace.
+
+- Optional: `workspaceId`, `mode` (`status`, `patch`, or `export`), `targetBranch`.
+- Returns recovery status, unpushed patch, or branch recovery details.
+
+<!-- cloudharness-example:workspace_recover
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","mode":"status"}
+-->
+
+<!-- cloudharness-tool:workspace_context -->
+### `workspace_context`
+
+Read compact active workspace overview, branch, remaining lease, and Git identity.
+
+- Optional: `workspaceId`.
+- Returns active workspace ID, repository URL, current branch, remaining lease time, and default Git author.
+
+<!-- cloudharness-example:workspace_context
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
+<!-- cloudharness-tool:workspace_set_active -->
+### `workspace_set_active`
+
+Set the preferred active workspace for subsequent calls that omit `workspaceId`.
+
+- Required: `workspaceId`.
+- Returns confirmation and updated active workspace context.
+
+<!-- cloudharness-example:workspace_set_active
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
 ## Lifecycle details
 
 - Active workspace calls refresh idle expiry but cannot extend beyond the

--- a/apps/runner/src/operation-manager.ts
+++ b/apps/runner/src/operation-manager.ts
@@ -23,6 +23,21 @@ type Managed = {
   maxBytes?: number;
 };
 
+export type TrackedOperation = {
+  id: string;
+  workspaceId?: string | undefined;
+  kind: string;
+  status: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+  createdAt: number;
+  deadlineMs?: number | undefined;
+  progress?: { percent?: number | undefined; stage?: string | undefined; message?: string | undefined } | undefined;
+  result?: unknown;
+  error?: { code: string; message: string; retryable: boolean } | undefined;
+  output: Buffer;
+  offset: number;
+  child?: ChildProcessWithoutNullStreams | undefined;
+  container?: string | undefined;
+};
 const id = (prefix: string) => `${prefix}_${randomBytes(24).toString('base64url')}`;
 
 export class OperationManager {
@@ -31,7 +46,7 @@ export class OperationManager {
   private readonly sessions = new Map<string, Managed>();
   private readonly idempotency = new Map<string, string>();
   private readonly retainedOutputBytes = 67_108_864;
-
+  private readonly genericOperations = new Map<string, TrackedOperation>();
   private records(workspaceId: string): Managed[] {
     return [...this.tasks.values(), ...this.shells.values(), ...this.sessions.values()]
       .filter((record) => record.workspaceId === workspaceId)
@@ -276,6 +291,15 @@ export class OperationManager {
         record.child?.kill();
       }
     }
+    for (const [opId, op] of this.genericOperations) {
+      if (op.workspaceId === workspaceId) {
+        if (op.status === 'running' || op.status === 'queued') {
+          op.status = 'cancelled';
+          if (op.child) { try { op.child.kill('SIGTERM'); } catch { /* ignore */ } }
+        }
+        this.genericOperations.delete(opId);
+      }
+    }
     for (const [recordId, record] of this.tasks) if (record.workspaceId === workspaceId) this.tasks.delete(recordId);
     for (const [recordId, record] of this.shells) if (record.workspaceId === workspaceId) this.shells.delete(recordId);
     for (const [recordId, record] of this.sessions) if (record.workspaceId === workspaceId) this.sessions.delete(recordId);
@@ -316,5 +340,93 @@ export class OperationManager {
       cursor: String(nextCursor),
       truncated: missedOutput || nextCursor < end
     };
+  }
+
+  registerGenericOperation(op: { id: string; workspaceId?: string; kind: string; deadlineMs?: number; container?: string }): TrackedOperation {
+    while (this.genericOperations.size >= 500) {
+      const oldest = [...this.genericOperations.entries()]
+        .filter(([, o]) => o.status === 'completed' || o.status === 'failed' || o.status === 'cancelled')
+        .sort((a, b) => a[1].createdAt - b[1].createdAt)[0];
+      if (oldest) {
+        this.genericOperations.delete(oldest[0]);
+      } else {
+        const oldestAny = [...this.genericOperations.entries()].sort((a, b) => a[1].createdAt - b[1].createdAt)[0];
+        if (oldestAny) this.genericOperations.delete(oldestAny[0]);
+        break;
+      }
+    }
+    const tracked: TrackedOperation = {
+      id: op.id,
+      workspaceId: op.workspaceId,
+      kind: op.kind,
+      status: 'running',
+      createdAt: Date.now(),
+      deadlineMs: op.deadlineMs,
+      output: Buffer.alloc(0),
+      offset: 0,
+      container: op.container
+    };
+    this.genericOperations.set(op.id, tracked);
+    return tracked;
+  }
+
+  updateGenericOperation(id: string, patch: Partial<TrackedOperation>): TrackedOperation | undefined {
+    const current = this.genericOperations.get(id);
+    if (!current) return undefined;
+    Object.assign(current, patch);
+    return current;
+  }
+
+  getGenericOperation(id: string): TrackedOperation | undefined {
+    const gen = this.genericOperations.get(id);
+    if (gen) return gen;
+    const task = this.tasks.get(id);
+    if (task) {
+      return {
+        id: task.id,
+        workspaceId: task.workspaceId,
+        kind: 'task',
+        status: task.status === 'succeeded' ? 'completed' : task.status === 'blocked' ? 'failed' : task.status === 'failed' ? 'failed' : task.status === 'cancelled' ? 'cancelled' : 'running',
+        createdAt: task.createdAt,
+        output: task.output,
+        offset: task.offset,
+        child: task.child,
+        container: task.container,
+        error: task.status === 'blocked' ? { code: 'CONFLICT', message: 'Task blocked by dependency failure', retryable: false } : undefined
+      };
+    }
+    return undefined;
+  }
+
+  async cancelGenericOperation(id: string): Promise<TrackedOperation> {
+    const op = this.genericOperations.get(id);
+    if (op) {
+      if (op.status === 'running' || op.status === 'queued') {
+        op.status = 'cancelled';
+        if (op.child) {
+          try { op.child.kill('SIGTERM'); } catch { /* process already exited */ }
+        }
+        if (op.container) {
+          try {
+            await terminateContainerProcessGroup(op.container, `/tmp/cloud-harness-operations/${id}.pid`);
+          } catch { /* container already stopped */ }
+        }
+      }
+      return op;
+    }
+    const task = this.tasks.get(id);
+    if (task) {
+      await this.cancelTask(task.workspaceId, id);
+      return {
+        id: task.id,
+        workspaceId: task.workspaceId,
+        kind: 'task',
+        status: 'cancelled',
+        createdAt: task.createdAt,
+        output: task.output,
+        offset: task.offset
+      };
+    }
+    throw new HarnessError('NOT_FOUND', `operation ${id} not found`, 404, false);
   }
 }

--- a/apps/runner/src/state-store.ts
+++ b/apps/runner/src/state-store.ts
@@ -33,11 +33,14 @@ export type WorkspaceRecord = {
   repositoryRef: string | null;
   containerName: string | null;
   workspacePath: string;
-  status: 'CREATING' | 'ACTIVE' | 'REAPING' | 'CLOSED' | 'FAILED';
+  status: 'CREATING' | 'ACTIVE' | 'REAPING' | 'CLOSED' | 'FAILED' | 'EXPIRED_RECOVERABLE';
   networkMode: 'none' | 'bridge';
   createdAt: number;
   lastActivityAt: number;
   expiresAt: number;
+  hardExpiresAt: number;
+  gitAuthorName: string | null;
+  gitAuthorEmail: string | null;
   generation: number;
   error: string | null;
 };
@@ -86,14 +89,18 @@ const fromPrivilegeGrantRow = (row: PrivilegeGrantRow): PrivilegeGrantRecord => 
 type Row = {
   id: string; owner_id: string; idempotency_key: string; repository_url: string; repository_ref: string | null;
   container_name: string | null; workspace_path: string; status: WorkspaceRecord['status']; network_mode: 'none' | 'bridge';
-  created_at: number; last_activity_at: number; expires_at: number; generation: number; error: string | null;
+  created_at: number; last_activity_at: number; expires_at: number; hard_expires_at?: number | null;
+  git_author_name?: string | null; git_author_email?: string | null;
+  generation: number; error: string | null;
 };
 
 const fromRow = (row: Row): WorkspaceRecord => ({
   id: row.id, ownerId: row.owner_id, idempotencyKey: row.idempotency_key, repositoryUrl: row.repository_url,
   repositoryRef: row.repository_ref, containerName: row.container_name, workspacePath: row.workspace_path,
   status: row.status, networkMode: row.network_mode, createdAt: row.created_at, lastActivityAt: row.last_activity_at,
-  expiresAt: row.expires_at, generation: row.generation, error: row.error
+  expiresAt: row.expires_at, hardExpiresAt: row.hard_expires_at ?? (row.created_at + 14_400_000),
+  gitAuthorName: row.git_author_name ?? null, gitAuthorEmail: row.git_author_email ?? null,
+  generation: row.generation, error: row.error
 });
 
 export class StateStore {
@@ -131,6 +138,23 @@ export class StateStore {
       );
       CREATE INDEX IF NOT EXISTS privilege_grants_owner_workspace ON privilege_grants(owner_id, workspace_id);
     `);
+    const cols = (this.database.prepare('PRAGMA table_info(workspaces)').all() as { name: string }[]).map((c) => c.name);
+    if (!cols.includes('hard_expires_at')) {
+      this.database.exec('ALTER TABLE workspaces ADD COLUMN hard_expires_at INTEGER;');
+    }
+    if (!cols.includes('git_author_name')) {
+      this.database.exec('ALTER TABLE workspaces ADD COLUMN git_author_name TEXT;');
+    }
+    if (!cols.includes('git_author_email')) {
+      this.database.exec('ALTER TABLE workspaces ADD COLUMN git_author_email TEXT;');
+    }
+    this.database.exec(`
+      CREATE TABLE IF NOT EXISTS preferred_workspaces (owner_id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL);
+      CREATE TABLE IF NOT EXISTS git_identities (owner_id TEXT PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL);
+      CREATE TABLE IF NOT EXISTS comment_idempotency (owner_id TEXT NOT NULL, idempotency_key TEXT NOT NULL, result_json TEXT NOT NULL, created_at INTEGER NOT NULL, PRIMARY KEY(owner_id, idempotency_key));
+      CREATE TABLE IF NOT EXISTS finalize_idempotency (owner_id TEXT NOT NULL, workspace_id TEXT NOT NULL, idempotency_key TEXT NOT NULL, result_json TEXT NOT NULL, created_at INTEGER NOT NULL, PRIMARY KEY(owner_id, workspace_id, idempotency_key));
+      CREATE TABLE IF NOT EXISTS batch_write_idempotency (owner_id TEXT NOT NULL, workspace_id TEXT NOT NULL, idempotency_key TEXT NOT NULL, result_json TEXT NOT NULL, created_at INTEGER NOT NULL, PRIMARY KEY(owner_id, workspace_id, idempotency_key));
+    `);
     migratePrincipalSchema(this.database);
     this.database.prepare('INSERT OR IGNORE INTO runtime_meta(key, value) VALUES (?, ?)')
       .run('runner_instance_id', randomBytes(18).toString('hex'));
@@ -144,11 +168,28 @@ export class StateStore {
 
   create(record: WorkspaceRecord): void {
     this.database.prepare(`INSERT INTO workspaces
-      (id, owner_id, idempotency_key, repository_url, repository_ref, container_name, workspace_path, status, network_mode, created_at, last_activity_at, expires_at, generation, error)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-      .run(record.id, record.ownerId, record.idempotencyKey, record.repositoryUrl, record.repositoryRef, record.containerName, record.workspacePath, record.status, record.networkMode, record.createdAt, record.lastActivityAt, record.expiresAt, record.generation, record.error);
+      (id, owner_id, idempotency_key, repository_url, repository_ref, container_name, workspace_path, status, network_mode, created_at, last_activity_at, expires_at, hard_expires_at, git_author_name, git_author_email, generation, error)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run(
+        record.id,
+        record.ownerId,
+        record.idempotencyKey,
+        record.repositoryUrl,
+        record.repositoryRef ?? null,
+        record.containerName ?? null,
+        record.workspacePath,
+        record.status,
+        record.networkMode,
+        record.createdAt,
+        record.lastActivityAt,
+        record.expiresAt,
+        record.hardExpiresAt ?? (record.createdAt + 14_400_000),
+        record.gitAuthorName ?? null,
+        record.gitAuthorEmail ?? null,
+        record.generation,
+        record.error ?? null
+      );
   }
-
   byId(id: string): WorkspaceRecord | undefined {
     const row = this.database.prepare('SELECT * FROM workspaces WHERE id = ?').get(id) as Row | undefined;
     return row ? fromRow(row) : undefined;
@@ -206,14 +247,109 @@ export class StateStore {
   active(): WorkspaceRecord[] {
     return (this.database.prepare("SELECT * FROM workspaces WHERE status IN ('CREATING','ACTIVE','REAPING')").all() as Row[]).map(fromRow);
   }
-
-  update(id: string, changes: Partial<Pick<WorkspaceRecord, 'containerName' | 'status' | 'lastActivityAt' | 'expiresAt' | 'generation' | 'error'>>): WorkspaceRecord {
+  update(id: string, changes: Partial<Pick<WorkspaceRecord, 'containerName' | 'status' | 'lastActivityAt' | 'expiresAt' | 'hardExpiresAt' | 'gitAuthorName' | 'gitAuthorEmail' | 'generation' | 'error'>>): WorkspaceRecord {
     const current = this.byId(id);
     if (!current) throw new Error(`workspace ${id} missing`);
     const next = { ...current, ...changes };
-    this.database.prepare('UPDATE workspaces SET container_name=?, status=?, last_activity_at=?, expires_at=?, generation=?, error=? WHERE id=?')
-      .run(next.containerName, next.status, next.lastActivityAt, next.expiresAt, next.generation, next.error, id);
+    this.database.prepare('UPDATE workspaces SET container_name=?, status=?, last_activity_at=?, expires_at=?, hard_expires_at=?, git_author_name=?, git_author_email=?, generation=?, error=? WHERE id=?')
+      .run(
+        next.containerName ?? null,
+        next.status,
+        next.lastActivityAt,
+        next.expiresAt,
+        next.hardExpiresAt ?? (next.createdAt + 14_400_000),
+        next.gitAuthorName ?? null,
+        next.gitAuthorEmail ?? null,
+        next.generation,
+        next.error ?? null,
+        id
+      );
     return next;
+  }
+
+  setPreferredWorkspace(ownerId: string, workspaceId: string): void {
+    this.database.prepare('INSERT INTO preferred_workspaces(owner_id, workspace_id) VALUES (?, ?) ON CONFLICT(owner_id) DO UPDATE SET workspace_id = excluded.workspace_id')
+      .run(ownerId, workspaceId);
+  }
+
+  getPreferredWorkspace(ownerId: string): string | undefined {
+    const row = this.database.prepare('SELECT workspace_id FROM preferred_workspaces WHERE owner_id = ?').get(ownerId) as { workspace_id: string } | undefined;
+    return row?.workspace_id;
+  }
+
+  setGitIdentity(ownerId: string, identity: { name: string; email: string }): void {
+    this.database.prepare('INSERT INTO git_identities(owner_id, name, email) VALUES (?, ?, ?) ON CONFLICT(owner_id) DO UPDATE SET name = excluded.name, email = excluded.email')
+      .run(ownerId, identity.name, identity.email);
+  }
+
+  getGitIdentity(ownerId: string): { name: string; email: string } | undefined {
+    const row = this.database.prepare('SELECT name, email FROM git_identities WHERE owner_id = ?').get(ownerId) as { name: string; email: string } | undefined;
+    return row ? { name: row.name, email: row.email } : undefined;
+  }
+
+  getCommentIdempotency(ownerId: string, key: string): string | undefined {
+    const row = this.database.prepare('SELECT result_json FROM comment_idempotency WHERE owner_id = ? AND idempotency_key = ?').get(ownerId, key) as { result_json: string } | undefined;
+    return row?.result_json;
+  }
+
+  setCommentIdempotency(ownerId: string, key: string, resultJson: string): void {
+    this.database.prepare('INSERT OR REPLACE INTO comment_idempotency(owner_id, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?)')
+      .run(ownerId, key, resultJson, Date.now());
+  }
+
+  getFinalizeIdempotency(ownerId: string, workspaceId: string, key: string): string | undefined {
+    const row = this.database.prepare('SELECT result_json FROM finalize_idempotency WHERE owner_id = ? AND workspace_id = ? AND idempotency_key = ?').get(ownerId, workspaceId, key) as { result_json: string } | undefined;
+    return row?.result_json;
+  }
+
+  setFinalizeIdempotency(ownerId: string, workspaceId: string, key: string, resultJson: string): void {
+    this.database.prepare('INSERT OR REPLACE INTO finalize_idempotency(owner_id, workspace_id, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?, ?)')
+      .run(ownerId, workspaceId, key, resultJson, Date.now());
+  }
+
+  getBatchWriteIdempotency(ownerId: string, workspaceId: string, key: string): string | undefined {
+    const row = this.database.prepare('SELECT result_json FROM batch_write_idempotency WHERE owner_id = ? AND workspace_id = ? AND idempotency_key = ?').get(ownerId, workspaceId, key) as { result_json: string } | undefined;
+    return row?.result_json;
+  }
+
+  setBatchWriteIdempotency(ownerId: string, workspaceId: string, key: string, resultJson: string): void {
+    this.database.prepare('INSERT OR REPLACE INTO batch_write_idempotency(owner_id, workspace_id, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?, ?)')
+      .run(ownerId, workspaceId, key, resultJson, Date.now());
+  }
+
+  resolveActiveWorkspace(ownerId: string, explicitId?: string): WorkspaceRecord {
+    if (explicitId) {
+      const record = this.byOwnerAndId(ownerId, explicitId);
+      if (!record) throw new Error('NOT_FOUND');
+      return record;
+    }
+    const activeWorkspaces = this.list(ownerId).filter((w) => w.status === 'ACTIVE' || w.status === 'CREATING');
+    const preferred = this.getPreferredWorkspace(ownerId);
+    if (preferred) {
+      const record = this.byOwnerAndId(ownerId, preferred);
+      if (record && (record.status === 'ACTIVE' || record.status === 'CREATING')) {
+        return record;
+      }
+    }
+    const firstActive = activeWorkspaces[0];
+    if (activeWorkspaces.length === 1 && firstActive) {
+      return firstActive;
+    }
+    if (activeWorkspaces.length === 0) {
+      if (preferred) {
+        const record = this.byOwnerAndId(ownerId, preferred);
+        if (record && record.status === 'EXPIRED_RECOVERABLE') {
+          return record;
+        }
+      }
+      const recoverable = this.list(ownerId).filter((w) => w.status === 'EXPIRED_RECOVERABLE');
+      const firstRecoverable = recoverable[0];
+      if (recoverable.length === 1 && firstRecoverable) {
+        return firstRecoverable;
+      }
+      throw new Error('NO_ACTIVE_WORKSPACE');
+    }
+    throw new Error('AMBIGUOUS_ACTIVE_WORKSPACES');
   }
 
   updateFenced(
@@ -233,7 +369,7 @@ export class StateStore {
   }
 
   claimForReaping(id: string, generation: number): boolean {
-    const result = this.database.prepare("UPDATE workspaces SET status='REAPING', generation=generation+1 WHERE id=? AND generation=? AND status IN ('CREATING','ACTIVE','FAILED')").run(id, generation);
+    const result = this.database.prepare("UPDATE workspaces SET status='REAPING', generation=generation+1 WHERE id=? AND generation=? AND status IN ('CREATING','ACTIVE','FAILED','EXPIRED_RECOVERABLE')").run(id, generation);
     return result.changes === 1;
   }
   createPrivilegeGrant(input: { ownerId: string; workspaceId: string; command: string; cwd?: string; ttlMs?: number }): PrivilegeGrantRecord {

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -578,20 +578,28 @@ export class WorkspaceService {
     }
   }
 
-  private async runRecoveryWorker(record: WorkspaceRecord, operation: RunnerOperation, input: Record<string, unknown>, signal?: AbortSignal): Promise<RunnerResponse> {
+  private async runRecoveryWorker(
+    record: WorkspaceRecord,
+    operation: RunnerOperation,
+    input: Record<string, unknown>,
+    signal?: AbortSignal,
+    writable = false
+  ): Promise<RunnerResponse> {
     if (record.containerName) {
       return await this.runWorker(record, operation, input, signal);
     }
     const helperName = `chm-rec-${record.id.slice(3, 15)}-${randomBytes(4).toString('hex')}`;
+    const mode = writable ? 'rw' : 'ro';
     try {
       const result = await runDocker([
         'run', '-i', '--rm', '--name', helperName,
         '--label', 'cloud-harness.role=recover-helper', '--label', 'cloud-harness.ephemeral=true',
         '--label', `cloud-harness.instance=${this.instanceId}`, '--label', `cloud-harness.workspace=${record.id}`,
-        '--network', 'none', '--user', '10001:10001', '--read-only',
+        '--network', 'none', '--user', '10001:10001',
+        ...(writable ? [] : ['--read-only']),
         '--tmpfs', '/tmp:rw,exec,nosuid,nodev,size=64m',
         '--pids-limit', '64', '--memory', '256m', '--memory-swap', '256m', '--cpus', '1',
-        '--volume', `${record.workspacePath}/repo:/workspace:ro`,
+        '--volume', `${record.workspacePath}/repo:/workspace:${mode}`,
         '--workdir', '/workspace',
         '--env', 'HOME=/tmp/cloud-harness-home',
         '--entrypoint', '/opt/harness/worker-runner.sh',
@@ -1082,7 +1090,7 @@ export class WorkspaceService {
         const snapshotRes = await this.runRecoveryWorker(rec, 'workspace_recover', {
           mode: 'snapshot_commit',
           message: `chore(recovery): export snapshot for ${targetBranch}`
-        }, signal);
+        }, signal, true);
         const snapshotData = snapshotRes.data as { headCommitSha?: string; committedChanges?: boolean } | undefined;
         const pushResult = await this.remotePush(rec, { refspec: `HEAD:refs/heads/${targetBranch}` }, signal);
         return {

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { chmod, chown, mkdir, readdir, realpath, rm, statfs } from 'node:fs/promises';
-import { join, relative, resolve, sep } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import {
   HarnessError,
   InternalRunnerRequestSchema,
@@ -26,10 +26,31 @@ import { validatedWorkspaceEnvironment } from './workspace-environment.js';
 const opaqueId = (prefix: string) => `${prefix}_${randomBytes(24).toString('base64url')}`;
 const activeStatus = new Set<WorkspaceRecord['status']>(['CREATING', 'ACTIVE', 'REAPING']);
 const auditedFileMutations = new Set<RunnerOperation>([
-  'files_write', 'files_apply_patch', 'files_delete', 'files_move', 'files_mkdir'
+  'files_write', 'files_write_batch', 'files_apply_patch', 'files_delete', 'files_move', 'files_mkdir'
 ]);
 
 function publicRecord(record: WorkspaceRecord) {
+  const now = Date.now();
+  const remainingLeaseMs = Math.max(0, record.expiresAt - now);
+  const hardRemainingMs = Math.max(0, record.hardExpiresAt - now);
+  const canRenewLease = record.status === 'ACTIVE' && hardRemainingMs > 60_000;
+  let leaseState: 'ACTIVE' | 'WARNING' | 'EXPIRED_RECOVERABLE' | 'EXPIRED' = 'ACTIVE';
+  const leaseWarnings: string[] = [];
+
+  if (record.status === 'EXPIRED_RECOVERABLE') {
+    leaseState = 'EXPIRED_RECOVERABLE';
+    leaseWarnings.push('Workspace lease has expired. Work is retained in recoverable grace state.');
+  } else if (record.status === 'CLOSED' || record.status === 'FAILED') {
+    leaseState = 'EXPIRED';
+  } else if (remainingLeaseMs <= 300_000 && record.status === 'ACTIVE') {
+    leaseState = 'WARNING';
+    leaseWarnings.push(`Workspace idle lease expiring in ${Math.round(remainingLeaseMs / 1000)}s.`);
+  }
+
+  if (hardRemainingMs <= 600_000 && hardRemainingMs > 0 && record.status === 'ACTIVE') {
+    leaseWarnings.push(`Workspace approaching hard deadline in ${Math.round(hardRemainingMs / 1000)}s.`);
+  }
+
   return {
     workspaceId: record.id,
     repositoryUrl: record.repositoryUrl,
@@ -39,6 +60,12 @@ function publicRecord(record: WorkspaceRecord) {
     createdAt: new Date(record.createdAt).toISOString(),
     lastActivityAt: new Date(record.lastActivityAt).toISOString(),
     expiresAt: new Date(record.expiresAt).toISOString(),
+    idleExpiresAt: new Date(record.expiresAt).toISOString(),
+    hardExpiresAt: new Date(record.hardExpiresAt).toISOString(),
+    remainingLeaseMs,
+    canRenewLease,
+    leaseState,
+    ...(leaseWarnings.length > 0 ? { leaseWarnings } : {}),
     error: record.error
   };
 }
@@ -132,12 +159,32 @@ export class WorkspaceService {
     for (const entry of await readdir(this.config.jobsRoot, { withFileTypes: true })) {
       if (!entry.isDirectory() || !/^ws_[A-Za-z0-9_-]{20,80}$/.test(entry.name)) continue;
       const record = this.store.byId(entry.name);
-      if (!record || !activeStatus.has(record.status)) await this.safeRemovePath(join(this.config.jobsRoot, entry.name));
+      if (!record || (!activeStatus.has(record.status) && record.status !== 'EXPIRED_RECOVERABLE')) {
+        await this.safeRemovePath(join(this.config.jobsRoot, entry.name));
+      }
     }
   }
 
   private async ensureCapacity(ownerId: string): Promise<void> {
-    if (this.store.list(ownerId).some((record) => activeStatus.has(record.status))) throw new HarnessError('LIMIT_EXCEEDED', 'only one active workspace is allowed in this MVP', 429, true);
+    const list = this.store.list(ownerId);
+    const active = list.filter((record) => activeStatus.has(record.status));
+    const now = Date.now();
+    for (const record of active) {
+      if (record.expiresAt <= now || record.hardExpiresAt <= now) {
+        if (record.containerName) {
+          await removeContainer(record.containerName).catch(() => undefined);
+        }
+        this.store.update(record.id, {
+          status: 'EXPIRED_RECOVERABLE',
+          containerName: null,
+          lastActivityAt: now
+        });
+      }
+    }
+    const remainingActive = this.store.list(ownerId).filter((record) => activeStatus.has(record.status));
+    if (remainingActive.length > 0) {
+      throw new HarnessError('LIMIT_EXCEEDED', 'only one active workspace is allowed in this MVP', 429, true);
+    }
     const info = await statfs(this.config.jobsRoot);
     const freeBytes = Number(info.bavail) * Number(info.bsize);
     if (freeBytes < this.config.minFreeBytes) throw new HarnessError('LIMIT_EXCEEDED', 'host free-space reserve would be violated', 507, true);
@@ -352,11 +399,13 @@ export class WorkspaceService {
     if (parsed.ref?.startsWith('-')) throw new HarnessError('INVALID_INPUT', 'ref cannot start with a dash');
     const now = Date.now();
     const workspaceId = opaqueId('ws');
+    const hardExpiresAt = now + this.config.wallTtlSeconds * 1_000;
     const record: WorkspaceRecord = {
       id: workspaceId, ownerId, idempotencyKey: parsed.idempotencyKey, repositoryUrl: url.toString(),
       repositoryRef: parsed.ref ?? null, containerName: null, workspacePath: join(this.config.jobsRoot, workspaceId),
       status: 'CREATING', networkMode: parsed.networkMode ?? this.config.networkMode, createdAt: now,
-      lastActivityAt: now, expiresAt: this.expiry(now, now), generation: 1, error: null
+      lastActivityAt: now, expiresAt: this.expiry(now, now), hardExpiresAt, gitAuthorName: null, gitAuthorEmail: null,
+      generation: 1, error: null
     };
     try {
       this.store.create(record);
@@ -404,24 +453,67 @@ export class WorkspaceService {
     return { ok: true, message: 'Workspaces listed', data: { workspaces: page.map(publicRecord) }, truncated: false, ...(next ? { cursor: next } : {}) };
   }
 
-  status(ownerId: string, workspaceId: string): RunnerResponse {
-    const record = this.requireWorkspace(ownerId, workspaceId, false);
+  status(ownerId: string, workspaceId?: string): RunnerResponse {
+    const record = this.requireWorkspace(ownerId, workspaceId, false, true);
     return { ok: true, message: 'Workspace status', data: publicRecord(record), truncated: false };
   }
 
-  private requireWorkspace(ownerId: string, workspaceId: string, active = true): WorkspaceRecord {
-    const record = this.store.byOwnerAndId(ownerId, workspaceId);
-    if (!record) throw new HarnessError('NOT_FOUND', 'workspace not found', 404);
-    if (active && record.status !== 'ACTIVE') throw new HarnessError(record.status === 'CLOSED' ? 'EXPIRED' : 'CONFLICT', `workspace is ${record.status.toLowerCase()}`, 409);
-    if (active && record.expiresAt <= Date.now()) throw new HarnessError('EXPIRED', 'workspace expired', 410);
+  private requireWorkspace(ownerId: string, workspaceId?: string, active = true, allowRecoverable = false): WorkspaceRecord {
+    let record: WorkspaceRecord;
+    try {
+      record = this.store.resolveActiveWorkspace(ownerId, workspaceId);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        if (err.message === 'NO_ACTIVE_WORKSPACE' || err.message === 'NOT_FOUND') {
+          throw new HarnessError('NOT_FOUND', 'workspace not found', 404);
+        }
+        if (err.message === 'AMBIGUOUS_ACTIVE_WORKSPACES') {
+          const list = this.store.list(ownerId).filter((w) => w.status === 'ACTIVE' || w.status === 'CREATING');
+          throw new HarnessError('CONFLICT', `Multiple active workspaces found (${list.map((w) => w.id).join(', ')}). Specify workspaceId or set active workspace.`, 409);
+        }
+        if (err.message === 'FORBIDDEN') {
+          throw new HarnessError('FORBIDDEN', 'workspace access not authorized', 403);
+        }
+      }
+      throw new HarnessError('NOT_FOUND', `workspace ${workspaceId ?? ''} not found`, 404);
+    }
+    if (record.status === 'EXPIRED_RECOVERABLE') {
+      if (allowRecoverable) return record;
+      throw new HarnessError('EXPIRED', 'workspace is expired and in recoverable grace state; use workspace_recover or workspace_lease_renew', 410);
+    }
+    if (active && record.status !== 'ACTIVE') {
+      throw new HarnessError(record.status === 'CLOSED' ? 'EXPIRED' : 'CONFLICT', `workspace is ${record.status.toLowerCase()}`, 409);
+    }
+    if (active && record.status === 'ACTIVE' && record.expiresAt <= Date.now()) {
+      if (record.containerName) {
+        void removeContainer(record.containerName).catch(() => undefined);
+      }
+      this.store.updateFenced(record.id, record.generation, ['ACTIVE'], { status: 'EXPIRED_RECOVERABLE', containerName: null, lastActivityAt: Date.now() });
+      throw new HarnessError('EXPIRED', 'workspace expired', 410);
+    }
     return record;
   }
 
   private touch(record: WorkspaceRecord): WorkspaceRecord {
+    if (record.status === 'EXPIRED_RECOVERABLE') return record;
     const now = Date.now();
-    const touched = this.store.updateFenced(record.id, record.generation, ['ACTIVE'], { lastActivityAt: now, expiresAt: this.expiry(record.createdAt, now) });
+    const touched = this.store.updateFenced(record.id, record.generation, ['ACTIVE'], {
+      lastActivityAt: now,
+      expiresAt: this.expiry(record.createdAt, now)
+    });
     if (!touched) throw new HarnessError('EXPIRED', 'workspace lifecycle changed', 410);
     return touched;
+  }
+
+  private async withMutationLease<T>(record: WorkspaceRecord, action: () => Promise<T>): Promise<T> {
+    const now = Date.now();
+    const holdExpiry = Math.min(record.hardExpiresAt + 300_000, Math.max(record.expiresAt, now + 300_000));
+    this.store.update(record.id, { expiresAt: holdExpiry });
+    try {
+      return await action();
+    } finally {
+      this.touch(record);
+    }
   }
 
   private async runWorker(record: WorkspaceRecord, operation: RunnerOperation, input: Record<string, unknown>, signal?: AbortSignal): Promise<RunnerResponse> {
@@ -430,6 +522,15 @@ export class WorkspaceService {
     const operationId = opaqueId('op');
     const pidFile = `/tmp/cloud-harness-operations/${operationId}.pid`;
     const jsonMaxBytes = Math.min(67_108_864, Math.max(this.config.maxOutputBytes, 262_144) * 6 + 8_192);
+
+    this.operations.registerGenericOperation({
+      id: operationId,
+      workspaceId: record.id,
+      kind: operation,
+      deadlineMs: Date.now() + timeout,
+      container: record.containerName
+    });
+
     let result;
     try {
       result = await runDocker([
@@ -440,15 +541,73 @@ export class WorkspaceService {
         ...(signal ? { signal } : {})
       });
     } catch (error) {
+      this.operations.updateGenericOperation(operationId, {
+        status: signal?.aborted ? 'cancelled' : 'failed',
+        error: { code: signal?.aborted ? 'CANCELLED' : 'INTERNAL_ERROR', message: error instanceof Error ? error.message : 'worker failed', retryable: false }
+      });
       if (signal?.aborted) {
         await terminateContainerProcessGroup(record.containerName, pidFile);
         throw new HarnessError('CANCELLED', 'request cancelled', 499, false);
       }
       throw error;
     }
-    if (result.exitCode !== 0) throw new HarnessError('INTERNAL_ERROR', `worker failed: ${result.stderr || result.stdout}`.slice(0, 2_000), 500, true);
-    try { return RunnerResponseSchema.parse(JSON.parse(result.stdout)); }
-    catch { throw new HarnessError('INTERNAL_ERROR', 'worker returned an invalid bounded result', 500, true); }
+    if (result.exitCode !== 0) {
+      this.operations.updateGenericOperation(operationId, {
+        status: 'failed',
+        error: { code: 'INTERNAL_ERROR', message: result.stderr || result.stdout || 'worker failed', retryable: true }
+      });
+      throw new HarnessError('INTERNAL_ERROR', `worker failed: ${result.stderr || result.stdout}`.slice(0, 2_000), 500, true);
+    }
+    try {
+      const parsed = RunnerResponseSchema.parse(JSON.parse(result.stdout));
+      this.operations.updateGenericOperation(operationId, {
+        status: parsed.ok ? 'completed' : 'failed',
+        result: parsed.data,
+        error: parsed.error
+      });
+      return {
+        ...parsed,
+        data: parsed.data && typeof parsed.data === 'object' ? { ...parsed.data, operationId } : parsed.data
+      };
+    } catch {
+      this.operations.updateGenericOperation(operationId, {
+        status: 'failed',
+        error: { code: 'INTERNAL_ERROR', message: 'worker returned an invalid bounded result', retryable: true }
+      });
+      throw new HarnessError('INTERNAL_ERROR', 'worker returned an invalid bounded result', 500, true);
+    }
+  }
+
+  private async runRecoveryWorker(record: WorkspaceRecord, operation: RunnerOperation, input: Record<string, unknown>, signal?: AbortSignal): Promise<RunnerResponse> {
+    if (record.containerName) {
+      return await this.runWorker(record, operation, input, signal);
+    }
+    const helperName = `chm-rec-${record.id.slice(3, 15)}-${randomBytes(4).toString('hex')}`;
+    try {
+      const result = await runDocker([
+        'run', '-i', '--rm', '--name', helperName,
+        '--label', 'cloud-harness.role=recover-helper', '--label', 'cloud-harness.ephemeral=true',
+        '--label', `cloud-harness.instance=${this.instanceId}`, '--label', `cloud-harness.workspace=${record.id}`,
+        '--network', 'none', '--user', '10001:10001', '--read-only',
+        '--tmpfs', '/tmp:rw,exec,nosuid,nodev,size=64m',
+        '--pids-limit', '64', '--memory', '256m', '--memory-swap', '256m', '--cpus', '1',
+        '--volume', `${record.workspacePath}/repo:/workspace:ro`,
+        '--workdir', '/workspace',
+        '--env', 'HOME=/tmp/cloud-harness-home',
+        '--entrypoint', '/opt/harness/worker-runner.sh',
+        this.config.executorImage,
+        opaqueId('rec')
+      ], {
+        stdin: JSON.stringify({ operation, input }),
+        timeoutMs: 60_000,
+        maxBytes: this.config.maxOutputBytes,
+        ...(signal ? { signal } : {})
+      });
+      if (result.exitCode !== 0) throw new HarnessError('INTERNAL_ERROR', `recovery worker failed: ${result.stderr || result.stdout}`.slice(0, 2_000), 500, true);
+      return RunnerResponseSchema.parse(JSON.parse(result.stdout));
+    } finally {
+      await removeContainer(helperName);
+    }
   }
 
   private async runGitTransferHelper(
@@ -503,12 +662,30 @@ export class WorkspaceService {
   }
 
   private async currentBranch(record: WorkspaceRecord, signal?: AbortSignal): Promise<string> {
-    if (!record.containerName) throw new HarnessError('UNAVAILABLE', 'workspace executor is unavailable', 503, true);
-    const result = await runDocker([
-      'exec', record.containerName, 'git', '-c', 'core.hooksPath=/dev/null', '-c', 'core.pager=cat', 'branch', '--show-current'
-    ], { timeoutMs: 30_000, maxBytes: 8_192, ...(signal ? { signal } : {}) });
-    if (result.exitCode !== 0) throw new HarnessError('CONFLICT', 'current Git branch could not be determined', 409, false);
-    return result.stdout.trim();
+    if (record.containerName) {
+      const result = await runDocker([
+        'exec', record.containerName, 'git', '-c', 'core.hooksPath=/dev/null', '-c', 'core.pager=cat', 'branch', '--show-current'
+      ], { timeoutMs: 30_000, maxBytes: 8_192, ...(signal ? { signal } : {}) });
+      if (result.exitCode !== 0) throw new HarnessError('CONFLICT', 'current Git branch could not be determined', 409, false);
+      return result.stdout.trim();
+    }
+    const helperName = `chm-br-${record.id.slice(3, 15)}-${randomBytes(4).toString('hex')}`;
+    try {
+      const result = await runDocker([
+        'run', '--rm', '--name', helperName,
+        '--label', 'cloud-harness.ephemeral=true',
+        '--network', 'none', '--user', '10001:10001', '--read-only',
+        '--volume', `${record.workspacePath}/repo:/workspace:ro`,
+        '--workdir', '/workspace',
+        '--entrypoint', 'git',
+        this.config.executorImage,
+        '-c', 'core.hooksPath=/dev/null', '-c', 'core.pager=cat', 'branch', '--show-current'
+      ], { timeoutMs: 30_000, maxBytes: 8_192, ...(signal ? { signal } : {}) });
+      if (result.exitCode !== 0) throw new HarnessError('CONFLICT', 'current Git branch could not be determined', 409, false);
+      return result.stdout.trim();
+    } finally {
+      await removeContainer(helperName);
+    }
   }
 
   private async remoteFetch(record: WorkspaceRecord, remoteRef: string | undefined, signal?: AbortSignal) {
@@ -517,9 +694,11 @@ export class WorkspaceService {
     const transferName = `git-transfer-${randomBytes(12).toString('hex')}`;
     try {
       const fetched = await this.runGitTransferHelper(record, 'fetch', transferName, remoteRef ?? '', token, undefined, signal);
-      const imported = await this.withPausedExecutor(record, async () =>
-        await this.runGitTransferHelper(record, 'import', transferName, remoteRef ?? '', undefined, undefined, signal)
-      );
+      const imported = record.containerName
+        ? await this.withPausedExecutor(record, async () =>
+            await this.runGitTransferHelper(record, 'import', transferName, remoteRef ?? '', undefined, undefined, signal)
+          )
+        : await this.runGitTransferHelper(record, 'import', transferName, remoteRef ?? '', undefined, undefined, signal);
       return { fetched, imported };
     } finally {
       await this.safeRemovePath(join(record.workspacePath, transferName));
@@ -536,15 +715,20 @@ export class WorkspaceService {
     const refspec = normalizePushRefspec(requestedRefspec, branch);
     const transferName = `git-transfer-${randomBytes(12).toString('hex')}`;
     try {
-      await this.withPausedExecutor(record, async () =>
-        await this.runGitTransferHelper(record, 'stage-push', transferName, '', undefined, undefined, signal)
-      );
+      if (record.containerName) {
+        await this.withPausedExecutor(record, async () =>
+          await this.runGitTransferHelper(record, 'stage-push', transferName, '', undefined, undefined, signal)
+        );
+      } else {
+        await this.runGitTransferHelper(record, 'stage-push', transferName, '', undefined, undefined, signal);
+      }
       const pushed = await this.runGitTransferHelper(record, 'push', transferName, refspec, token, input.expectedRemoteOid as string | undefined, signal);
       return { ok: true, message: 'Git push complete', data: { output: pushed.stdout || pushed.stderr, refspec }, truncated: pushed.truncated };
     } finally {
       await this.safeRemovePath(join(record.workspacePath, transferName));
     }
   }
+
   private async handleExecRun(record: WorkspaceRecord, validated: Record<string, unknown>, signal?: AbortSignal): Promise<RunnerResponse> {
     const command = validated.command as string;
     const cwd = ((validated.cwd as string) || '.').replaceAll('\\', '/').replace(/^\/+/, '').replace(/\/+$/, '') || '.';
@@ -659,14 +843,13 @@ export class WorkspaceService {
 
   private async runBrokeredGitHubAction(
     record: WorkspaceRecord,
-    action: 'pr_list' | 'pr_view' | 'pr_create' | 'issue_list' | 'issue_view' | 'issue_create',
+    action: string,
     args: string[],
     signal?: AbortSignal
   ): Promise<RunnerResponse> {
-    const isWrite = action === 'pr_create' || action === 'issue_create';
+    const isWrite = ['pr_create', 'issue_create', 'issue_comment', 'issue_comment_update', 'label_create', 'issue_labels_add', 'issue_labels_remove', 'issue_update'].includes(action);
     const permissionScope = action.startsWith('pr_') ? 'pull_requests' : 'issues';
 
-    // mintPrincipalRepositoryScopedToken handles both cloudflare-access (via installations) and owner-bearer (via config.githubApp.installationId)
     const token = await mintPrincipalRepositoryScopedToken({
       config: this.config,
       principalId: record.ownerId,
@@ -691,11 +874,11 @@ export class WorkspaceService {
         '--network', 'bridge',
         '--user', '10001:10001',
         '--read-only',
-        '--tmpfs', '/tmp:rw,exec,size=32m',
+        '--tmpfs', '/tmp:rw,exec,nosuid,nodev,size=64m',
         '--cap-drop', 'ALL',
         '--security-opt', 'no-new-privileges',
-        '--pids-limit', '128',
-        '--memory', '512m', '--memory-swap', '512m', '--cpus', '1',
+        '--pids-limit', '64',
+        '--memory', '256m', '--memory-swap', '256m', '--cpus', '1',
         '--ulimit', 'nofile=1024:1024',
         '--volume', `${record.workspacePath}/repo:/workspace:ro`,
         '--workdir', '/workspace',
@@ -729,11 +912,403 @@ export class WorkspaceService {
     const validated = TOOL_SCHEMA_BY_NAME[operation].parse(input) as Record<string, unknown>;
     if (operation === 'workspace_open') return await this.open(ownerId, validated);
     if (operation === 'workspace_list') return this.list(ownerId, validated);
-    const workspaceId = validated.workspaceId as string;
+    if (operation === 'operation_status') {
+      const opId = validated.operationId as string;
+      const op = this.operations.getGenericOperation(opId);
+      if (!op) throw new HarnessError('NOT_FOUND', `operation ${opId} not found`);
+      if (op.workspaceId) {
+        const ws = this.store.byOwnerAndId(ownerId, op.workspaceId);
+        if (!ws) throw new HarnessError('NOT_FOUND', `operation ${opId} not found`);
+      }
+      const offset = validated.cursor ? Number(validated.cursor) : 0;
+      if (!Number.isSafeInteger(offset) || offset < 0) throw new HarnessError('INVALID_INPUT', 'invalid operation output cursor');
+      const total = op.output.length;
+      const end = Math.min(total, offset + 65_536);
+      const page = op.output.subarray(offset, end).toString('utf8');
+      const isTruncated = end < total;
+      return {
+        ok: true,
+        message: `Operation ${op.status}`,
+        data: {
+          operationId: op.id,
+          status: op.status,
+          kind: op.kind,
+          createdAt: new Date(op.createdAt).toISOString(),
+          progress: op.progress,
+          result: op.result,
+          output: page
+        },
+        ...(isTruncated ? { cursor: String(end) } : {}),
+        truncated: isTruncated
+      };
+    }
+    if (operation === 'operation_cancel') {
+      const opId = validated.operationId as string;
+      const existing = this.operations.getGenericOperation(opId);
+      if (!existing) throw new HarnessError('NOT_FOUND', `operation ${opId} not found`);
+      if (existing.workspaceId) {
+        const ws = this.store.byOwnerAndId(ownerId, existing.workspaceId);
+        if (!ws) throw new HarnessError('NOT_FOUND', `operation ${opId} not found`);
+      }
+      const op = await this.operations.cancelGenericOperation(opId);
+      return {
+        ok: true,
+        message: 'Operation cancelled',
+        data: {
+          operationId: op.id,
+          status: op.status
+        },
+        truncated: false
+      };
+    }
+    if (operation === 'operation_wait') {
+      const opId = validated.operationId as string;
+      const existing = this.operations.getGenericOperation(opId);
+      if (!existing) throw new HarnessError('NOT_FOUND', `operation ${opId} not found`);
+      if (existing.workspaceId) {
+        const ws = this.store.byOwnerAndId(ownerId, existing.workspaceId);
+        if (!ws) throw new HarnessError('NOT_FOUND', `operation ${opId} not found`);
+      }
+      const timeoutMs = (validated.timeoutMs as number) || 60_000;
+      const startTime = Date.now();
+      while (Date.now() - startTime < timeoutMs) {
+        const op = this.operations.getGenericOperation(opId);
+        if (!op) throw new HarnessError('NOT_FOUND', `operation ${opId} not found`);
+        if (op.status === 'completed' || op.status === 'failed' || op.status === 'cancelled') {
+          return {
+            ok: op.status === 'completed',
+            message: `Operation ${op.status}`,
+            data: { operationId: op.id, status: op.status, result: op.result, error: op.error },
+            truncated: false
+          };
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
+      return {
+        ok: false,
+        message: 'Operation wait timed out',
+        error: { code: 'TIMEOUT', message: 'Operation did not reach terminal state within timeout', retryable: true },
+        truncated: false
+      };
+    }
+    if (operation === 'workspace_set_active') {
+      const targetId = validated.workspaceId as string;
+      const targetRecord = this.store.byOwnerAndId(ownerId, targetId);
+      if (!targetRecord) throw new HarnessError('NOT_FOUND', `workspace ${targetId} not found`);
+      this.store.setPreferredWorkspace(ownerId, targetId);
+      return {
+        ok: true,
+        message: 'Active workspace set',
+        data: { activeWorkspaceId: targetId, workspace: publicRecord(targetRecord) },
+        truncated: false
+      };
+    }
+    if (operation === 'git_identity_status') {
+      const identity = this.store.getGitIdentity(ownerId);
+      return {
+        ok: true,
+        message: 'Git identity status',
+        data: identity ? { ...identity, source: 'owner' } : {
+          name: 'Cloud Harness Agent',
+          email: 'agent@cloud-harness.local',
+          source: 'default'
+        },
+        truncated: false
+      };
+    }
+    if (operation === 'git_identity_set') {
+      const name = validated.name as string;
+      const email = validated.email as string;
+      if (validated.workspaceId) {
+        const ws = this.requireWorkspace(ownerId, validated.workspaceId as string, false, true);
+        this.store.update(ws.id, { gitAuthorName: name, gitAuthorEmail: email });
+      } else {
+        this.store.setGitIdentity(ownerId, { name, email });
+      }
+      return {
+        ok: true,
+        message: 'Git identity configured',
+        data: { name, email },
+        truncated: false
+      };
+    }
+
+    const workspaceId = validated.workspaceId as string | undefined;
     if (operation === 'workspace_status') return this.status(ownerId, workspaceId);
-    if (operation === 'workspace_close') return await this.close(ownerId, workspaceId);
-    const record = this.touch(this.requireWorkspace(ownerId, workspaceId));
+    if (operation === 'workspace_close') {
+      const rec = this.requireWorkspace(ownerId, workspaceId, false, true);
+      return await this.close(ownerId, rec.id);
+    }
+    if (operation === 'workspace_lease_renew') {
+      const rec = this.requireWorkspace(ownerId, workspaceId, false, true);
+      const now = Date.now();
+      if (rec.hardExpiresAt <= now) {
+        throw new HarnessError('EXPIRED', 'Workspace hard lease limit reached and cannot be renewed');
+      }
+      const extSec = (validated.extensionSeconds as number) ?? this.config.idleTtlSeconds;
+      const newExpires = Math.min(rec.hardExpiresAt, now + extSec * 1000);
+      const updated = this.store.update(rec.id, { status: 'ACTIVE', lastActivityAt: now, expiresAt: newExpires });
+      return { ok: true, message: 'Workspace lease renewed', data: publicRecord(updated), truncated: false };
+    }
+    if (operation === 'workspace_recover') {
+      const rec = this.requireWorkspace(ownerId, workspaceId, false, true);
+      const mode = (validated.mode as 'status' | 'patch' | 'export') ?? 'status';
+      if (mode === 'status') {
+        const gitStatus = await this.runRecoveryWorker(rec, 'git_status', {}, signal);
+        const gitLog = await this.runRecoveryWorker(rec, 'git_log', { limit: 10 }, signal);
+        return {
+          ok: true,
+          message: 'Workspace recovery status',
+          data: {
+            workspace: publicRecord(rec),
+            gitStatus: gitStatus.data,
+            gitLog: gitLog.data
+          },
+          truncated: false
+        };
+      }
+      if (mode === 'patch') {
+        const diff = await this.runRecoveryWorker(rec, 'git_diff', { readAll: true }, signal);
+        return {
+          ok: true,
+          message: 'Workspace recovery patch',
+          data: {
+            workspace: publicRecord(rec),
+            patch: diff.data
+          },
+          truncated: false
+        };
+      }
+      if (mode === 'export') {
+        const targetBranch = (validated.targetBranch as string | undefined) ?? await this.currentBranch(rec, signal);
+        const pushResult = await this.remotePush(rec, { refspec: `HEAD:refs/heads/${targetBranch}` }, signal);
+        return {
+          ok: pushResult.ok,
+          message: pushResult.ok ? 'Workspace state exported to remote branch' : 'Workspace export failed',
+          data: {
+            workspace: publicRecord(rec),
+            branch: targetBranch,
+            pushResult: pushResult.data
+          },
+          truncated: false
+        };
+      }
+    }
+
+    const record = this.touch(this.requireWorkspace(ownerId, workspaceId, true, false));
     await this.enforceActiveLimits(record);
+
+    if (operation === 'workspace_context') {
+      let branch = '';
+      try {
+        branch = await this.currentBranch(record, signal);
+      } catch { /* branch resolution optional */ }
+      const gitIdentity = this.store.getGitIdentity(ownerId) ?? {
+        name: record.gitAuthorName || 'Cloud Harness Agent',
+        email: record.gitAuthorEmail || 'agent@cloud-harness.local'
+      };
+      return {
+        ok: true,
+        message: 'Workspace context',
+        data: {
+          workspace: publicRecord(record),
+          branch,
+          gitIdentity
+        },
+        truncated: false
+      };
+    }
+    if (operation === 'files_write_batch') {
+      const idempotencyKey = validated.idempotencyKey as string | undefined;
+      if (idempotencyKey) {
+        const cached = this.store.getBatchWriteIdempotency(ownerId, record.id, idempotencyKey);
+        if (cached) {
+          return JSON.parse(cached) as RunnerResponse;
+        }
+      }
+      return await this.withMutationLease(record, async () => {
+        const result = await this.runWorker(record, 'files_write_batch', validated, signal);
+        await this.enforceActiveLimits(record);
+        if (idempotencyKey && result.ok) {
+          this.store.setBatchWriteIdempotency(ownerId, record.id, idempotencyKey, JSON.stringify(result));
+        }
+        return result;
+      });
+    }
+    if (operation === 'workspace_finalize') {
+      const idempotencyKey = validated.idempotencyKey as string | undefined;
+      if (idempotencyKey) {
+        const cached = this.store.getFinalizeIdempotency(ownerId, record.id, idempotencyKey);
+        if (cached) {
+          return JSON.parse(cached) as RunnerResponse;
+        }
+      }
+
+      return await this.withMutationLease(record, async () => {
+        // Step 1: Preflight checks
+        const preflight = validated.preflight as { checkDiff?: boolean; forbiddenPatterns?: string[] } | undefined;
+        if (preflight?.checkDiff !== false) {
+          const diffResult = await this.runWorker(record, 'git_diff', { readAll: true }, signal);
+          const diffOutput = (diffResult.data && typeof diffResult.data === 'object' && 'output' in diffResult.data && typeof diffResult.data.output === 'string') ? diffResult.data.output : '';
+          if (diffResult.truncated) {
+            return {
+              ok: false,
+              message: 'Preflight check failed: diff output too large to verify cleanly',
+              data: { step: 'preflight', error: 'diff output exceeds preflight capacity' },
+              error: { code: 'LIMIT_EXCEEDED', message: 'diff exceeds verification limit', retryable: false },
+              truncated: false
+            };
+          }
+          if (diffOutput.includes('<<<<<<< ') || diffOutput.includes('=======\n') || diffOutput.includes('>>>>>>> ')) {
+            return {
+              ok: false,
+              message: 'Preflight check failed: unresolved merge conflict markers detected',
+              data: { step: 'preflight', errors: ['Merge conflict markers found in working tree'] },
+              error: { code: 'CONFLICT', message: 'Merge conflict markers detected', retryable: false },
+              truncated: false
+            };
+          }
+          if (preflight?.forbiddenPatterns) {
+            for (const pat of preflight.forbiddenPatterns) {
+              if (pat && diffOutput.includes(pat)) {
+                return {
+                  ok: false,
+                  message: `Preflight check failed: forbidden pattern "${pat}" detected`,
+                  data: { step: 'preflight', errors: [`Forbidden pattern "${pat}" found in diff`] },
+                  error: { code: 'INVALID_INPUT', message: `Forbidden pattern "${pat}" detected`, retryable: false },
+                  truncated: false
+                };
+              }
+            }
+          }
+        }
+
+        // Step 2: Check current git status
+        const currentStatus = await this.runWorker(record, 'git_status', {}, signal);
+        const statusOutput = (currentStatus.data && typeof currentStatus.data === 'object' && 'output' in currentStatus.data && typeof currentStatus.data.output === 'string') ? currentStatus.data.output : '';
+        const changedLines = statusOutput.split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('##'));
+        const branch = (validated.branch as string | undefined) ?? await this.currentBranch(record, signal);
+
+        // If tree is already clean, check if we need to push or if already finalized
+        if (changedLines.length === 0) {
+          const logResult = await this.runWorker(record, 'git_log', { limit: 1 }, signal);
+          const commitSha = (logResult.data && typeof logResult.data === 'object' && 'output' in logResult.data && typeof logResult.data.output === 'string') ? logResult.data.output.split('\t')?.[0] || '' : '';
+          let pushed = false;
+          let pushResult: RunnerResponse | undefined;
+          if (validated.push !== false) {
+            try {
+              pushResult = await this.remotePush(record, { refspec: `HEAD:refs/heads/${branch}` }, signal);
+              pushed = Boolean(pushResult.ok);
+            } catch (err: unknown) {
+              const pushErrMsg = err instanceof Error ? err.message : 'push failed';
+              return {
+                ok: false,
+                message: `Working tree clean but push failed: ${pushErrMsg}`,
+                data: { step: 'push', commitSha, branch, pushed: false, pushError: pushErrMsg, resumeAction: 'Call git_push or workspace_finalize to retry push' },
+                error: { code: 'UNAVAILABLE', message: pushErrMsg, retryable: true },
+                truncated: false
+              };
+            }
+          }
+          const response: RunnerResponse = {
+            ok: true,
+            message: `Workspace already clean and finalized at ${commitSha.slice(0, 7)}`,
+            data: { commitSha, branch, pushed, alreadyFinalized: true, finalStatus: currentStatus.data },
+            truncated: false
+          };
+          if (idempotencyKey) {
+            this.store.setFinalizeIdempotency(ownerId, record.id, idempotencyKey, JSON.stringify(response));
+          }
+          return response;
+        }
+
+        // Step 3: Stage changes
+        const stageResult = await this.runWorker(record, 'git_add', {
+          all: validated.all !== false && (!validated.paths || (validated.paths as string[]).length === 0),
+          paths: (validated.paths as string[]) ?? []
+        }, signal);
+        if (!stageResult.ok) {
+          return {
+            ok: false,
+            message: 'Failed to stage changes',
+            data: { step: 'stage', error: stageResult.message },
+            error: { code: 'CONFLICT', message: stageResult.message, retryable: true },
+            truncated: false
+          };
+        }
+
+        // Step 4: Resolve Git author & Commit
+        const storedIdentity = this.store.getGitIdentity(ownerId);
+        const authorName = (validated.authorName as string | undefined) || record.gitAuthorName || storedIdentity?.name || 'Cloud Harness Agent';
+        const authorEmail = (validated.authorEmail as string | undefined) || record.gitAuthorEmail || storedIdentity?.email || 'agent@cloud-harness.local';
+
+        const commitMsg = validated.commitMessage as string;
+        const commitResult = await this.runWorker(record, 'git_commit', {
+          message: commitMsg,
+          authorName,
+          authorEmail,
+          all: false
+        }, signal);
+        if (!commitResult.ok) {
+          return {
+            ok: false,
+            message: `Commit failed: ${commitResult.message}`,
+            data: { step: 'commit', error: commitResult.message },
+            error: { code: 'CONFLICT', message: commitResult.message, retryable: true },
+            truncated: false
+          };
+        }
+
+        const logResult = await this.runWorker(record, 'git_log', { limit: 1 }, signal);
+        const commitSha = (logResult.data && typeof logResult.data === 'object' && 'output' in logResult.data && typeof logResult.data.output === 'string') ? logResult.data.output.split('\t')?.[0] || '' : '';
+
+        // Step 5: Push if requested
+        let pushResult: RunnerResponse | undefined;
+        let pushed = false;
+        if (validated.push !== false) {
+          try {
+            pushResult = await this.remotePush(record, { refspec: `HEAD:refs/heads/${branch}` }, signal);
+            pushed = Boolean(pushResult.ok);
+          } catch (pushErr: unknown) {
+            const pushErrMsg = pushErr instanceof Error ? pushErr.message : 'push failed';
+            return {
+              ok: false,
+              message: `Commit created (${commitSha.slice(0, 7)}) but push failed: ${pushErrMsg}`,
+              data: {
+                step: 'push',
+                commitSha,
+                branch,
+                pushed: false,
+                pushError: pushErrMsg,
+                resumeAction: 'Call git_push or workspace_finalize to retry push'
+              },
+              error: { code: 'UNAVAILABLE', message: pushErrMsg, retryable: true },
+              truncated: false
+            };
+          }
+        }
+
+        const finalStatus = await this.runWorker(record, 'git_status', {}, signal);
+        await this.enforceActiveLimits(record);
+
+        const response: RunnerResponse = {
+          ok: true,
+          message: pushed ? `Workspace finalized and pushed to ${branch}` : `Workspace finalized (commit ${commitSha.slice(0, 7)})`,
+          data: {
+            commitSha,
+            branch,
+            pushed,
+            pushResult: pushResult?.data,
+            finalStatus: finalStatus.data
+          },
+          truncated: false
+        };
+        if (idempotencyKey) {
+          this.store.setFinalizeIdempotency(ownerId, record.id, idempotencyKey, JSON.stringify(response));
+        }
+        return response;
+      });
+    }
     if (operation === 'exec_run') {
       validated.maxOutputBytes = Math.min(validated.maxOutputBytes as number, this.config.maxOutputBytes);
       const result = await this.handleExecRun(record, validated, signal);
@@ -741,7 +1316,13 @@ export class WorkspaceService {
       return result;
     }
     if (operation === 'github_action') {
-      const action = validated.action as 'pr_list' | 'pr_view' | 'pr_create' | 'issue_list' | 'issue_view' | 'issue_create';
+      const action = validated.action as string;
+      if ((action === 'issue_comment' || action === 'issue_labels_add') && validated.idempotencyKey) {
+        const cached = this.store.getCommentIdempotency(ownerId, validated.idempotencyKey as string);
+        if (cached) {
+          return JSON.parse(cached) as RunnerResponse;
+        }
+      }
       let args: string[] = [];
       switch (action) {
         case 'pr_list': args = [String(validated.limit ?? 20), (validated.state as string) ?? 'open']; break;
@@ -750,8 +1331,17 @@ export class WorkspaceService {
         case 'issue_list': args = [String(validated.limit ?? 20), (validated.state as string) ?? 'open']; break;
         case 'issue_view': args = [String(validated.issueNumber)]; break;
         case 'issue_create': args = [validated.title as string, (validated.body as string) ?? '']; break;
+        case 'issue_comment': args = [String(validated.issueNumber), validated.body as string]; break;
+        case 'issue_comment_update': args = [String(validated.commentId), validated.body as string]; break;
+        case 'label_create': args = [validated.name as string, (validated.color as string) ?? '0E8A16', (validated.description as string) ?? '']; break;
+        case 'issue_labels_add': args = [String(validated.issueNumber), (validated.labels as string[]).join(','), String(validated.createMissing ?? true)]; break;
+        case 'issue_labels_remove': args = [String(validated.issueNumber), validated.label as string]; break;
+        case 'issue_update': args = [String(validated.issueNumber), (validated.title as string) ?? '', (validated.body as string) ?? '', (validated.state as string) ?? '', (validated.stateReason as string) ?? '']; break;
       }
       const result = await this.runBrokeredGitHubAction(record, action, args, signal);
+      if ((action === 'issue_comment' || action === 'issue_labels_add') && validated.idempotencyKey && result.ok) {
+        this.store.setCommentIdempotency(ownerId, validated.idempotencyKey as string, JSON.stringify(result));
+      }
       await this.enforceActiveLimits(record);
       return result;
     }
@@ -884,6 +1474,36 @@ export class WorkspaceService {
     });
   }
 
+  private auditWorkspaceMutation(
+    ownerId: string,
+    action: string,
+    record: WorkspaceRecord,
+    details: Record<string, string | number | boolean>
+  ): void {
+    if (!this.metadata) return;
+    try {
+      this.metadata.recordAudit(
+        ownerId,
+        action,
+        'workspace',
+        record.id,
+        record.generation,
+        details
+      );
+    } catch { /* mutation audit persistence is best-effort */ }
+  }
+
+  private auditWorkspaceOutcome(
+    ownerId: string,
+    action: string,
+    record: WorkspaceRecord,
+    details: Record<string, string | number | boolean>
+  ): void {
+    try {
+      this.metadata?.recordAudit(ownerId, action, 'workspace', record.id, record.generation, details);
+    } catch { /* outcome audit persistence is best-effort */ }
+  }
+
   async readArtifactSource(
     principal: PrincipalSelector,
     input: { workspaceId: string; path: string }
@@ -902,16 +1522,16 @@ export class WorkspaceService {
   ): Promise<RunnerResponse> {
     const parsed = InternalRunnerRequestSchema.parse({ version: 2, principal, operation, input });
     const ownerId = this.store.resolvePrincipal(parsed.principal);
-    const record = this.requireWorkspace(ownerId, parsed.input.workspaceId, false);
+    const record = this.requireWorkspace(ownerId, parsed.input.workspaceId, false, true);
     if (parsed.operation === 'workspace_detail') {
       return { ok: true, message: 'Workspace detail', data: internalWorkspaceDetail(record), truncated: false };
     }
-    return await this.closeFenced(ownerId, parsed.input.workspaceId, parsed.input.expectedGeneration);
+    return await this.closeFenced(ownerId, parsed.input.workspaceId, parsed.input.expectedGeneration!);
   }
 
   async closeFenced(ownerId: string, workspaceId: string, expectedGeneration: number): Promise<RunnerResponse> {
-    const record = this.requireWorkspace(ownerId, workspaceId, false);
-    if (record.status === 'CLOSED' || record.expiresAt <= Date.now()) {
+    const record = this.requireWorkspace(ownerId, workspaceId, false, true);
+    if (record.status === 'CLOSED' || (record.status === 'ACTIVE' && record.expiresAt <= Date.now())) {
       throw new HarnessError('EXPIRED', 'workspace expired', 410);
     }
     if (record.generation !== expectedGeneration) {
@@ -920,14 +1540,14 @@ export class WorkspaceService {
     this.auditWorkspaceMutation(ownerId, 'workspace.close.requested', record, {});
     if (!this.store.claimForReaping(record.id, expectedGeneration)) {
       const current = this.store.byOwnerAndId(ownerId, workspaceId);
-      if (!current || current.status === 'CLOSED' || current.expiresAt <= Date.now()) {
+      if (!current || current.status === 'CLOSED' || (current.status === 'ACTIVE' && current.expiresAt <= Date.now())) {
         throw new HarnessError('EXPIRED', 'workspace expired', 410);
       }
       throw new HarnessError('CONFLICT', 'workspace lifecycle changed', 409);
     }
     const claimed = this.store.byOwnerAndId(ownerId, workspaceId)!;
     try {
-      await this.closeRecord(claimed, 'closed by owner');
+      await this.closeRecord(claimed, 'closed by operator');
     } catch (error) {
       this.auditWorkspaceOutcome(ownerId, 'workspace.close.failed', claimed, {});
       throw error;
@@ -942,60 +1562,32 @@ export class WorkspaceService {
     };
   }
 
-  private auditWorkspaceMutation(
-    principalId: string,
-    action: string,
-    record: WorkspaceRecord,
-    details: Record<string, string | number | boolean>
-  ): void {
-    this.metadata?.recordAudit(principalId, action, 'workspace', record.id, record.generation, details);
-  }
-
-  private auditWorkspaceOutcome(
-    principalId: string,
-    action: string,
-    record: WorkspaceRecord,
-    details: Record<string, string | number | boolean>
-  ): void {
-    try {
-      this.auditWorkspaceMutation(principalId, action, record, details);
-    } catch {
-      process.stderr.write('workspace audit outcome could not be persisted; the durable request event requires reconciliation\n');
-    }
-  }
-
   async close(ownerId: string, workspaceId: string): Promise<RunnerResponse> {
-    const record = this.requireWorkspace(ownerId, workspaceId, false);
-    if (record.status === 'CLOSED') return { ok: true, message: 'Workspace already closed', data: publicRecord(record), truncated: false };
-    await this.closeRecord(record, 'closed by owner');
-    return { ok: true, message: 'Workspace closed', data: publicRecord(this.store.byId(workspaceId)!), truncated: false };
+    const record = this.requireWorkspace(ownerId, workspaceId, false, true);
+    await this.closeRecord(record, 'closed by client');
+    this.auditWorkspaceOutcome(ownerId, 'workspace.closed', record, { reason: 'closed by client' });
+    const finalRecord = this.store.byId(workspaceId) ?? record;
+    return { ok: true, message: 'Workspace closed', data: publicRecord(finalRecord), truncated: false };
   }
 
   private async safeRemovePath(path: string): Promise<void> {
-    const root = resolve(this.config.jobsRoot);
     const target = resolve(path);
-    if (target === root || !target.startsWith(`${root}${sep}`) || relative(root, target).startsWith('..')) throw new Error('refusing unsafe workspace cleanup path');
-    try {
-      const actualRoot = await realpath(root);
-      const actualTarget = await realpath(target);
-      if (!actualTarget.startsWith(`${actualRoot}${sep}`)) throw new Error('workspace cleanup path escaped jobs root');
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    if (!target.startsWith(`${resolve(this.config.jobsRoot)}${sep}`)) {
+      throw new Error(`path ${path} is outside jobsRoot ${this.config.jobsRoot}`);
     }
     try {
       await rm(target, { recursive: true, force: true, maxRetries: 3 });
     } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'EACCES' && code !== 'EPERM') throw error;
-      const helperName = `chm-clean-${randomBytes(8).toString('hex')}`;
+      if ((error as { code?: string })?.code === 'ENOENT') return;
+      const helperName = `chm-rm-${randomBytes(8).toString('hex')}`;
       const cleaned = await runDocker([
         'run', '--rm', '--pull', 'never', '--name', helperName,
         '--label', 'cloud-harness.role=cleanup-helper', '--label', 'cloud-harness.ephemeral=true',
-        '--label', `cloud-harness.instance=${this.instanceId}`, '--network', 'none', '--user', '0:0',
-        '--read-only', '--tmpfs', '/tmp:rw,nosuid,nodev,size=16m',
-        '--pids-limit', '32', '--memory', '128m', '--memory-swap', '128m', '--cpus', '0.25',
-        '--volume', `${target}:/target:rw`, '--entrypoint', '/usr/bin/find', this.config.executorImage,
-        '/target', '-mindepth', '1', '-delete'
+        '--label', `cloud-harness.instance=${this.instanceId}`,
+        '--network', 'none', '--user', '0:0',
+        '--volume', `${target}:/target`,
+        '--entrypoint', '/bin/sh', this.config.executorImage,
+        '-c', 'chmod -R u+rwX /target 2>/dev/null || true'
       ], { timeoutMs: 30_000, maxBytes: 65_536 });
       if (cleaned.exitCode !== 0) throw new HarnessError('UNAVAILABLE', 'workspace permissions could not be normalized for cleanup', 503, true);
       await rm(target, { recursive: true, force: true, maxRetries: 3 });
@@ -1019,10 +1611,25 @@ export class WorkspaceService {
   private async reapExpired(): Promise<void> {
     const now = Date.now();
     for (const record of this.store.active()) {
-      if (record.expiresAt <= now) await this.closeRecord(record, 'workspace TTL expired').catch(() => undefined);
-      else if (record.status === 'ACTIVE') {
+      if (record.expiresAt <= now || record.hardExpiresAt <= now) {
+        if (record.containerName) {
+          await removeContainer(record.containerName).catch(() => undefined);
+        }
+        this.store.updateFenced(record.id, record.generation, ['ACTIVE'], {
+          status: 'EXPIRED_RECOVERABLE',
+          containerName: null,
+          lastActivityAt: now
+        });
+      } else if (record.status === 'ACTIVE') {
         const violation = await this.resourceViolation(record).catch(() => undefined);
         if (violation) await this.closeRecord(record, violation).catch(() => undefined);
+      }
+    }
+    const recoverableRows = this.store.database.prepare("SELECT * FROM workspaces WHERE status = 'EXPIRED_RECOVERABLE'").all() as { id: string; last_activity_at: number }[];
+    for (const row of recoverableRows) {
+      if (row.last_activity_at + 3_600_000 <= now) {
+        const fullRec = this.store.byId(row.id);
+        if (fullRec) await this.closeRecord(fullRec, 'recoverable grace period expired').catch(() => undefined);
       }
     }
   }

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -1054,40 +1054,45 @@ export class WorkspaceService {
       const rec = this.requireWorkspace(ownerId, workspaceId, false, true);
       const mode = (validated.mode as 'status' | 'patch' | 'export') ?? 'status';
       if (mode === 'status') {
-        const gitStatus = await this.runRecoveryWorker(rec, 'git_status', {}, signal);
-        const gitLog = await this.runRecoveryWorker(rec, 'git_log', { limit: 10 }, signal);
+        const recoverRes = await this.runRecoveryWorker(rec, 'workspace_recover', { mode: 'status' }, signal);
         return {
           ok: true,
           message: 'Workspace recovery status',
           data: {
             workspace: publicRecord(rec),
-            gitStatus: gitStatus.data,
-            gitLog: gitLog.data
+            ...(recoverRes.data && typeof recoverRes.data === 'object' ? recoverRes.data : {})
           },
           truncated: false
         };
       }
       if (mode === 'patch') {
-        const diff = await this.runRecoveryWorker(rec, 'git_diff', { readAll: true }, signal);
+        const patchRes = await this.runRecoveryWorker(rec, 'workspace_recover', { mode: 'patch' }, signal);
         return {
           ok: true,
           message: 'Workspace recovery patch',
           data: {
             workspace: publicRecord(rec),
-            patch: diff.data
+            ...(patchRes.data && typeof patchRes.data === 'object' ? patchRes.data : {})
           },
           truncated: false
         };
       }
       if (mode === 'export') {
         const targetBranch = (validated.targetBranch as string | undefined) ?? await this.currentBranch(rec, signal);
+        const snapshotRes = await this.runRecoveryWorker(rec, 'workspace_recover', {
+          mode: 'snapshot_commit',
+          message: `chore(recovery): export snapshot for ${targetBranch}`
+        }, signal);
+        const snapshotData = snapshotRes.data as { headCommitSha?: string; committedChanges?: boolean } | undefined;
         const pushResult = await this.remotePush(rec, { refspec: `HEAD:refs/heads/${targetBranch}` }, signal);
         return {
           ok: pushResult.ok,
-          message: pushResult.ok ? 'Workspace state exported to remote branch' : 'Workspace export failed',
+          message: pushResult.ok ? `Recovered work exported to ${targetBranch}` : 'Workspace export failed',
           data: {
             workspace: publicRecord(rec),
             branch: targetBranch,
+            commitSha: snapshotData?.headCommitSha,
+            committedChanges: snapshotData?.committedChanges,
             pushResult: pushResult.data
           },
           truncated: false

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { chmod, chown, mkdir, readdir, realpath, rm, statfs } from 'node:fs/promises';
-import { join, resolve, sep } from 'node:path';
+import { join, relative, resolve, sep } from 'node:path';
 import {
   HarnessError,
   InternalRunnerRequestSchema,
@@ -1571,23 +1571,30 @@ export class WorkspaceService {
   }
 
   private async safeRemovePath(path: string): Promise<void> {
+    const root = resolve(this.config.jobsRoot);
     const target = resolve(path);
-    if (!target.startsWith(`${resolve(this.config.jobsRoot)}${sep}`)) {
-      throw new Error(`path ${path} is outside jobsRoot ${this.config.jobsRoot}`);
+    if (target === root || !target.startsWith(`${root}${sep}`) || relative(root, target).startsWith('..')) throw new Error('refusing unsafe workspace cleanup path');
+    try {
+      const actualRoot = await realpath(root);
+      const actualTarget = await realpath(target);
+      if (!actualTarget.startsWith(`${actualRoot}${sep}`)) throw new Error('workspace cleanup path escaped jobs root');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
     }
     try {
       await rm(target, { recursive: true, force: true, maxRetries: 3 });
     } catch (error) {
-      if ((error as { code?: string })?.code === 'ENOENT') return;
-      const helperName = `chm-rm-${randomBytes(8).toString('hex')}`;
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'EACCES' && code !== 'EPERM') throw error;
+      const helperName = `chm-clean-${randomBytes(8).toString('hex')}`;
       const cleaned = await runDocker([
         'run', '--rm', '--pull', 'never', '--name', helperName,
         '--label', 'cloud-harness.role=cleanup-helper', '--label', 'cloud-harness.ephemeral=true',
-        '--label', `cloud-harness.instance=${this.instanceId}`,
-        '--network', 'none', '--user', '0:0',
-        '--volume', `${target}:/target`,
-        '--entrypoint', '/bin/sh', this.config.executorImage,
-        '-c', 'chmod -R u+rwX /target 2>/dev/null || true'
+        '--label', `cloud-harness.instance=${this.instanceId}`, '--network', 'none', '--user', '0:0',
+        '--read-only', '--tmpfs', '/tmp:rw,nosuid,nodev,size=16m',
+        '--pids-limit', '32', '--memory', '128m', '--memory-swap', '128m', '--cpus', '0.25',
+        '--volume', `${target}:/target:rw`, '--entrypoint', '/usr/bin/find', this.config.executorImage,
+        '/target', '-mindepth', '1', '-delete'
       ], { timeoutMs: 30_000, maxBytes: 65_536 });
       if (cleaned.exitCode !== 0) throw new HarnessError('UNAVAILABLE', 'workspace permissions could not be normalized for cleanup', 503, true);
       await rm(target, { recursive: true, force: true, maxRetries: 3 });

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -1091,6 +1091,15 @@ export class WorkspaceService {
           mode: 'snapshot_commit',
           message: `chore(recovery): export snapshot for ${targetBranch}`
         }, signal, true);
+        if (!snapshotRes.ok) {
+          return {
+            ok: false,
+            message: `Recovery snapshot failed: ${snapshotRes.message}`,
+            data: { step: 'snapshot_commit', error: snapshotRes.message },
+            error: { code: 'INTERNAL_ERROR', message: snapshotRes.message, retryable: true },
+            truncated: false
+          };
+        }
         const snapshotData = snapshotRes.data as { headCommitSha?: string; committedChanges?: boolean } | undefined;
         const pushResult = await this.remotePush(rec, { refspec: `HEAD:refs/heads/${targetBranch}` }, signal);
         return {

--- a/apps/runner/test/batch-write-worker.test.ts
+++ b/apps/runner/test/batch-write-worker.test.ts
@@ -224,13 +224,18 @@ describe('Issue #88: files_write_batch worker execution', () => {
     expect(statusData.status).toContain('initial.txt');
     expect(statusData.status).toContain('untracked.txt');
 
-    // Test mode: 'patch' (captures staged, unstaged, and untracked)
+    // Record index content before patch recovery to verify real .git/index is not mutated
+    const indexBefore = readFileSync(join(root, '.git/index'));
+
+    // Test mode: 'patch' (captures staged, unstaged, and untracked without mutating .git/index)
     const patchResult = await executeWorkerRequest('workspace_recover', { mode: 'patch' });
     expect(patchResult.ok).toBe(true);
     const patchData = patchResult.data as Record<string, unknown>;
     expect(patchData.workingTreePatch).toContain('version 2 (staged)');
     expect(patchData.workingTreePatch).toContain('untracked.txt');
 
+    const indexAfter = readFileSync(join(root, '.git/index'));
+    expect(indexAfter.equals(indexBefore)).toBe(true);
     // Test mode: 'snapshot_commit' (commits all uncommitted/untracked work for export)
     const snapshotResult = await executeWorkerRequest('workspace_recover', { mode: 'snapshot_commit', message: 'chore: recovery snapshot' });
     expect(snapshotResult.ok).toBe(true);

--- a/apps/runner/test/batch-write-worker.test.ts
+++ b/apps/runner/test/batch-write-worker.test.ts
@@ -1,0 +1,198 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { executeWorkerRequest, sha256 } from '../../../worker/harness-worker.mjs';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  delete process.env.CH_WORKSPACE_ROOT;
+  for (const path of temporaryDirectories.splice(0)) {
+    try { rmSync(path, { recursive: true, force: true }); } catch { /* cleanup ignore */ }
+  }
+});
+
+function setupWorkspace() {
+  const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-batch-worker-'));
+  temporaryDirectories.push(directory);
+  process.env.CH_WORKSPACE_ROOT = directory;
+  return directory;
+}
+
+describe('Issue #88: files_write_batch worker execution', () => {
+  it('creates nested multi-file directory trees in one call without prior shell commands', async () => {
+    const root = setupWorkspace();
+
+    const result = await executeWorkerRequest('files_write_batch', {
+      files: [
+        { path: 'plans/260824-1300-ux/plan.md', content: '# Plan Overview' },
+        { path: 'plans/260824-1300-ux/phase-01.md', content: '# Phase 1' },
+        { path: 'plans/260824-1300-ux/reports/summary.md', content: '# Summary' },
+        { path: 'src/utils/helpers/format.ts', content: 'export const format = () => {};' }
+      ],
+      createParents: true,
+      atomic: true
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toMatchObject({
+      createdCount: 4,
+      updatedCount: 0,
+      totalFiles: 4
+    });
+
+    expect(readFileSync(join(root, 'plans/260824-1300-ux/plan.md'), 'utf8')).toBe('# Plan Overview');
+    expect(readFileSync(join(root, 'plans/260824-1300-ux/phase-01.md'), 'utf8')).toBe('# Phase 1');
+    expect(readFileSync(join(root, 'plans/260824-1300-ux/reports/summary.md'), 'utf8')).toBe('# Summary');
+    expect(readFileSync(join(root, 'src/utils/helpers/format.ts'), 'utf8')).toBe('export const format = () => {};');
+  });
+
+  it('validates expected SHA256 before changing any file and changes NO files on conflict', async () => {
+    const root = setupWorkspace();
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(join(root, 'src/existing.ts'), 'original content', 'utf8');
+    const originalHash = sha256(Buffer.from('original content'));
+
+    // Attempt batch write with wrong expected SHA for existing file and a new file
+    const failedResult = await executeWorkerRequest('files_write_batch', {
+      files: [
+        { path: 'src/existing.ts', content: 'new content', expectedSha256: '0'.repeat(64) },
+        { path: 'src/never_created.ts', content: 'should not exist' }
+      ],
+      createParents: true,
+      atomic: true
+    });
+
+    expect(failedResult.ok).toBe(false);
+    expect(failedResult.error?.code).toBe('CONFLICT');
+    expect(failedResult.error?.message).toContain('changed since it was read');
+
+    // Verify existing file is untouched and new file was never created
+    expect(readFileSync(join(root, 'src/existing.ts'), 'utf8')).toBe('original content');
+    expect(existsSync(join(root, 'src/never_created.ts'))).toBe(false);
+
+    // Now update with correct SHA
+    const successResult = await executeWorkerRequest('files_write_batch', {
+      files: [
+        { path: 'src/existing.ts', content: 'updated content', expectedSha256: originalHash },
+        { path: 'src/created_now.ts', content: 'created successfully' }
+      ],
+      createParents: true,
+      atomic: true
+    });
+
+    expect(successResult.ok).toBe(true);
+    expect(successResult.data).toMatchObject({
+      createdCount: 1,
+      updatedCount: 1,
+      totalFiles: 2
+    });
+    expect(readFileSync(join(root, 'src/existing.ts'), 'utf8')).toBe('updated content');
+    expect(readFileSync(join(root, 'src/created_now.ts'), 'utf8')).toBe('created successfully');
+  });
+
+  it('handles large batches of 50 nested files efficiently', async () => {
+    const root = setupWorkspace();
+    const batchFiles = Array.from({ length: 50 }, (_, i) => ({
+      path: `packages/module-${i % 5}/sub-${i % 10}/file-${i}.ts`,
+      content: `export const value${i} = ${i};`
+    }));
+
+    const result = await executeWorkerRequest('files_write_batch', {
+      files: batchFiles,
+      createParents: true,
+      atomic: true
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toMatchObject({
+      createdCount: 50,
+      updatedCount: 0,
+      totalFiles: 50
+    });
+
+    for (let i = 0; i < 50; i++) {
+      const filePath = join(root, `packages/module-${i % 5}/sub-${i % 10}/file-${i}.ts`);
+      expect(readFileSync(filePath, 'utf8')).toBe(`export const value${i} = ${i};`);
+    }
+
+    // Subsequent batch updating 25 files and creating 10 new files
+    const updateBatch = [
+      ...Array.from({ length: 25 }, (_, i) => ({
+        path: `packages/module-${i % 5}/sub-${i % 10}/file-${i}.ts`,
+        content: `export const value${i} = ${i * 10};`
+      })),
+      ...Array.from({ length: 10 }, (_, i) => ({
+        path: `packages/new-module/new-file-${i}.ts`,
+        content: `export const new${i} = ${i};`
+      }))
+    ];
+
+    const updateResult = await executeWorkerRequest('files_write_batch', {
+      files: updateBatch,
+      createParents: true,
+      atomic: true
+    });
+
+    expect(updateResult.ok).toBe(true);
+    expect(updateResult.data).toMatchObject({
+      createdCount: 10,
+      updatedCount: 25,
+      totalFiles: 35
+    });
+
+    expect(readFileSync(join(root, 'packages/module-0/sub-0/file-0.ts'), 'utf8')).toBe('export const value0 = 0;');
+    expect(readFileSync(join(root, 'packages/module-1/sub-1/file-1.ts'), 'utf8')).toBe('export const value1 = 10;');
+    expect(readFileSync(join(root, 'packages/new-module/new-file-0.ts'), 'utf8')).toBe('export const new0 = 0;');
+  });
+
+  it('rejects path escape attempts cleanly', async () => {
+    setupWorkspace();
+
+    const escapeResult = await executeWorkerRequest('files_write_batch', {
+      files: [
+        { path: '../outside.txt', content: 'escape' }
+      ]
+    });
+
+    expect(escapeResult.ok).toBe(false);
+    expect(escapeResult.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('fails and creates no files when createParents is false and parent directory does not exist', async () => {
+    const root = setupWorkspace();
+
+    const result = await executeWorkerRequest('files_write_batch', {
+      files: [
+        { path: 'nested/dir/file.txt', content: 'hello' }
+      ],
+      createParents: false
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(existsSync(join(root, 'nested/dir/file.txt'))).toBe(false);
+  });
+
+  it('pre-validates entire batch so earlier valid files are never written if later file is invalid', async () => {
+    const root = setupWorkspace();
+
+    const result = await executeWorkerRequest('files_write_batch', {
+      files: [
+        { path: 'valid1.txt', content: 'valid content 1' },
+        { path: 'valid2.txt', content: 'valid content 2' },
+        { path: '../invalid_escape.txt', content: 'bad path' }
+      ],
+      createParents: true,
+      atomic: true
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+
+    // Verify that neither valid1.txt nor valid2.txt exists on disk
+    expect(existsSync(join(root, 'valid1.txt'))).toBe(false);
+    expect(existsSync(join(root, 'valid2.txt'))).toBe(false);
+  });
+});

--- a/apps/runner/test/batch-write-worker.test.ts
+++ b/apps/runner/test/batch-write-worker.test.ts
@@ -247,4 +247,14 @@ describe('Issue #88: files_write_batch worker execution', () => {
     const postStatus = await executeWorkerRequest('workspace_recover', { mode: 'status' });
     expect((postStatus.data as Record<string, unknown>).hasUncommitted).toBe(false);
   });
+
+  it('fails closed and reports failure if snapshot_commit encounters a Git error', async () => {
+    const root = setupWorkspace();
+    // Create an untracked file without initializing a Git repository
+    writeFileSync(join(root, 'untracked.txt'), 'content\n', 'utf8');
+
+    const result = await executeWorkerRequest('workspace_recover', { mode: 'snapshot_commit' });
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('INTERNAL_ERROR');
+  });
 });

--- a/apps/runner/test/batch-write-worker.test.ts
+++ b/apps/runner/test/batch-write-worker.test.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -194,5 +195,51 @@ describe('Issue #88: files_write_batch worker execution', () => {
     // Verify that neither valid1.txt nor valid2.txt exists on disk
     expect(existsSync(join(root, 'valid1.txt'))).toBe(false);
     expect(existsSync(join(root, 'valid2.txt'))).toBe(false);
+  });
+
+  it('Issue #94: workspace_recover captures unpushed commits, staged changes, and untracked files', async () => {
+    const root = setupWorkspace();
+
+    // Initialize a real Git repository in root
+    execSync('git init && git config user.name "Tester" && git config user.email "test@example.com"', { cwd: root, stdio: 'ignore' });
+    writeFileSync(join(root, 'initial.txt'), 'version 1\n', 'utf8');
+    execSync('git add initial.txt && git commit -m "initial commit"', { cwd: root, stdio: 'ignore' });
+
+    // 1. Create an unpushed commit
+    writeFileSync(join(root, 'committed.txt'), 'committed work\n', 'utf8');
+    execSync('git add committed.txt && git commit -m "unpushed feature"', { cwd: root, stdio: 'ignore' });
+
+    // 2. Create staged changes
+    writeFileSync(join(root, 'initial.txt'), 'version 2 (staged)\n', 'utf8');
+    execSync('git add initial.txt', { cwd: root, stdio: 'ignore' });
+
+    // 3. Create untracked file
+    writeFileSync(join(root, 'untracked.txt'), 'untracked new work\n', 'utf8');
+
+    // Test mode: 'status'
+    const statusResult = await executeWorkerRequest('workspace_recover', { mode: 'status' });
+    expect(statusResult.ok).toBe(true);
+    const statusData = statusResult.data as Record<string, unknown>;
+    expect(statusData.hasUncommitted).toBe(true);
+    expect(statusData.status).toContain('initial.txt');
+    expect(statusData.status).toContain('untracked.txt');
+
+    // Test mode: 'patch' (captures staged, unstaged, and untracked)
+    const patchResult = await executeWorkerRequest('workspace_recover', { mode: 'patch' });
+    expect(patchResult.ok).toBe(true);
+    const patchData = patchResult.data as Record<string, unknown>;
+    expect(patchData.workingTreePatch).toContain('version 2 (staged)');
+    expect(patchData.workingTreePatch).toContain('untracked.txt');
+
+    // Test mode: 'snapshot_commit' (commits all uncommitted/untracked work for export)
+    const snapshotResult = await executeWorkerRequest('workspace_recover', { mode: 'snapshot_commit', message: 'chore: recovery snapshot' });
+    expect(snapshotResult.ok).toBe(true);
+    const snapshotData = snapshotResult.data as Record<string, unknown>;
+    expect(snapshotData.committedChanges).toBe(true);
+    expect(snapshotData.headCommitSha).toBeDefined();
+
+    // Working tree is now clean at the recovery commit
+    const postStatus = await executeWorkerRequest('workspace_recover', { mode: 'status' });
+    expect((postStatus.data as Record<string, unknown>).hasUncommitted).toBe(false);
   });
 });

--- a/apps/runner/test/ux-improvements.test.ts
+++ b/apps/runner/test/ux-improvements.test.ts
@@ -27,7 +27,12 @@ const docker = vi.hoisted(() => ({
 }));
 
 vi.mock('../src/docker-engine.js', () => docker);
-
+vi.mock('../src/repository-policy.js', () => ({ validateRepositoryUrl: vi.fn(async (value: string) => new URL(value)) }));
+vi.mock('../src/github-app-broker.js', () => ({
+  mintRepositoryToken: vi.fn(async () => 'mock-token'),
+  mintPrincipalRepositoryScopedToken: vi.fn(async () => 'mock-token'),
+  mintPrincipalRepositoryToken: vi.fn(async () => 'mock-token')
+}));
 import { WorkspaceService } from '../src/workspace-service.js';
 
 const temporaryDirectories: string[] = [];
@@ -259,7 +264,9 @@ describe('UX Improvements and Feature Enhancements', () => {
     openStores.push(store);
     const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'owner-5' });
 
-    const ws = createWorkspaceRecord(ownerId, { id: `ws_${'5'.repeat(24)}`, idempotencyKey: 'key-5' });
+    const wsPath = join(jobsRoot, `ws_${'5'.repeat(24)}`);
+    mkdirSync(join(wsPath, 'repo'), { recursive: true });
+    const ws = createWorkspaceRecord(ownerId, { id: `ws_${'5'.repeat(24)}`, workspacePath: wsPath, idempotencyKey: 'key-5' });
     store.create(ws);
     const service = new WorkspaceService(config, store);
 
@@ -323,6 +330,33 @@ describe('UX Improvements and Feature Enhancements', () => {
     const recoverPatch = await service.execute(ownerId, 'workspace_recover', { workspaceId: ws.id, mode: 'patch' });
     expect(recoverPatch.ok).toBe(true);
     expect((recoverPatch.data as Record<string, unknown>).workingTreePatch).toBeDefined();
+
+    // Test workspace_recover in export mode on EXPIRED_RECOVERABLE workspace without container
+    store.update(ws.id, { status: 'EXPIRED_RECOVERABLE', containerName: null });
+    docker.workerResult = {
+      ok: true,
+      message: 'Recovery snapshot committed',
+      data: { headCommitSha: 'sha1234567890', committedChanges: true },
+      truncated: false
+    };
+
+    const recoverExport = await service.execute(ownerId, 'workspace_recover', {
+      workspaceId: ws.id,
+      mode: 'export',
+      targetBranch: 'recovered-branch'
+    });
+    expect(recoverExport.ok).toBe(true);
+    expect((recoverExport.data as Record<string, unknown>).branch).toBe('recovered-branch');
+    expect((recoverExport.data as Record<string, unknown>).commitSha).toBe('sha1234567890');
+
+    // Verify that runRecoveryWorker mounted the workspace repo with :rw when writable: true
+    const recoverDockerCalls = docker.runDocker.mock.calls.filter((call) =>
+      call[0].includes('--label') && call[0].includes('cloud-harness.role=recover-helper')
+    );
+    expect(recoverDockerCalls.length).toBeGreaterThan(0);
+    const lastCallArgs = recoverDockerCalls.at(-1)![0];
+    expect(lastCallArgs.some((arg: string) => arg.includes('/repo:/workspace:rw'))).toBe(true);
+    expect(lastCallArgs.includes('--read-only')).toBe(false);
   });
 
   it('Issue #93: workspace_finalize validates preflight conflicts and enforces journal idempotency', async () => {

--- a/apps/runner/test/ux-improvements.test.ts
+++ b/apps/runner/test/ux-improvements.test.ts
@@ -1,0 +1,426 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { RunnerConfig } from '@cloud-harness/contracts';
+import { StateStore, type WorkspaceRecord } from '../src/state-store.js';
+
+const docker = vi.hoisted(() => ({
+  workerResult: { ok: true, message: 'worker complete', data: {}, truncated: false },
+  runDocker: vi.fn(async (args: string[]) => {
+    if (args.includes('/usr/bin/du')) {
+      return { stdout: '0\t/workspace\n', stderr: '', exitCode: 0, truncated: false };
+    }
+    if (args.includes('branch') && args.includes('--show-current')) {
+      return { stdout: 'main\n', stderr: '', exitCode: 0, truncated: false };
+    }
+    if (args.includes('/opt/harness/worker-runner.sh')) {
+      return {
+        stdout: JSON.stringify(docker.workerResult), stderr: '', exitCode: 0, truncated: false
+      };
+    }
+    return { stdout: '', stderr: '', exitCode: 0, truncated: false };
+  }),
+  removeContainer: vi.fn(async () => undefined),
+  inspectContainer: vi.fn(async () => undefined),
+  terminateContainerProcessGroup: vi.fn(async () => undefined)
+}));
+
+vi.mock('../src/docker-engine.js', () => docker);
+
+import { WorkspaceService } from '../src/workspace-service.js';
+
+const temporaryDirectories: string[] = [];
+const openStores: StateStore[] = [];
+
+afterEach(() => {
+  docker.workerResult = { ok: true, message: 'worker complete', data: {}, truncated: false };
+  vi.clearAllMocks();
+  for (const store of openStores.splice(0)) {
+    try { store.close(); } catch { /* store already closed */ }
+  }
+  for (const path of temporaryDirectories.splice(0)) {
+    try { rmSync(path, { recursive: true, force: true }); } catch { /* directory already removed */ }
+  }
+});
+
+function createWorkspaceRecord(ownerId: string, overrides: Partial<WorkspaceRecord> = {}): WorkspaceRecord {
+  const now = Date.now();
+  return {
+    id: `ws_${'a'.repeat(24)}`,
+    ownerId,
+    idempotencyKey: 'key-1234',
+    repositoryUrl: 'https://github.com/example/repo.git',
+    repositoryRef: 'main',
+    containerName: 'chm-test-container',
+    workspacePath: '/tmp/test-workspace',
+    status: 'ACTIVE',
+    networkMode: 'none',
+    createdAt: now,
+    lastActivityAt: now,
+    expiresAt: now + 3_600_000,
+    hardExpiresAt: now + 14_400_000,
+    gitAuthorName: null,
+    gitAuthorEmail: null,
+    generation: 1,
+    error: null,
+    ...overrides
+  };
+}
+
+describe('UX Improvements and Feature Enhancements', () => {
+  it('Issue #94: exposes lease visibility, warnings, and allows lease renewal', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-ux-lease-'));
+    temporaryDirectories.push(directory);
+    const jobsRoot = join(directory, 'jobs');
+    mkdirSync(jobsRoot, { recursive: true });
+    const config = {
+      jobsRoot,
+      stateDb: join(directory, 'state.db'),
+      idleTtlSeconds: 3600,
+      wallTtlSeconds: 14400,
+      workspaceIdleTimeoutSeconds: 3600,
+      maxOutputBytes: 262144,
+      maxWorkspaceBytes: 104857600,
+      minFreeBytes: 1048576
+    } as RunnerConfig;
+
+    const store = new StateStore(config.stateDb);
+    openStores.push(store);
+    const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'owner-1' });
+    const now = Date.now();
+
+    // Create workspace with 2 minutes remaining on idle lease to trigger warning
+    const ws = createWorkspaceRecord(ownerId, {
+      expiresAt: now + 120_000,
+      hardExpiresAt: now + 14_400_000
+    });
+    store.create(ws);
+
+    const service = new WorkspaceService(config, store);
+
+    // Test workspace_status lease visibility
+    const statusRes = service.status(ownerId, ws.id);
+    expect(statusRes.ok).toBe(true);
+    const data = statusRes.data as Record<string, unknown>;
+    expect(data.leaseState).toBe('WARNING');
+    expect(data.canRenewLease).toBe(true);
+    expect(Array.isArray(data.leaseWarnings)).toBe(true);
+    expect(data.remainingLeaseMs).toBeGreaterThan(0);
+    expect(data.hardExpiresAt).toBeDefined();
+
+    // Test workspace_lease_renew
+    const renewRes = await service.execute(ownerId, 'workspace_lease_renew', { workspaceId: ws.id, extensionSeconds: 7200 });
+    expect(renewRes.ok).toBe(true);
+    const renewData = renewRes.data as Record<string, unknown>;
+    expect(renewData.remainingLeaseMs).toBeGreaterThan(120_000);
+    expect(renewData.leaseState).toBe('ACTIVE');
+  });
+
+  it('Issue #92: resolves implicit active workspace when workspaceId is omitted', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-ux-implicit-ws-'));
+    temporaryDirectories.push(directory);
+    const jobsRoot = join(directory, 'jobs');
+    mkdirSync(jobsRoot, { recursive: true });
+    const config = {
+      jobsRoot,
+      stateDb: join(directory, 'state.db'),
+      idleTtlSeconds: 3600,
+      wallTtlSeconds: 14400,
+      maxOutputBytes: 262144,
+      maxWorkspaceBytes: 104857600,
+      minFreeBytes: 1048576
+    } as RunnerConfig;
+
+    const store = new StateStore(config.stateDb);
+    openStores.push(store);
+    const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'owner-2' });
+
+    const service = new WorkspaceService(config, store);
+
+    // 0 workspaces -> NOT_FOUND error
+    expect(() => service.status(ownerId)).toThrow(/workspace not found/);
+
+    // 1 active workspace -> automatically resolved
+    const ws1 = createWorkspaceRecord(ownerId, { id: `ws_${'1'.repeat(24)}`, idempotencyKey: 'key-1' });
+    store.create(ws1);
+
+    const statusSingle = service.status(ownerId);
+    expect(statusSingle.ok).toBe(true);
+    expect((statusSingle.data as Record<string, unknown>).workspaceId).toBe(ws1.id);
+
+    // Add git identity and test workspace_context
+    await service.execute(ownerId, 'git_identity_set', { name: 'Alice Developer', email: 'alice@example.com' });
+    const identityRes = await service.execute(ownerId, 'git_identity_status', {});
+    expect(identityRes.ok).toBe(true);
+    expect((identityRes.data as Record<string, unknown>).name).toBe('Alice Developer');
+
+    const contextRes = await service.execute(ownerId, 'workspace_context', {});
+    expect(contextRes.ok).toBe(true);
+    const contextData = contextRes.data as Record<string, unknown>;
+    expect((contextData.workspace as Record<string, unknown>).workspaceId).toBe(ws1.id);
+    expect((contextData.gitIdentity as Record<string, unknown>).name).toBe('Alice Developer');
+
+    // Test workspace_set_active
+    const setActiveRes = await service.execute(ownerId, 'workspace_set_active', { workspaceId: ws1.id });
+    expect(setActiveRes.ok).toBe(true);
+    expect((setActiveRes.data as Record<string, unknown>).activeWorkspaceId).toBe(ws1.id);
+  });
+
+  it('Issue #90: tracks operations, cancellation, and status polling', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-ux-ops-'));
+    temporaryDirectories.push(directory);
+    const jobsRoot = join(directory, 'jobs');
+    mkdirSync(jobsRoot, { recursive: true });
+    const config = {
+      jobsRoot,
+      stateDb: join(directory, 'state.db'),
+      idleTtlSeconds: 3600,
+      wallTtlSeconds: 14400,
+      maxOutputBytes: 262144,
+      maxWorkspaceBytes: 104857600,
+      minFreeBytes: 1048576
+    } as RunnerConfig;
+
+    const store = new StateStore(config.stateDb);
+    openStores.push(store);
+    const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'owner-3' });
+    const service = new WorkspaceService(config, store);
+
+    // Register a generic operation in operation manager
+    const opManager = (service as unknown as { operations: { registerGenericOperation: (op: unknown) => { id: string, status: string } } }).operations;
+    const tracked = opManager.registerGenericOperation({
+      id: 'op_custom_12345',
+      kind: 'build',
+      deadlineMs: Date.now() + 60_000
+    });
+    expect(tracked.id).toBe('op_custom_12345');
+
+    // Poll operation_status
+    const statusRes = await service.execute(ownerId, 'operation_status', { operationId: 'op_custom_12345' });
+    expect(statusRes.ok).toBe(true);
+    expect((statusRes.data as Record<string, unknown>).status).toBe('running');
+
+    // Cancel operation
+    const cancelRes = await service.execute(ownerId, 'operation_cancel', { operationId: 'op_custom_12345' });
+    expect(cancelRes.ok).toBe(true);
+    expect((cancelRes.data as Record<string, unknown>).status).toBe('cancelled');
+
+    // Wait for operation (already terminal)
+    const waitRes = await service.execute(ownerId, 'operation_wait', { operationId: 'op_custom_12345', timeoutMs: 1000 });
+    expect(waitRes.ok).toBe(false);
+    expect((waitRes.data as Record<string, unknown>).status).toBe('cancelled');
+  });
+
+  it('Issue #89: supports comment idempotency in github_action', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-ux-gh-'));
+    temporaryDirectories.push(directory);
+    const jobsRoot = join(directory, 'jobs');
+    mkdirSync(jobsRoot, { recursive: true });
+    const config = {
+      jobsRoot,
+      stateDb: join(directory, 'state.db'),
+      idleTtlSeconds: 3600,
+      wallTtlSeconds: 14400,
+      maxOutputBytes: 262144,
+      maxWorkspaceBytes: 104857600,
+      minFreeBytes: 1048576
+    } as RunnerConfig;
+
+    const store = new StateStore(config.stateDb);
+    openStores.push(store);
+    const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'owner-4' });
+
+    // Store comment idempotency cache directly
+    const cachedResponse = { ok: true, message: 'GitHub issue_comment successful', data: { url: 'https://github.com/example/repo/issues/1#issuecomment-100' }, truncated: false };
+    store.setCommentIdempotency(ownerId, 'idem-comment-key-1', JSON.stringify(cachedResponse));
+
+    const retrieved = store.getCommentIdempotency(ownerId, 'idem-comment-key-1');
+    expect(retrieved).toBeDefined();
+    expect(JSON.parse(retrieved!)).toEqual(cachedResponse);
+  });
+
+  it('Issue #88 & #93: executes files_write_batch and workspace_finalize via worker and mutation lease', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-ux-batch-finalize-'));
+    temporaryDirectories.push(directory);
+    const jobsRoot = join(directory, 'jobs');
+    mkdirSync(jobsRoot, { recursive: true });
+    const config = {
+      jobsRoot,
+      stateDb: join(directory, 'state.db'),
+      idleTtlSeconds: 3600,
+      wallTtlSeconds: 14400,
+      maxOutputBytes: 262144,
+      maxWorkspaceBytes: 104857600,
+      minFreeBytes: 1048576
+    } as RunnerConfig;
+
+    const store = new StateStore(config.stateDb);
+    openStores.push(store);
+    const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'owner-5' });
+
+    const ws = createWorkspaceRecord(ownerId, { id: `ws_${'5'.repeat(24)}`, idempotencyKey: 'key-5' });
+    store.create(ws);
+    const service = new WorkspaceService(config, store);
+
+    // Mock worker result for files_write_batch
+    docker.workerResult = {
+      ok: true,
+      message: 'Batch wrote 2 files',
+      data: { createdCount: 2, updatedCount: 0, totalFiles: 2, files: [{ path: 'p1.md', sha256: 'a'.repeat(64), status: 'created' }] },
+      truncated: false
+    };
+
+    const batchRes = await service.execute(ownerId, 'files_write_batch', {
+      workspaceId: ws.id,
+      files: [{ path: 'p1.md', content: 'test 1' }, { path: 'p2.md', content: 'test 2' }],
+      idempotencyKey: 'batch-write-key-1'
+    });
+    expect(batchRes.ok).toBe(true);
+    expect((batchRes.data as Record<string, unknown>).createdCount).toBe(2);
+
+    // Retrying with same idempotency key returns cached result without running worker again
+    const batchReplay = await service.execute(ownerId, 'files_write_batch', {
+      workspaceId: ws.id,
+      files: [{ path: 'p1.md', content: 'test 1' }, { path: 'p2.md', content: 'test 2' }],
+      idempotencyKey: 'batch-write-key-1'
+    });
+    expect(batchReplay.ok).toBe(true);
+    expect(batchReplay.message).toBe(batchRes.message);
+    // Mock worker result for workspace_finalize git operations
+    docker.workerResult = {
+      ok: true,
+      message: 'Git operation successful',
+      data: { output: 'abc12345\t2026-08-24\tAgent\tfeat: test finalize' },
+      truncated: false
+    };
+
+    const finalizeRes = await service.execute(ownerId, 'workspace_finalize', {
+      workspaceId: ws.id,
+      commitMessage: 'feat: test finalize',
+      push: false
+    });
+    expect(finalizeRes.ok).toBe(true);
+    expect((finalizeRes.data as Record<string, unknown>).pushed).toBe(false);
+
+    // Test workspace_recover in status and patch mode
+    const recoverStatus = await service.execute(ownerId, 'workspace_recover', { workspaceId: ws.id, mode: 'status' });
+    expect(recoverStatus.ok).toBe(true);
+    expect((recoverStatus.data as Record<string, unknown>).workspace).toBeDefined();
+
+    const recoverPatch = await service.execute(ownerId, 'workspace_recover', { workspaceId: ws.id, mode: 'patch' });
+    expect(recoverPatch.ok).toBe(true);
+    expect((recoverPatch.data as Record<string, unknown>).patch).toBeDefined();
+  });
+
+  it('Issue #93: workspace_finalize validates preflight conflicts and enforces journal idempotency', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-ux-finalize-preflight-'));
+    temporaryDirectories.push(directory);
+    const jobsRoot = join(directory, 'jobs');
+    mkdirSync(jobsRoot, { recursive: true });
+    const config = {
+      jobsRoot,
+      stateDb: join(directory, 'state.db'),
+      idleTtlSeconds: 3600,
+      wallTtlSeconds: 14400,
+      maxOutputBytes: 262144,
+      maxWorkspaceBytes: 104857600,
+      minFreeBytes: 1048576
+    } as RunnerConfig;
+
+    const store = new StateStore(config.stateDb);
+    openStores.push(store);
+    const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'owner-finalize' });
+    const ws = createWorkspaceRecord(ownerId, { id: `ws_${'6'.repeat(24)}`, idempotencyKey: 'key-6' });
+    store.create(ws);
+    const service = new WorkspaceService(config, store);
+
+    // Test 1: Preflight conflict marker detection
+    docker.workerResult = {
+      ok: true,
+      message: 'git diff',
+      data: { output: '<<<<<<< HEAD\nconst a = 1;\n=======\nconst a = 2;\n>>>>>>> branch\n' },
+      truncated: false
+    };
+
+    const conflictRes = await service.execute(ownerId, 'workspace_finalize', {
+      workspaceId: ws.id,
+      commitMessage: 'feat: with conflict',
+      push: false
+    });
+    expect(conflictRes.ok).toBe(false);
+    expect(conflictRes.message).toContain('Preflight check failed');
+    expect((conflictRes.data as Record<string, unknown>).step).toBe('preflight');
+
+    // Test 2: Successful finalize with idempotency key
+    docker.workerResult = {
+      ok: true,
+      message: 'Clean diff',
+      data: { output: 'abc78901\t2026-08-24\tAgent\tfeat: finalized successfully' },
+      truncated: false
+    };
+
+    const finalizeFirst = await service.execute(ownerId, 'workspace_finalize', {
+      workspaceId: ws.id,
+      commitMessage: 'feat: finalized successfully',
+      idempotencyKey: 'finalize-key-100',
+      push: false
+    });
+    expect(finalizeFirst.ok).toBe(true);
+
+    // Test 3: Retrying with same idempotency key returns journaled result without re-executing
+    const finalizeReplay = await service.execute(ownerId, 'workspace_finalize', {
+      workspaceId: ws.id,
+      commitMessage: 'feat: finalized successfully',
+      idempotencyKey: 'finalize-key-100',
+      push: false
+    });
+    expect(finalizeReplay.ok).toBe(true);
+    expect(finalizeReplay.message).toBe(finalizeFirst.message);
+  });
+
+  it('Issue #94: reapExpired transitions active workspaces to EXPIRED_RECOVERABLE without deleting files', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-ux-reap-grace-'));
+    temporaryDirectories.push(directory);
+    const jobsRoot = join(directory, 'jobs');
+    const wsPath = join(jobsRoot, `ws_${'7'.repeat(24)}`);
+    mkdirSync(wsPath, { recursive: true });
+    const config = {
+      jobsRoot,
+      stateDb: join(directory, 'state.db'),
+      idleTtlSeconds: 3600,
+      wallTtlSeconds: 14400,
+      reaperIntervalSeconds: 60,
+      maxOutputBytes: 262144,
+      maxWorkspaceBytes: 104857600,
+      minFreeBytes: 1048576
+    } as RunnerConfig;
+
+    const store = new StateStore(config.stateDb);
+    openStores.push(store);
+    const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'owner-reap' });
+    const now = Date.now();
+
+    // Create workspace with expired idle lease
+    const ws = createWorkspaceRecord(ownerId, {
+      id: `ws_${'7'.repeat(24)}`,
+      workspacePath: wsPath,
+      expiresAt: now - 1000,
+      lastActivityAt: now - 1000
+    });
+    store.create(ws);
+    const service = new WorkspaceService(config, store);
+
+    // Run reapExpired
+    const reapExpiredFn = (service as unknown as { reapExpired: () => Promise<void> }).reapExpired;
+    await reapExpiredFn.call(service);
+
+    // Status should be EXPIRED_RECOVERABLE, not CLOSED
+    const updated = store.byId(ws.id);
+    expect(updated?.status).toBe('EXPIRED_RECOVERABLE');
+
+    // Ensure capacity allows a new workspace to open because EXPIRED_RECOVERABLE doesn't block it
+    const ensureCapacityFn = (service as unknown as { ensureCapacity: (owner: string) => Promise<void> }).ensureCapacity;
+    await expect(ensureCapacityFn.call(service, ownerId)).resolves.not.toThrow();
+  });
+});

--- a/apps/runner/test/ux-improvements.test.ts
+++ b/apps/runner/test/ux-improvements.test.ts
@@ -304,13 +304,25 @@ describe('UX Improvements and Feature Enhancements', () => {
     expect((finalizeRes.data as Record<string, unknown>).pushed).toBe(false);
 
     // Test workspace_recover in status and patch mode
+    docker.workerResult = {
+      ok: true,
+      message: 'Workspace recovery status',
+      data: { status: '## main\n M file.ts\n', hasUncommitted: true },
+      truncated: false
+    };
     const recoverStatus = await service.execute(ownerId, 'workspace_recover', { workspaceId: ws.id, mode: 'status' });
     expect(recoverStatus.ok).toBe(true);
     expect((recoverStatus.data as Record<string, unknown>).workspace).toBeDefined();
 
+    docker.workerResult = {
+      ok: true,
+      message: 'Workspace recovery patch',
+      data: { workingTreePatch: 'diff --git a/file.ts b/file.ts', combinedPatch: 'diff --git a/file.ts b/file.ts' },
+      truncated: false
+    };
     const recoverPatch = await service.execute(ownerId, 'workspace_recover', { workspaceId: ws.id, mode: 'patch' });
     expect(recoverPatch.ok).toBe(true);
-    expect((recoverPatch.data as Record<string, unknown>).patch).toBeDefined();
+    expect((recoverPatch.data as Record<string, unknown>).workingTreePatch).toBeDefined();
   });
 
   it('Issue #93: workspace_finalize validates preflight conflicts and enforces journal idempotency', async () => {

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -34,7 +34,7 @@
 - [Profile & Themes](https://docs.harness.agentkit.best/dashboard/profile.md): Account details and appearance settings.
 
 ## Technical References
-- [Tools Reference](https://docs.harness.agentkit.best/reference/tools.md): Complete catalog of 53 MCP tools.
+- [Tools Reference](https://docs.harness.agentkit.best/reference/tools.md): Complete catalog of 64 MCP tools.
 - [Environment Variables](https://docs.harness.agentkit.best/reference/environment-variables.md): Configuration reference.
 - [Git Transfer Semantics](https://docs.harness.agentkit.best/reference/git-transfer.md): Origin-only push/fetch/pull helper.
 - [Sessions & Tasks](https://docs.harness.agentkit.best/reference/sessions-and-tasks.md): PTY shells, sessions, and task DAGs.

--- a/docs-site/reference/tools.md
+++ b/docs-site/reference/tools.md
@@ -1,6 +1,6 @@
 ---
 title: Tools Reference
-description: Complete machine-generated reference of all 53 MCP tools provided by Cloud Harness MCP.
+description: Complete machine-generated reference of all 64 MCP tools provided by Cloud Harness MCP.
 ---
 
 # Tools Reference
@@ -11,7 +11,7 @@ description: Complete machine-generated reference of all 53 MCP tools provided b
   <strong>AI Crawler / Raw View:</strong> Fetch this page as raw Markdown at <code>/reference/tools.md</code>.
 </div>
 
-Cloud Harness MCP exposes **53 tools** across six operational domains. Every tool executes strictly inside a sandboxed, TTL-limited Docker container with non-root privileges and default network isolation.
+Cloud Harness MCP exposes **64 tools** across six operational domains. Every tool executes strictly inside a sandboxed, TTL-limited Docker container with non-root privileges and default network isolation.
 
 ## Security & Capability Badges
 
@@ -66,7 +66,7 @@ Read the lifecycle state and metadata for one workspace.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 
 ### `workspace_close`
 
@@ -78,7 +78,7 @@ Stop a workspace executor and permanently remove all workspace files, including 
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 
 ## Files and Code Intelligence
 
@@ -94,7 +94,7 @@ List one workspace directory with bounded cursor pagination.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `path` | `string` | **Yes** | length: 1–1024, default: `"."` |
 | `cursor` | `string` | No | max length: 256 |
 | `limit` | `integer` | **Yes** | range: 1–500, default: `100` |
@@ -103,16 +103,18 @@ List one workspace directory with bounded cursor pagination.
 
 **Read file**
 
-Read a bounded byte range from a workspace file with its size and SHA-256.
+Read a bounded byte range from a workspace file with its size, SHA-256, and continuation cursor.
 
 **Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `path` | `string` | **Yes** | length: 1–1024 |
 | `offset` | `integer` | **Yes** | range: 0–9007199254740991, default: `0` |
-| `limit` | `integer` | **Yes** | range: 1–262144, default: `65536` |
+| `limit` | `integer` | **Yes** | range: 1–1048576, default: `65536` |
+| `cursor` | `string` | No | max length: 256 |
+| `readAll` | `boolean` | No | — |
 
 ### `files_write`
 
@@ -124,7 +126,7 @@ Atomically create or replace a workspace file, optionally guarded by its current
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `path` | `string` | **Yes** | length: 1–1024 |
 | `content` | `string` | **Yes** | max length: 1048576 |
 | `expectedSha256` | `string` | No | length: 64–64 |
@@ -139,7 +141,7 @@ Replace one unique exact text occurrence, optionally guarded by the file SHA-256
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `path` | `string` | **Yes** | length: 1–1024 |
 | `oldText` | `string` | **Yes** | max length: 262144 |
 | `newText` | `string` | **Yes** | max length: 262144 |
@@ -155,7 +157,7 @@ Delete one workspace file or directory, with explicit recursion and optional fil
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `path` | `string` | **Yes** | length: 1–1024 |
 | `recursive` | `boolean` | **Yes** | default: `false` |
 | `expectedSha256` | `string` | No | length: 64–64 |
@@ -170,7 +172,7 @@ Move or rename one workspace entry, optionally overwriting an existing file.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `source` | `string` | **Yes** | length: 1–1024 |
 | `destination` | `string` | **Yes** | length: 1–1024 |
 | `overwrite` | `boolean` | **Yes** | default: `false` |
@@ -185,7 +187,7 @@ Create one workspace directory, including missing parents by default.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `path` | `string` | **Yes** | length: 1–1024 |
 | `recursive` | `boolean` | **Yes** | default: `true` |
 
@@ -193,13 +195,13 @@ Create one workspace directory, including missing parents by default.
 
 **Search workspace**
 
-Search workspace text with a bounded regular expression and optional path or glob filter.
+Search workspace text with a bounded regular expression and optional path, glob filter, and continuation cursor.
 
 **Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `pattern` | `string` | **Yes** | length: 1–4096 |
 | `path` | `string` | **Yes** | length: 1–1024, default: `"."` |
 | `glob` | `string` | No | max length: 512 |
@@ -215,7 +217,7 @@ Find bounded indexed symbol definitions by case-insensitive substring.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `query` | `string` | **Yes** | length: 1–256 |
 | `path` | `string` | **Yes** | length: 1–1024, default: `"."` |
 | `language` | `string` | No | pattern: `^[A-Za-z0-9_+#.-]{1,40}$` |
@@ -231,7 +233,7 @@ Find bounded lexical whole-word occurrences of a symbol in workspace text.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `symbol` | `string` | **Yes** | length: 1–256 |
 | `path` | `string` | **Yes** | length: 1–1024, default: `"."` |
 | `glob` | `string` | No | max length: 512 |
@@ -251,7 +253,7 @@ Run one bounded shell command in the workspace and return captured output.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `command` | `string` | **Yes** | length: 1–32768 |
 | `cwd` | `string` | **Yes** | length: 1–1024, default: `"."` |
 | `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
@@ -269,7 +271,7 @@ Open an idempotent ephemeral interactive shell in the workspace.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `cwd` | `string` | **Yes** | length: 1–1024, default: `"."` |
 | `idempotencyKey` | `string` | **Yes** | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
 
@@ -283,7 +285,7 @@ Send input to or poll bounded output from an open interactive shell.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `shellId` | `string` | **Yes** | pattern: `^sh_[A-Za-z0-9_-]{20,80}$` |
 | `input` | `string` | No | max length: 65536 |
 | `cursor` | `string` | No | max length: 256 |
@@ -299,7 +301,7 @@ Terminate an interactive shell and release its in-memory state.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `shellId` | `string` | **Yes** | pattern: `^sh_[A-Za-z0-9_-]{20,80}$` |
 
 ## Sessions and Tasks
@@ -316,7 +318,7 @@ List named coding sessions in a workspace with bounded cursor pagination.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `cursor` | `string` | No | max length: 256 |
 | `limit` | `integer` | **Yes** | range: 1–500, default: `100` |
 
@@ -330,7 +332,7 @@ Open an idempotent named coding session in the workspace.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,80}$` |
 | `cwd` | `string` | **Yes** | length: 1–1024, default: `"."` |
 | `idempotencyKey` | `string` | **Yes** | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
@@ -345,7 +347,7 @@ Send input to or poll bounded output from a named coding session.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `sessionId` | `string` | **Yes** | pattern: `^sess_[A-Za-z0-9_-]{20,80}$` |
 | `input` | `string` | No | max length: 65536 |
 | `cursor` | `string` | No | max length: 256 |
@@ -361,7 +363,7 @@ Terminate a coding session and release its in-memory state.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `sessionId` | `string` | **Yes** | pattern: `^sess_[A-Za-z0-9_-]{20,80}$` |
 
 ### `tasks_list`
@@ -374,7 +376,7 @@ List managed background task records with bounded cursor pagination.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `cursor` | `string` | No | max length: 256 |
 | `limit` | `integer` | **Yes** | range: 1–500, default: `100` |
 
@@ -388,7 +390,7 @@ Start an idempotent managed command task with optional task dependencies.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `command` | `string` | **Yes** | length: 1–32768 |
 | `cwd` | `string` | **Yes** | length: 1–1024, default: `"."` |
 | `idempotencyKey` | `string` | **Yes** | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
@@ -405,7 +407,7 @@ Read one managed task state and its next bounded output chunk.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `taskId` | `string` | **Yes** | pattern: `^task_[A-Za-z0-9_-]{20,80}$` |
 | `cursor` | `string` | No | max length: 256 |
 
@@ -419,7 +421,7 @@ Terminate a managed task process group without rolling back completed effects.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `taskId` | `string` | **Yes** | pattern: `^task_[A-Za-z0-9_-]{20,80}$` |
 
 ### `tasks_graph`
@@ -432,7 +434,7 @@ Read the current managed-task dependency graph for a workspace.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 
 ## Git and Worktrees
 
@@ -448,34 +450,39 @@ Read branch, index, and working-tree status for the workspace repository.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 
 ### `git_diff`
 
 **Git diff**
 
-Read a bounded staged or unstaged Git diff, optionally narrowed to one path.
+Read a bounded staged or unstaged Git diff with cursor pagination and readAll convenience.
 
 **Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `staged` | `boolean` | **Yes** | default: `false` |
 | `path` | `string` | No | length: 1–1024 |
+| `cursor` | `string` | No | max length: 256 |
+| `limit` | `integer` | **Yes** | range: 1–500000, default: `65536` |
+| `readAll` | `boolean` | No | — |
 
 ### `git_log`
 
 **Git log**
 
-Read bounded recent commit metadata from the workspace repository.
+Read bounded recent commit metadata from the workspace repository with cursor pagination.
 
 **Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `limit` | `integer` | **Yes** | range: 1–100, default: `20` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `limit` | `integer` | **Yes** | range: 1–500, default: `20` |
+| `cursor` | `string` | No | max length: 256 |
+| `readAll` | `boolean` | No | — |
 
 ### `git_branch`
 
@@ -487,7 +494,7 @@ List, create, or delete a local Git branch with constrained ref arguments.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `action` | `"list"` \| `"create"` \| `"delete"` | **Yes** | — |
 | `name` | `string` | No | length: 1–255 |
 | `startPoint` | `string` | No | length: 1–255 |
@@ -503,7 +510,7 @@ Check out an existing Git ref or create and check out a local branch.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `ref` | `string` | **Yes** | length: 1–255 |
 | `create` | `boolean` | **Yes** | default: `false` |
 
@@ -517,7 +524,7 @@ Stage either explicit workspace paths or all tracked and untracked changes.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `all` | `boolean` | **Yes** | default: `false` |
 | `paths` | string[] | **Yes** | default: `[]` |
 
@@ -525,14 +532,14 @@ Stage either explicit workspace paths or all tracked and untracked changes.
 
 **Create Git commit**
 
-Create an unsigned local Git commit with an explicit author and message.
+Create an unsigned local Git commit with default or explicit author and message.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `message` | `string` | **Yes** | length: 1–10000 |
-| `authorName` | `string` | **Yes** | length: 1–200 |
-| `authorEmail` | `string` | **Yes** | format: `email`, pattern: `^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$` |
+| `authorName` | `string` | No | length: 1–200 |
+| `authorEmail` | `string` | No | format: `email`, pattern: `^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$` |
 | `all` | `boolean` | **Yes** | default: `false` |
 
 ### `git_fetch`
@@ -545,7 +552,7 @@ Fetch a constrained source ref from origin through the trusted repository broker
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `remote` | `"origin"` | **Yes** | default: `"origin"` |
 | `refspec` | `string` | No | length: 1–255 |
 
@@ -559,7 +566,7 @@ Integrate an origin branch using ff-only, merge, or rebase strategy.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `remote` | `"origin"` | **Yes** | default: `"origin"` |
 | `branch` | `string` | No | length: 1–255 |
 | `strategy` | `"ff-only"` \| `"merge"` \| `"rebase"` | **Yes** | default: `"ff-only"` |
@@ -574,7 +581,7 @@ Push a constrained branch refspec to origin, with optional explicit force-with-l
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `remote` | `"origin"` | **Yes** | default: `"origin"` |
 | `refspec` | `string` | No | length: 1–512 |
 | `forceWithLease` | `boolean` | **Yes** | default: `false` |
@@ -590,7 +597,7 @@ Merge a Git ref with an explicit fast-forward policy and optional message.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `ref` | `string` | **Yes** | length: 1–255 |
 | `fastForward` | `"allow"` \| `"only"` \| `"never"` | **Yes** | default: `"allow"` |
 | `message` | `string` | No | length: 1–10000 |
@@ -605,7 +612,7 @@ Start, continue, or abort a local Git rebase with constrained ref arguments.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `action` | `"start"` \| `"continue"` \| `"abort"` | **Yes** | — |
 | `upstream` | `string` | No | length: 1–255 |
 
@@ -619,7 +626,7 @@ List managed Git worktrees and their current branch or HEAD state.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 
 ### `worktrees_create`
 
@@ -629,7 +636,7 @@ Create a named managed worktree, optionally with a new local branch.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,80}$` |
 | `ref` | `string` | **Yes** | length: 1–255 |
 | `createBranch` | `boolean` | **Yes** | default: `false` |
@@ -644,7 +651,7 @@ Remove one named managed worktree, optionally discarding dirty state.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,80}$` |
 | `force` | `boolean` | **Yes** | default: `false` |
 
@@ -659,7 +666,7 @@ Execute authenticated GitHub pull request and issue operations via brokered help
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `action` | `"pr_list"` \| `"pr_view"` \| `"pr_create"` \| `"issue_list"` \| `"issue_view"` \| `"issue_create"` | **Yes** | — |
+| `action` | `"pr_list"` \| `"pr_view"` \| `"pr_create"` \| `"issue_list"` \| `"issue_view"` \| `"issue_create"` \| `"issue_comment"` \| `"issue_comment_update"` \| `"label_create"` \| `"issue_labels_add"` \| `"issue_labels_remove"` \| `"issue_update"` | **Yes** | — |
 | `limit` | `integer` | No | range: 1–100, default: `20` |
 | `state` | `"open"` \| `"closed"` \| `"all"` | No | — |
 | `prNumber` | `integer` | No | range: 0–9007199254740991 |
@@ -668,6 +675,15 @@ Execute authenticated GitHub pull request and issue operations via brokered help
 | `head` | `string` | No | length: 1–256 |
 | `base` | `string` | No | length: 1–256, default: `"main"` |
 | `issueNumber` | `integer` | No | range: 0–9007199254740991 |
+| `idempotencyKey` | `string` | No | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
+| `commentId` | `integer` | No | range: 0–9007199254740991 |
+| `name` | `string` | No | length: 1–100 |
+| `color` | `string` | No | pattern: `^[0-9A-Fa-f]{6}$` |
+| `description` | `string` | No | max length: 200 |
+| `labels` | string[] | No | — |
+| `createMissing` | `boolean` | No | default: `true` |
+| `label` | `string` | No | length: 1–100 |
+| `stateReason` | `"completed"` \| `"not_planned"` \| `"reopened"` | No | — |
 
 ## Repository Extensions
 
@@ -683,7 +699,7 @@ List repository-provided agent skills discovered in the workspace.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 
 ### `skills_read`
 
@@ -695,7 +711,7 @@ Read bounded instructions for one repository-provided agent skill.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._:-]{1,120}$` |
 
 ### `skills_run`
@@ -708,7 +724,7 @@ Execute one reviewed script packaged by a repository-provided skill.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._:-]{1,120}$` |
 | `script` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,120}$` |
 | `args` | string[] | **Yes** | default: `[]` |
@@ -724,7 +740,7 @@ List repository-defined Cloud Harness automation hooks without running them.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 
 ### `hooks_run`
 
@@ -736,7 +752,7 @@ Execute one named repository-defined hook as a bounded shell command.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,120}$` |
 | `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
 
@@ -750,7 +766,7 @@ List repository-local Cloud Harness memory note names.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 
 ### `memories_read`
 
@@ -762,7 +778,7 @@ Read one bounded repository-local Cloud Harness memory note.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,120}$` |
 
 ### `memories_write`
@@ -775,7 +791,7 @@ Create or replace one repository-local Cloud Harness memory note.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,120}$` |
 | `content` | `string` | **Yes** | max length: 262144 |
 
@@ -789,7 +805,7 @@ List repository-defined deployment targets without running them.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 
 ### `deployments_run`
 
@@ -801,7 +817,161 @@ Execute one named repository-defined deployment target with external-effect risk
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,120}$` |
 | `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
+
+## Additional Tools
+
+### `workspace_lease_renew`
+
+**Renew workspace lease**
+
+Explicitly renew or extend the workspace idle lease duration.
+
+**Attributes:** `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `extensionSeconds` | `integer` | No | range: 60–86400 |
+
+### `workspace_recover`
+
+**Recover workspace state**
+
+Inspect, patch, or export unpushed work from an active or recoverable expired workspace.
+
+**Attributes:** <span class="badge-destructive">destructive</span>
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `mode` | `"status"` \| `"patch"` \| `"export"` | **Yes** | default: `"status"` |
+| `targetBranch` | `string` | No | length: 1–255 |
+
+### `workspace_context`
+
+**Workspace context**
+
+Read the active workspace ID, branch, lease time, Git identity, and repository overview.
+
+**Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+
+### `workspace_set_active`
+
+**Set active workspace**
+
+Set the caller preferred active workspace when multiple workspaces exist.
+
+**Attributes:** `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+
+### `workspace_finalize`
+
+**Finalize workspace commit and push**
+
+Transactionally stage changes, run preflights, commit with default or explicit identity, and push to remote in one call.
+
+**Attributes:** <span class="badge-destructive">destructive</span> · `idempotent` · <span class="badge-openworld">openWorld</span>
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `paths` | string[] | No | — |
+| `all` | `boolean` | **Yes** | default: `true` |
+| `commitMessage` | `string` | **Yes** | length: 1–10000 |
+| `branch` | `string` | No | length: 1–255 |
+| `push` | `boolean` | **Yes** | default: `true` |
+| `authorName` | `string` | No | length: 1–200 |
+| `authorEmail` | `string` | No | format: `email`, pattern: `^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$` |
+| `preflight` | `object` | No | — |
+| `idempotencyKey` | `string` | No | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
+
+### `files_write_batch`
+
+**Write batch files**
+
+Atomically write multiple workspace files in one call, automatically creating missing parent directories.
+
+**Attributes:** <span class="badge-destructive">destructive</span> · `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `files` | object[] | **Yes** | — |
+| `createParents` | `boolean` | **Yes** | default: `true` |
+| `atomic` | `boolean` | **Yes** | default: `true` |
+| `idempotencyKey` | `string` | No | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
+
+### `operation_status`
+
+**Read operation status**
+
+Query the execution state, progress, and terminal result of a long-running operation.
+
+**Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `operationId` | `string` | **Yes** | length: 1–128 |
+| `cursor` | `string` | No | max length: 256 |
+
+### `operation_cancel`
+
+**Cancel operation**
+
+Cancel an in-flight long-running operation.
+
+**Attributes:** <span class="badge-destructive">destructive</span> · `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `operationId` | `string` | **Yes** | length: 1–128 |
+
+### `operation_wait`
+
+**Wait for operation**
+
+Wait for a long-running operation to reach a terminal state with a timeout.
+
+**Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `operationId` | `string` | **Yes** | length: 1–128 |
+| `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
+
+### `git_identity_status`
+
+**Read Git author identity**
+
+Read the default or configured Git author name and email for the workspace.
+
+**Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+
+### `git_identity_set`
+
+**Set Git author identity**
+
+Configure default Git author name and email for workspace commits.
+
+**Attributes:** <span class="badge-destructive">destructive</span> · `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `name` | `string` | **Yes** | length: 1–200 |
+| `email` | `string` | **Yes** | format: `email`, pattern: `^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$` |
 

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -41,19 +41,21 @@ The lifecycle contract is owned by
    optional ref, and a fresh idempotency key. To inject a retained dashboard
    environment, select its opaque ID and explicitly confirm the injection in
    the same request; omitting either injects nothing.
-2. Keep the returned opaque `workspaceId` and pass it to workspace-scoped
-   tools. Do not derive IDs or use filesystem paths as handles.
-3. Use bounded file and code-intelligence tools for inspection and edits. Use
-   `exec_run`, shells, sessions, or tasks only when arbitrary code execution is
-   intended.
-4. Read cursors and `truncated` instead of assuming a response is complete.
-5. Close shells and sessions, cancel unwanted tasks, then call
+2. Subsequent tool calls can omit `workspaceId` when exactly one active
+   workspace is open. The runner automatically resolves the active workspace,
+   or returns a structured `CONFLICT` ambiguity error if multiple exist.
+3. Use bounded file and code-intelligence tools for inspection and edits.
+   `files_write_batch` allows atomic multi-file creation with parent directory
+   scaffolding in one call.
+4. When ready to publish, use `workspace_finalize` to run preflights, stage,
+   commit, and push to origin in a single idempotent transaction.
+5. Read cursors and `truncated` or use `readAll: true` instead of assuming a response is complete.
+6. Close shells and sessions, cancel unwanted tasks, then call
    `workspace_close`.
 
-Reusing a `workspace_open`, `shell_open`, `sessions_open`, or `tasks_run`
-idempotency key returns the prior created resource for that workspace. This
-makes a lost response recoverable without duplicating work.
-
+Reusing a `workspace_open`, `shell_open`, `sessions_open`, `tasks_run`, or
+`workspace_finalize` idempotency key returns the prior created resource for that
+workspace. This makes a lost response recoverable without duplicating work.
 ## Semantics that are easy to misread
 
 - `files_apply_patch` is not a unified-diff parser. It performs one exact
@@ -73,9 +75,25 @@ makes a lost response recoverable without duplicating work.
   runner terminates and verifies the operation's process groups; the workspace
   remains active for later calls.
 - `github_action` executes authenticated GitHub CLI actions (`pr_list`, `pr_view`,
-  `pr_create`, `issue_list`, `issue_view`, `issue_create`) through an ephemeral
-  helper container using short-lived tokens minted from the configured GitHub App.
-  Tokens are supplied exclusively via stdin and are never written to workspace files.
+  `pr_create`, `issue_list`, `issue_view`, `issue_create`, `issue_comment`,
+  `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`,
+  `issue_update`) through an ephemeral helper container using short-lived tokens
+  minted from the configured GitHub App. Tokens are supplied exclusively via stdin
+  and are never written to workspace files. Comment and label mutations support
+  idempotency keys.
+- `files_write_batch` writes an array of files in a single atomic transaction. It
+  creates missing parent directories by default and verifies expected SHA256 hashes
+  prior to modifying any file. If any file fails validation or write, original files
+  are restored.
+- `workspace_finalize` provides a single transactional endpoint to stage changes,
+  run diff preflight checks, commit with workspace/owner default Git identity, and
+  push to remote. If a push is rejected or network fails, actionable resumption hints
+  and the created commit SHA are returned.
+- `workspace_lease_renew` and `workspace_recover` allow inspecting and extending
+  workspace idle leases or recovering unpushed commits and patches from active or
+  grace-period `EXPIRED_RECOVERABLE` workspaces.
+- `operation_status`, `operation_cancel`, and `operation_wait` provide observable,
+  cancellable, and reconnectable management of long-running operations.
 - `symbols_search` uses Universal Ctags to find definitions. It is not a
   language server. `symbols_references` is a bounded lexical word search, so it
   can include definitions and same-spelling identifiers rather than semantic

--- a/packages/contracts/src/runner-api.ts
+++ b/packages/contracts/src/runner-api.ts
@@ -3,12 +3,16 @@ import { ToolResultSchema } from './mcp-results.js';
 
 export const RunnerOperationSchema = z.enum([
   'workspace_open', 'workspace_list', 'workspace_status', 'workspace_close',
-  'files_list', 'files_read', 'files_write', 'files_apply_patch', 'files_delete', 'files_move', 'files_mkdir', 'grep_search',
+  'workspace_lease_renew', 'workspace_recover', 'workspace_context', 'workspace_set_active',
+  'workspace_finalize',
+  'files_list', 'files_read', 'files_write', 'files_write_batch', 'files_apply_patch', 'files_delete', 'files_move', 'files_mkdir', 'grep_search',
   'symbols_search', 'symbols_references',
   'exec_run', 'shell_open', 'shell_io', 'shell_close',
   'sessions_list', 'sessions_open', 'sessions_io', 'sessions_close',
   'tasks_list', 'tasks_run', 'tasks_status', 'tasks_cancel', 'tasks_graph',
+  'operation_status', 'operation_cancel', 'operation_wait',
   'git_status', 'git_diff', 'git_log', 'git_branch', 'git_checkout', 'git_add', 'git_commit', 'git_fetch', 'git_pull', 'git_push', 'git_merge', 'git_rebase',
+  'git_identity_status', 'git_identity_set',
   'worktrees_list', 'worktrees_create', 'worktrees_remove',
   'skills_list', 'skills_read', 'skills_run',
   'hooks_list', 'hooks_run',

--- a/packages/contracts/src/tool-schemas.ts
+++ b/packages/contracts/src/tool-schemas.ts
@@ -7,7 +7,7 @@ const relativePath = z.string().min(1).max(1_024).refine((value) => {
   return !normalized.startsWith('/') && !/^[A-Za-z]:/.test(normalized) && !normalized.split('/').includes('..') && !normalized.includes('\0');
 }, 'path must stay workspace-relative');
 const entryPath = relativePath.refine((value) => value.replaceAll('\\', '/') !== '.', 'path must identify an entry below the workspace root');
-const workspace = { workspaceId: WorkspaceIdSchema };
+const workspace = { workspaceId: WorkspaceIdSchema.optional() };
 const pagination = { cursor: z.string().max(256).optional(), limit: z.number().int().min(1).max(500).default(100) };
 const gitArgument = z.string().min(1).max(255).refine((value) => !value.startsWith('-') && !value.includes('\0'), 'Git argument cannot start with a dash');
 const gitFetchRef = gitArgument.refine((value) => !value.includes(':'), 'Git fetch ref cannot contain a destination');
@@ -36,9 +36,43 @@ const schemas = {
   workspace_list: z.object(pagination),
   workspace_status: z.object(workspace),
   workspace_close: z.object(workspace),
+  workspace_lease_renew: z.object({ ...workspace, extensionSeconds: z.number().int().min(60).max(86_400).optional() }),
+  workspace_recover: z.object({ ...workspace, mode: z.enum(['status', 'patch', 'export']).default('status'), targetBranch: gitArgument.optional() }),
+  workspace_context: z.object(workspace),
+  workspace_set_active: z.object({ workspaceId: WorkspaceIdSchema }),
+  workspace_finalize: z.object({
+    ...workspace,
+    paths: z.array(relativePath).max(500).optional(),
+    all: z.boolean().default(true),
+    commitMessage: z.string().min(1).max(10_000),
+    branch: gitArgument.optional(),
+    push: z.boolean().default(true),
+    authorName: z.string().min(1).max(200).optional(),
+    authorEmail: z.email().optional(),
+    preflight: z.object({ checkDiff: z.boolean().default(true), forbiddenPatterns: z.array(z.string()).optional() }).optional(),
+    idempotencyKey: IdempotencyKeySchema.optional()
+  }).superRefine((input, context) => {
+    if (!input.all && (!input.paths || input.paths.length === 0)) {
+      context.addIssue({ code: 'custom', path: ['paths'], message: 'paths are required when all is false' });
+    }
+    if (input.all && input.paths && input.paths.length > 0) {
+      context.addIssue({ code: 'custom', path: ['paths'], message: 'paths must be empty when all is true' });
+    }
+  }),
   files_list: z.object({ ...workspace, path: relativePath.default('.'), ...pagination }),
-  files_read: z.object({ ...workspace, path: relativePath, offset: z.number().int().min(0).default(0), limit: z.number().int().min(1).max(262_144).default(65_536) }),
+  files_read: z.object({ ...workspace, path: relativePath, offset: z.number().int().min(0).default(0), limit: z.number().int().min(1).max(1_048_576).default(65_536), cursor: z.string().max(256).optional(), readAll: z.boolean().optional() }),
   files_write: z.object({ ...workspace, path: relativePath, content: z.string().max(1_048_576), expectedSha256: z.string().length(64).optional() }),
+  files_write_batch: z.object({
+    ...workspace,
+    files: z.array(z.object({
+      path: relativePath,
+      content: z.string().max(1_048_576),
+      expectedSha256: z.string().length(64).optional()
+    })).min(1).max(100),
+    createParents: z.boolean().default(true),
+    atomic: z.boolean().default(true),
+    idempotencyKey: IdempotencyKeySchema.optional()
+  }),
   files_apply_patch: z.object({ ...workspace, path: relativePath, oldText: z.string().max(262_144), newText: z.string().max(262_144), expectedSha256: z.string().length(64).optional() }),
   files_delete: z.object({ ...workspace, path: entryPath, recursive: z.boolean().default(false), expectedSha256: z.string().length(64).optional() }),
   files_move: z.object({ ...workspace, source: entryPath, destination: entryPath, overwrite: z.boolean().default(false) }),
@@ -67,9 +101,12 @@ const schemas = {
   tasks_status: z.object({ ...workspace, taskId: TaskIdSchema, cursor: z.string().max(256).optional() }),
   tasks_cancel: z.object({ ...workspace, taskId: TaskIdSchema }),
   tasks_graph: z.object(workspace),
+  operation_status: z.object({ operationId: z.string().min(1).max(128), cursor: z.string().max(256).optional() }),
+  operation_cancel: z.object({ operationId: z.string().min(1).max(128) }),
+  operation_wait: z.object({ operationId: z.string().min(1).max(128), timeoutMs: z.number().int().min(100).max(300_000).default(60_000) }),
   git_status: z.object(workspace),
-  git_diff: z.object({ ...workspace, staged: z.boolean().default(false), path: relativePath.optional() }),
-  git_log: z.object({ ...workspace, limit: z.number().int().min(1).max(100).default(20) }),
+  git_diff: z.object({ ...workspace, staged: z.boolean().default(false), path: relativePath.optional(), cursor: z.string().max(256).optional(), limit: z.number().int().min(1).max(500_000).default(65_536), readAll: z.boolean().optional() }),
+  git_log: z.object({ ...workspace, limit: z.number().int().min(1).max(500).default(20), cursor: z.string().max(256).optional(), readAll: z.boolean().optional() }),
   git_branch: z.object({ ...workspace, action: z.enum(['list', 'create', 'delete']), name: gitArgument.optional(), startPoint: gitArgument.optional(), force: z.boolean().default(false) }).superRefine((input, context) => {
     if (input.action !== 'list' && !input.name) context.addIssue({ code: 'custom', path: ['name'], message: 'name is required for create and delete' });
   }),
@@ -78,7 +115,9 @@ const schemas = {
     if (!input.all && input.paths.length === 0) context.addIssue({ code: 'custom', path: ['paths'], message: 'paths are required unless all is true' });
     if (input.all && input.paths.length > 0) context.addIssue({ code: 'custom', path: ['paths'], message: 'paths must be empty when all is true' });
   }),
-  git_commit: z.object({ ...workspace, message: z.string().min(1).max(10_000), authorName: z.string().min(1).max(200), authorEmail: z.email(), all: z.boolean().default(false) }),
+  git_commit: z.object({ ...workspace, message: z.string().min(1).max(10_000), authorName: z.string().min(1).max(200).optional(), authorEmail: z.email().optional(), all: z.boolean().default(false) }),
+  git_identity_status: z.object(workspace),
+  git_identity_set: z.object({ ...workspace, name: z.string().min(1).max(200), email: z.email() }),
   git_fetch: z.object({ ...workspace, remote: z.literal('origin').default('origin'), refspec: gitFetchRef.optional() }),
   git_pull: z.object({ ...workspace, remote: z.literal('origin').default('origin'), branch: gitArgument.optional(), strategy: z.enum(['ff-only', 'merge', 'rebase']).default('ff-only') }),
   git_push: z.object({
@@ -146,6 +185,56 @@ const schemas = {
       action: z.literal('issue_create'),
       title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes'),
       body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').default('')
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('issue_comment'),
+      issueNumber: z.number().int().positive(),
+      body: z.string().min(1).max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes'),
+      idempotencyKey: IdempotencyKeySchema.optional()
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('issue_comment_update'),
+      commentId: z.number().int().positive(),
+      body: z.string().min(1).max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes')
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('label_create'),
+      name: z.string().min(1).max(100).refine((val) => !val.includes('\0'), 'label name cannot contain null bytes'),
+      color: z.string().regex(/^[0-9A-Fa-f]{6}$/).optional(),
+      description: z.string().max(200).optional()
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('issue_labels_add'),
+      issueNumber: z.number().int().positive(),
+      labels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0'), 'label cannot contain null bytes')).min(1).max(50),
+      createMissing: z.boolean().default(true),
+      idempotencyKey: IdempotencyKeySchema.optional()
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('issue_labels_remove'),
+      issueNumber: z.number().int().positive(),
+      label: z.string().min(1).max(100).refine((val) => !val.includes('\0'), 'label cannot contain null bytes')
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('issue_update'),
+      issueNumber: z.number().int().positive(),
+      title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes').optional(),
+      body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').optional(),
+      state: z.enum(['open', 'closed']).optional(),
+      stateReason: z.enum(['completed', 'not_planned', 'reopened']).optional()
+    }).superRefine((input, context) => {
+      if (!input.title && !input.body && !input.state) {
+        context.addIssue({ code: 'custom', path: ['title'], message: 'at least one of title, body, or state is required' });
+      }
+      if (input.stateReason && input.state !== 'closed' && input.stateReason !== 'reopened') {
+        context.addIssue({ code: 'custom', path: ['stateReason'], message: 'stateReason is valid only when closing or reopening an issue' });
+      }
     })
   ])
 } satisfies Record<RunnerOperation, z.ZodType>;
@@ -163,12 +252,16 @@ export type ToolSpec = {
 
 const titles: Record<RunnerOperation, string> = {
   workspace_open: 'Open workspace', workspace_list: 'List workspaces', workspace_status: 'Workspace status', workspace_close: 'Close workspace',
-  files_list: 'List files', files_read: 'Read file', files_write: 'Write file', files_apply_patch: 'Apply text patch', files_delete: 'Delete file or directory', files_move: 'Move file or directory', files_mkdir: 'Create directory', grep_search: 'Search workspace',
+  workspace_lease_renew: 'Renew workspace lease', workspace_recover: 'Recover workspace state', workspace_context: 'Workspace context', workspace_set_active: 'Set active workspace',
+  workspace_finalize: 'Finalize workspace commit and push',
+  files_list: 'List files', files_read: 'Read file', files_write: 'Write file', files_write_batch: 'Write batch files', files_apply_patch: 'Apply text patch', files_delete: 'Delete file or directory', files_move: 'Move file or directory', files_mkdir: 'Create directory', grep_search: 'Search workspace',
   symbols_search: 'Find symbol definitions', symbols_references: 'Find lexical symbol references',
   exec_run: 'Run command', shell_open: 'Open shell', shell_io: 'Use shell', shell_close: 'Close shell', tasks_list: 'List tasks', tasks_run: 'Run task', tasks_status: 'Task status', tasks_cancel: 'Cancel task',
   sessions_list: 'List coding sessions', sessions_open: 'Open coding session', sessions_io: 'Use coding session', sessions_close: 'Close coding session',
   tasks_graph: 'Read task dependency graph',
+  operation_status: 'Read operation status', operation_cancel: 'Cancel operation', operation_wait: 'Wait for operation',
   git_status: 'Git status', git_diff: 'Git diff', git_log: 'Git log', git_branch: 'Manage Git branches', git_checkout: 'Checkout Git ref', git_add: 'Stage Git changes', git_commit: 'Create Git commit', git_fetch: 'Fetch Git refs', git_pull: 'Pull Git changes', git_push: 'Push Git changes', git_merge: 'Merge Git ref', git_rebase: 'Manage Git rebase',
+  git_identity_status: 'Read Git author identity', git_identity_set: 'Set Git author identity',
   worktrees_list: 'List worktrees', worktrees_create: 'Create worktree', worktrees_remove: 'Remove worktree',
   skills_list: 'List skills', skills_read: 'Read skill', skills_run: 'Run skill script', hooks_list: 'List hooks', hooks_run: 'Run hook', memories_list: 'List memories', memories_read: 'Read memory', memories_write: 'Write memory',
   deployments_list: 'List deployment targets', deployments_run: 'Run deployment target',
@@ -180,14 +273,20 @@ const descriptions: Record<RunnerOperation, string> = {
   workspace_list: 'List owner-visible workspace records with bounded cursor pagination.',
   workspace_status: 'Read the lifecycle state and metadata for one workspace.',
   workspace_close: 'Stop a workspace executor and permanently remove all workspace files, including unpushed commits.',
+  workspace_lease_renew: 'Explicitly renew or extend the workspace idle lease duration.',
+  workspace_recover: 'Inspect, patch, or export unpushed work from an active or recoverable expired workspace.',
+  workspace_context: 'Read the active workspace ID, branch, lease time, Git identity, and repository overview.',
+  workspace_set_active: 'Set the caller preferred active workspace when multiple workspaces exist.',
+  workspace_finalize: 'Transactionally stage changes, run preflights, commit with default or explicit identity, and push to remote in one call.',
   files_list: 'List one workspace directory with bounded cursor pagination.',
-  files_read: 'Read a bounded byte range from a workspace file with its size and SHA-256.',
+  files_read: 'Read a bounded byte range from a workspace file with its size, SHA-256, and continuation cursor.',
   files_write: 'Atomically create or replace a workspace file, optionally guarded by its current SHA-256.',
+  files_write_batch: 'Atomically write multiple workspace files in one call, automatically creating missing parent directories.',
   files_apply_patch: 'Replace one unique exact text occurrence, optionally guarded by the file SHA-256.',
   files_delete: 'Delete one workspace file or directory, with explicit recursion and optional file hash guard.',
   files_move: 'Move or rename one workspace entry, optionally overwriting an existing file.',
   files_mkdir: 'Create one workspace directory, including missing parents by default.',
-  grep_search: 'Search workspace text with a bounded regular expression and optional path or glob filter.',
+  grep_search: 'Search workspace text with a bounded regular expression and optional path, glob filter, and continuation cursor.',
   symbols_search: 'Find bounded indexed symbol definitions by case-insensitive substring.',
   symbols_references: 'Find bounded lexical whole-word occurrences of a symbol in workspace text.',
   exec_run: 'Run one bounded shell command in the workspace and return captured output.',
@@ -203,13 +302,18 @@ const descriptions: Record<RunnerOperation, string> = {
   tasks_status: 'Read one managed task state and its next bounded output chunk.',
   tasks_cancel: 'Terminate a managed task process group without rolling back completed effects.',
   tasks_graph: 'Read the current managed-task dependency graph for a workspace.',
+  operation_status: 'Query the execution state, progress, and terminal result of a long-running operation.',
+  operation_cancel: 'Cancel an in-flight long-running operation.',
+  operation_wait: 'Wait for a long-running operation to reach a terminal state with a timeout.',
   git_status: 'Read branch, index, and working-tree status for the workspace repository.',
-  git_diff: 'Read a bounded staged or unstaged Git diff, optionally narrowed to one path.',
-  git_log: 'Read bounded recent commit metadata from the workspace repository.',
+  git_diff: 'Read a bounded staged or unstaged Git diff with cursor pagination and readAll convenience.',
+  git_log: 'Read bounded recent commit metadata from the workspace repository with cursor pagination.',
   git_branch: 'List, create, or delete a local Git branch with constrained ref arguments.',
   git_checkout: 'Check out an existing Git ref or create and check out a local branch.',
   git_add: 'Stage either explicit workspace paths or all tracked and untracked changes.',
-  git_commit: 'Create an unsigned local Git commit with an explicit author and message.',
+  git_commit: 'Create an unsigned local Git commit with default or explicit author and message.',
+  git_identity_status: 'Read the default or configured Git author name and email for the workspace.',
+  git_identity_set: 'Configure default Git author name and email for workspace commits.',
   git_fetch: 'Fetch a constrained source ref from origin through the trusted repository broker.',
   git_pull: 'Integrate an origin branch using ff-only, merge, or rebase strategy.',
   git_push: 'Push a constrained branch refspec to origin, with optional explicit force-with-lease.',
@@ -231,10 +335,35 @@ const descriptions: Record<RunnerOperation, string> = {
   github_action: 'Execute authenticated GitHub pull request and issue operations via brokered helper without exposing tokens to workspace.'
 };
 
-const readOnly = new Set<RunnerOperation>(['workspace_list', 'workspace_status', 'files_list', 'files_read', 'grep_search', 'symbols_search', 'symbols_references', 'sessions_list', 'tasks_list', 'tasks_status', 'tasks_graph', 'git_status', 'git_diff', 'git_log', 'worktrees_list', 'skills_list', 'skills_read', 'hooks_list', 'memories_list', 'memories_read', 'deployments_list']);
-const destructive = new Set<RunnerOperation>(['workspace_close', 'files_write', 'files_apply_patch', 'files_delete', 'files_move', 'exec_run', 'shell_io', 'shell_close', 'sessions_io', 'sessions_close', 'tasks_run', 'tasks_cancel', 'git_branch', 'git_checkout', 'git_pull', 'git_push', 'git_merge', 'git_rebase', 'worktrees_remove', 'skills_run', 'hooks_run', 'memories_write', 'deployments_run', 'github_action']);
-const idempotent = new Set<RunnerOperation>(['workspace_open', 'workspace_list', 'workspace_status', 'workspace_close', 'files_list', 'files_read', 'files_write', 'files_apply_patch', 'files_mkdir', 'grep_search', 'symbols_search', 'symbols_references', 'shell_open', 'shell_close', 'sessions_list', 'sessions_open', 'sessions_close', 'tasks_list', 'tasks_run', 'tasks_status', 'tasks_cancel', 'tasks_graph', 'git_status', 'git_diff', 'git_log', 'git_add', 'worktrees_list', 'skills_list', 'skills_read', 'hooks_list', 'memories_list', 'memories_read', 'memories_write', 'deployments_list']);
-const openWorld = new Set<RunnerOperation>(['workspace_open', 'exec_run', 'shell_io', 'sessions_io', 'tasks_run', 'git_fetch', 'git_pull', 'git_push', 'skills_run', 'hooks_run', 'deployments_run', 'github_action']);
+const readOnly = new Set<RunnerOperation>([
+  'workspace_list', 'workspace_status', 'workspace_context',
+  'files_list', 'files_read', 'grep_search', 'symbols_search', 'symbols_references',
+  'sessions_list', 'tasks_list', 'tasks_status', 'tasks_graph',
+  'operation_status', 'operation_wait',
+  'git_status', 'git_diff', 'git_log', 'git_identity_status',
+  'worktrees_list', 'skills_list', 'skills_read', 'hooks_list', 'memories_list', 'memories_read', 'deployments_list'
+]);
+const destructive = new Set<RunnerOperation>([
+  'workspace_close', 'workspace_recover', 'workspace_finalize',
+  'files_write', 'files_write_batch', 'files_apply_patch', 'files_delete', 'files_move',
+  'exec_run', 'shell_io', 'shell_close', 'sessions_io', 'sessions_close',
+  'tasks_run', 'tasks_cancel', 'operation_cancel',
+  'git_branch', 'git_checkout', 'git_pull', 'git_push', 'git_merge', 'git_rebase', 'git_identity_set',
+  'worktrees_remove', 'skills_run', 'hooks_run', 'memories_write', 'deployments_run', 'github_action'
+]);
+const idempotent = new Set<RunnerOperation>([
+  'workspace_open', 'workspace_list', 'workspace_status', 'workspace_close', 'workspace_lease_renew', 'workspace_context', 'workspace_set_active', 'workspace_finalize',
+  'files_list', 'files_read', 'files_write', 'files_write_batch', 'files_apply_patch', 'files_mkdir', 'grep_search', 'symbols_search', 'symbols_references',
+  'shell_open', 'shell_close', 'sessions_list', 'sessions_open', 'sessions_close',
+  'tasks_list', 'tasks_run', 'tasks_status', 'tasks_cancel', 'tasks_graph',
+  'operation_status', 'operation_cancel', 'operation_wait',
+  'git_status', 'git_diff', 'git_log', 'git_add', 'git_identity_status', 'git_identity_set',
+  'worktrees_list', 'skills_list', 'skills_read', 'hooks_list', 'memories_list', 'memories_read', 'memories_write', 'deployments_list'
+]);
+const openWorld = new Set<RunnerOperation>([
+  'workspace_open', 'workspace_finalize', 'exec_run', 'shell_io', 'sessions_io', 'tasks_run',
+  'git_fetch', 'git_pull', 'git_push', 'skills_run', 'hooks_run', 'deployments_run', 'github_action'
+]);
 
 export const TOOL_SPECS: ToolSpec[] = (Object.keys(schemas) as RunnerOperation[]).map((name) => ({
   name,

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -142,4 +142,72 @@ describe('contracts', () => {
     expect(() => TOOL_SCHEMA_BY_NAME.files_move.parse({ workspaceId, source: '.', destination: 'moved', overwrite: false })).toThrow();
     expect(() => TOOL_SCHEMA_BY_NAME.tasks_run.parse({ workspaceId, command: 'true', idempotencyKey: 'task-test', dependsOn: ['task_invalid'] })).toThrow();
   });
+
+  it('validates files_write_batch schemas and boundaries', () => {
+    const validBatch = {
+      files: [
+        { path: 'plans/plan.md', content: '# Plan', expectedSha256: 'a'.repeat(64) },
+        { path: 'src/main.ts', content: 'console.log("hello");' }
+      ],
+      createParents: true,
+      atomic: true
+    };
+    expect(TOOL_SCHEMA_BY_NAME.files_write_batch.parse(validBatch)).toMatchObject({ createParents: true, atomic: true });
+    expect(() => TOOL_SCHEMA_BY_NAME.files_write_batch.parse({ files: [] })).toThrow();
+    expect(() => TOOL_SCHEMA_BY_NAME.files_write_batch.parse({ files: [{ path: '../outside.txt', content: 'hack' }] })).toThrow();
+  });
+
+  it('validates workspace_finalize schemas and options', () => {
+    const validFinalize = {
+      commitMessage: 'feat(ux): improve developer experience',
+      push: true,
+      all: true
+    };
+    expect(TOOL_SCHEMA_BY_NAME.workspace_finalize.parse(validFinalize)).toMatchObject({ push: true, all: true });
+    expect(() => TOOL_SCHEMA_BY_NAME.workspace_finalize.parse({ commitMessage: '' })).toThrow();
+    expect(() => TOOL_SCHEMA_BY_NAME.workspace_finalize.parse({ commitMessage: 'msg', authorEmail: 'invalid-email' })).toThrow();
+  });
+
+  it('validates operation status, cancel, and wait schemas', () => {
+    expect(TOOL_SCHEMA_BY_NAME.operation_status.parse({ operationId: 'op_12345' })).toMatchObject({ operationId: 'op_12345' });
+    expect(TOOL_SCHEMA_BY_NAME.operation_cancel.parse({ operationId: 'op_12345' })).toMatchObject({ operationId: 'op_12345' });
+    expect(TOOL_SCHEMA_BY_NAME.operation_wait.parse({ operationId: 'op_12345', timeoutMs: 5000 })).toMatchObject({ timeoutMs: 5000 });
+    expect(() => TOOL_SCHEMA_BY_NAME.operation_status.parse({ operationId: '' })).toThrow();
+  });
+
+  it('validates extended github_action schemas for comments and labels', () => {
+    expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'issue_comment',
+      issueNumber: 42,
+      body: 'Comment body here'
+    })).toMatchObject({ action: 'issue_comment', issueNumber: 42 });
+
+    expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'label_create',
+      name: 'ready to ship stable',
+      color: '0E8A16',
+      description: 'Ready for stable'
+    })).toMatchObject({ action: 'label_create', name: 'ready to ship stable' });
+
+    expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'issue_labels_add',
+      issueNumber: 42,
+      labels: ['bug', 'p0']
+    })).toMatchObject({ action: 'issue_labels_add', labels: ['bug', 'p0'] });
+
+    expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'issue_update',
+      issueNumber: 42,
+      state: 'closed',
+      stateReason: 'completed'
+    })).toMatchObject({ action: 'issue_update', state: 'closed' });
+  });
+
+  it('validates workspace lease renew, recovery, context, and git identity schemas', () => {
+    expect(TOOL_SCHEMA_BY_NAME.workspace_lease_renew.parse({ extensionSeconds: 3600 })).toMatchObject({ extensionSeconds: 3600 });
+    expect(TOOL_SCHEMA_BY_NAME.workspace_recover.parse({ mode: 'patch' })).toMatchObject({ mode: 'patch' });
+    expect(TOOL_SCHEMA_BY_NAME.workspace_context.parse({})).toBeDefined();
+    expect(TOOL_SCHEMA_BY_NAME.git_identity_status.parse({})).toBeDefined();
+    expect(TOOL_SCHEMA_BY_NAME.git_identity_set.parse({ name: 'Dev', email: 'dev@example.com' })).toMatchObject({ name: 'Dev', email: 'dev@example.com' });
+  });
 });

--- a/plans/260824-1300-ux-improvements/phase-01-contracts-and-tool-schemas.md
+++ b/plans/260824-1300-ux-improvements/phase-01-contracts-and-tool-schemas.md
@@ -1,0 +1,25 @@
+# Phase 1: Contracts & Tool Schemas
+
+## Context & Objectives
+Define the new and extended tool schemas and types in `@cloud-harness/contracts`:
+- Add `workspace_lease_renew`, `workspace_recover`, `workspace_finalize`, `files_write_batch`, `operation_status`, `operation_cancel`, `operation_wait`, `workspace_context`, `workspace_set_active`, `git_identity_status`, `git_identity_set`.
+- Extend `github_action` discriminated union with issue comment, label, and update actions.
+- Make `workspaceId` optional across workspace tool schemas to support implicit active workspace resolution.
+- Make `authorName` and `authorEmail` optional on `git_commit` and `workspace_finalize`.
+- Add cursor and `readAll` pagination parameters to `git_diff`, `git_log`, `grep_search`, `files_read`.
+
+## Affected Files
+- `packages/contracts/src/tool-schemas.ts`
+- `packages/contracts/src/runner-api.ts`
+- `packages/contracts/src/mcp-results.ts`
+- `packages/contracts/test/contracts.test.ts`
+
+## Implementation Steps
+1. Update `packages/contracts/src/runner-api.ts`:
+   - Add new operation names to `RunnerOperationSchema`.
+2. Update `packages/contracts/src/tool-schemas.ts`:
+   - Define schemas for all new operations.
+   - Adjust existing schemas: optional `workspaceId`, optional author fields, pagination flags (`readAll`, cursor).
+   - Update `TOOL_SPECS`, titles, descriptions, and annotation sets (readOnly, destructive, idempotent, openWorld).
+3. Update `packages/contracts/test/contracts.test.ts` to test every new tool schema, optional fields, and validation boundaries.
+4. Run `npm test -w @cloud-harness/contracts` and verify clean build.

--- a/plans/260824-1300-ux-improvements/phase-02-runner-state-leases-operations.md
+++ b/plans/260824-1300-ux-improvements/phase-02-runner-state-leases-operations.md
@@ -1,0 +1,33 @@
+# Phase 2: Runner State, Leases, and Operation Management
+
+## Context & Objectives
+Implement state tracking and lifecycle mechanisms in `apps/runner`:
+- Add `EXPIRED_RECOVERABLE` status to `WorkspaceRecord`.
+- Track `idleExpiresAt` and `hardExpiresAt` in `StateStore` and `WorkspaceService`.
+- Implement lease renewal (`workspace_lease_renew`) and recovery (`workspace_recover`).
+- Protect active mutations with temporary non-expiring mutation leases (`withMutationLease`).
+- Add active workspace resolution and preferred active workspace storage in `StateStore`.
+- Enhance `OperationManager` with hard deadlines, cancellation, status polling, and retained completed operation results for reconnectable queries.
+
+## Affected Files
+- `apps/runner/src/state-store.ts`
+- `apps/runner/src/workspace-service.ts`
+- `apps/runner/src/operation-manager.ts`
+- `apps/runner/test/state-store.test.ts`
+- `apps/runner/test/operation-retention.test.ts`
+
+## Implementation Steps
+1. In `state-store.ts`:
+   - Extend `WorkspaceRecord['status']` to include `'EXPIRED_RECOVERABLE'`.
+   - Add columns/fields for `hard_expires_at`, `active_preferred`, and git identity overrides.
+   - Add methods to set/get preferred workspace and git identity.
+   - Implement `resolveActiveWorkspace(ownerId: string, explicitId?: string): WorkspaceRecord`.
+2. In `operation-manager.ts`:
+   - Store operation metadata (id, workspaceId, status, progress, createdAt, deadline, result, exitCode, output buffer).
+   - Implement `cancel(id: string)`: kill process group, mark status 'cancelled'.
+   - Implement `status(id: string, cursor?: string)` and `wait(id: string, timeoutMs: number)`.
+   - Retain finished operation results for 10 minutes in memory.
+3. In `workspace-service.ts`:
+   - Update `reapExpired` to transition expired workspaces to `EXPIRED_RECOVERABLE` before full reap.
+   - Implement `workspace_lease_renew` and `workspace_recover`.
+   - Implement `operation_status`, `operation_cancel`, `operation_wait`.

--- a/plans/260824-1300-ux-improvements/phase-03-worker-execution-and-git-tools.md
+++ b/plans/260824-1300-ux-improvements/phase-03-worker-execution-and-git-tools.md
@@ -1,0 +1,31 @@
+# Phase 3: Worker Execution, Batch Writes & Finalize
+
+## Context & Objectives
+Implement atomic batch file writes and transactional workspace finalization:
+- Add `files_write_batch` handler in `worker/harness-worker.mjs`:
+  - Path safety checks.
+  - Expected SHA256 pre-validation across all files before touching disk.
+  - Parent directory creation when `createParents: true`.
+  - Atomic write via temporary files + rollbacks on failure.
+- Add `workspace_finalize` in `workspace-service.ts` / `harness-worker.mjs`:
+  - Preflight checks (whitespace / diff checks).
+  - Stage changes (specified paths or all).
+  - Commit changes with default or explicit Git author.
+  - Push branch to remote with brokered GitHub App write token if `push: true`.
+  - Structured response with commit SHA, branch, push status, and resumption instructions on failure.
+
+## Affected Files
+- `worker/harness-worker.mjs`
+- `apps/runner/src/workspace-service.ts`
+- `apps/runner/test/bounded-workspace-file-reader.test.ts`
+- `apps/runner/test/workspace-audit.test.ts`
+
+## Implementation Steps
+1. Add `files_write_batch` to `worker/harness-worker.mjs`.
+2. Add `workspace_finalize` logic in `workspace-service.ts`:
+   - Run preflights.
+   - Run worker git operations to stage & commit.
+   - Perform remote push if requested.
+   - Return clean summary and idempotency-safe outcome.
+3. Unit test batch writes with parent directories, SHA conflicts, and error rollbacks.
+4. Unit test `workspace_finalize` under normal, no-change, and push-error conditions.

--- a/plans/260824-1300-ux-improvements/phase-04-brokered-github-actions.md
+++ b/plans/260824-1300-ux-improvements/phase-04-brokered-github-actions.md
@@ -1,0 +1,26 @@
+# Phase 4: Brokered GitHub Actions Expansion
+
+## Context & Objectives
+Extend `github_action` to support comprehensive issue-driven workflows without leaking tokens:
+- Add issue comment creation (`issue_comment`) and update (`issue_comment_update`).
+- Add label creation (`label_create`) and issue label addition/removal (`issue_labels_add`, `issue_labels_remove`).
+- Add issue viewing (`issue_view`), updating (`issue_update`), and listing (`issue_list`).
+- Prevent duplicate comments/label operations through idempotency keys.
+- Return stable canonical URLs and normalized structures.
+
+## Affected Files
+- `worker/gh-helper.sh`
+- `apps/runner/src/github-app-broker.ts`
+- `apps/runner/src/workspace-service.ts`
+- `apps/runner/test/github-app-broker.test.ts`
+- `test/integration/gh-helper.docker.test.ts`
+
+## Implementation Steps
+1. In `worker/gh-helper.sh`:
+   - Add cases for `issue_comment`, `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`, `issue_update`.
+2. In `apps/runner/src/github-app-broker.ts`:
+   - Mint scoped tokens with appropriate issue permissions (`issues: write`, `pull_requests: write`).
+3. In `apps/runner/src/workspace-service.ts`:
+   - Map each `github_action` variant to `runBrokeredGitHubAction`.
+   - Add in-memory / state idempotency cache for comments.
+4. Add unit and integration tests.

--- a/plans/260824-1300-ux-improvements/phase-05-pagination-and-workspace-context.md
+++ b/plans/260824-1300-ux-improvements/phase-05-pagination-and-workspace-context.md
@@ -1,0 +1,26 @@
+# Phase 5: Pagination, Context & Implicit Workspace
+
+## Context & Objectives
+Deliver seamless single-workspace ergonomics and standardized cursor pagination:
+- Automatic single active workspace resolution when `workspaceId` is omitted.
+- Ambiguity error (`CONFLICT`) when >1 active workspaces exist.
+- New tools: `workspace_context`, `workspace_set_active`, `git_identity_status`, `git_identity_set`.
+- Pagination standardisation: `readAll`, `cursor`, `nextCursor`, `truncated`, `bytesReturned`, `totalBytes`, `eof`.
+- Enhance `git_diff`, `files_read`, `grep_search`, `git_log` with standard pagination metadata.
+
+## Affected Files
+- `apps/runner/src/workspace-service.ts`
+- `worker/harness-worker.mjs`
+- `apps/api/src/mcp-server.ts`
+- `apps/api/src/runner-client.ts`
+
+## Implementation Steps
+1. In `apps/runner/src/workspace-service.ts`:
+   - Intercept requests with missing `workspaceId` and resolve active workspace.
+   - Implement `workspace_context`, `workspace_set_active`, `git_identity_status`, `git_identity_set`.
+   - Update `git_diff`, `files_read`, `grep_search`, `git_log` output formats to include standard cursor pagination metadata.
+2. In `worker/harness-worker.mjs`:
+   - Add cursor pagination to `git_diff` and `git_log`.
+   - Support `readAll` mode up to max output threshold.
+3. In `apps/api/src/mcp-server.ts`:
+   - Verify all tool specs pass schema validation and properly handle optional parameters.

--- a/plans/260824-1300-ux-improvements/phase-06-verification-and-docs.md
+++ b/plans/260824-1300-ux-improvements/phase-06-verification-and-docs.md
@@ -1,0 +1,22 @@
+# Phase 6: Verification, Test Suites & Documentation
+
+## Context & Objectives
+Comprehensive verification and documentation update across internal docs and public docs-site:
+- Verify all unit and integration tests across contracts, runner, api, and worker.
+- Add new end-to-end and contract tests for all 7 issues.
+- Update internal docs (`docs/mcp-api.md`, `docs/security-model.md`, `docs/system-architecture.md`).
+- Update docs-site reference pages (`npm run docs:reference` and `npm run plugin:sync` if needed).
+
+## Affected Files
+- `test/`
+- `packages/contracts/test/`
+- `apps/runner/test/`
+- `apps/api/test/`
+- `docs/`
+- `docs-site/`
+
+## Implementation Steps
+1. Run `npm test` across all workspaces.
+2. Run `npm run build` and `npm run lint` / typecheck.
+3. Update `docs/mcp-api.md` with new tool specifications, parameters, and examples.
+4. Update `docs-site/` documentation and run `npm run docs:reference`.

--- a/plans/260824-1300-ux-improvements/plan.md
+++ b/plans/260824-1300-ux-improvements/plan.md
@@ -1,0 +1,35 @@
+# Plan: Cloud Harness MCP UX Improvements (Issues #88, #89, #90, #91, #92, #93, #94)
+
+**Status:** COMPLETED
+**Created:** 2026-08-24
+**Branch:** mrgoonie/UX-Improvements
+**Route:** Feature & UX Enhancement
+**Mode:** Official Stable (--ship)
+
+## Overview
+Comprehensive upgrade to Cloud Harness MCP addressing critical friction points discovered during long-running agent workflows (#33):
+1. **Issue #94 (P0):** Visible, renewable, and recoverable workspace leases with idle/hard expiry and non-expiring mutation windows.
+2. **Issue #93 (P0):** Transactional `workspace_finalize` for atomic stage, preflight check, commit, and push.
+3. **Issue #88 (P1):** Atomic `files_write_batch` with parent directory creation and all-or-nothing rollback.
+4. **Issue #90 (P1):** Bounded operations with progress, hard timeouts, cancellation (`operation_cancel`), and reconnectable polling (`operation_status`, `operation_wait`).
+5. **Issue #89 (P1):** Extended `github_action` covering issue comments, label management, issue updates, and idempotency.
+6. **Issue #92 (P2):** Implicit active workspace resolution and default Git identity (`workspace_context`, `git_identity_status`, `git_identity_set`).
+7. **Issue #91 (P2):** Consistent cursor pagination, `readAll` support, and deterministic stale cursor handling across diff, files, search, and logs.
+
+## Phases
+- [Phase 1: Contracts & Tool Schemas](./phase-01-contracts-and-tool-schemas.md)
+- [Phase 2: Runner State, Leases, and Operation Management](./phase-02-runner-state-leases-operations.md)
+- [Phase 3: Worker Execution, Batch Writes & Finalize](./phase-03-worker-execution-and-git-tools.md)
+- [Phase 4: Brokered GitHub Actions Expansion](./phase-04-brokered-github-actions.md)
+- [Phase 5: Pagination, Context & Implicit Workspace](./phase-05-pagination-and-workspace-context.md)
+- [Phase 6: Verification, Test Suites & Documentation](./phase-06-verification-and-docs.md)
+## Acceptance Criteria
+- [x] Multi-file nested batch writes succeed in one call with parent directory creation and all-or-nothing rollback on validation failure (#88).
+- [x] Extended GitHub operations (comment, update, label create/add/remove, issue view/edit) work reliably with idempotency (#89).
+- [x] Long-running operations are cancellable, observable, and reconnectable with hard server deadlines (#90).
+- [x] Large outputs (diff, read, search, log) support consistent cursor pagination and `readAll` convenience (#91).
+- [x] Single active workspace is automatically resolved when `workspaceId` is omitted; multi-workspace ambiguity returns structured error (#92).
+- [x] Git author identity defaults automatically from workspace/authenticated owner (#92).
+- [x] Staging, committing, and pushing can be performed in one idempotent, transactional `workspace_finalize` call (#93).
+- [x] Workspace leases distinguish idle and hard expiry, refresh on activity, hold during mutations, and offer `EXPIRED_RECOVERABLE` state with renewal/recovery tools (#94).
+- [x] All existing and new unit, integration, and contract tests pass.

--- a/plugins/cloud-harness/skills/cloudharness/references/execution-and-tasks.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/execution-and-tasks.md
@@ -129,6 +129,44 @@ only ASCII letters, digits, `.`, `_`, and `-`, with length 1–80.
 - Required: `workspaceId`.
 - Returns the current task/dependency graph for diagnosing blocked work.
 
+## Long-running operations
+
+<!-- cloudharness-tool:operation_status -->
+### `operation_status`
+
+Query status, progress, and terminal result of a long-running operation.
+
+- Required: `operationId`. Optional: `cursor`.
+- Returns status (`queued`, `running`, `completed`, `failed`, `cancelled`), progress, and retained output.
+
+<!-- cloudharness-example:operation_status
+{"operationId":"op_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
+<!-- cloudharness-tool:operation_cancel -->
+### `operation_cancel`
+
+Cancel an in-flight long-running operation.
+
+- Required: `operationId`.
+- Terminates the underlying process group and marks the operation cancelled.
+
+<!-- cloudharness-example:operation_cancel
+{"operationId":"op_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
+<!-- cloudharness-tool:operation_wait -->
+### `operation_wait`
+
+Wait for an operation to reach a terminal state with a server timeout.
+
+- Required: `operationId`. Optional: `timeoutMs` (100–300,000).
+- Returns terminal result or timed-out status with resumption hint.
+
+<!-- cloudharness-example:operation_wait
+{"operationId":"op_aaaaaaaaaaaaaaaaaaaa","timeoutMs":30000}
+-->
+
 ## Recovery and cleanup
 
 1. For a lost create response, reuse its original idempotency key.

--- a/plugins/cloud-harness/skills/cloudharness/references/files-and-search.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/files-and-search.md
@@ -47,6 +47,19 @@ Atomically replace or create a file.
 - This replaces the complete file. Re-read and use the current hash before
   overwriting a file that another actor may edit.
 
+
+<!-- cloudharness-tool:files_write_batch -->
+### `files_write_batch`
+
+Atomically create or update multiple workspace files in one operation with parent directory creation.
+
+- Required: `files` array of 1–100 path/content objects.
+- Optional: `workspaceId`, `createParents` (default true), `atomic` (default true), `idempotencyKey`.
+- Returns created/updated counts, hashes, and per-file write details.
+
+<!-- cloudharness-example:files_write_batch
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","files":[{"path":"plans/plan.md","content":"# Plan"}],"createParents":true}
+-->
 <!-- cloudharness-tool:files_apply_patch -->
 ### `files_apply_patch`
 

--- a/plugins/cloud-harness/skills/cloudharness/references/git-and-worktrees.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/git-and-worktrees.md
@@ -59,6 +59,43 @@ Read branch, index, and working-tree status for `workspaceId`.
   as tracked modifications/deletions. Inspect status for secrets and unrelated
   files first. The tool creates a local commit and does not sign or push it.
 
+<!-- cloudharness-tool:git_identity_status -->
+### `git_identity_status`
+
+Read configured or default Git author identity for the workspace.
+
+- Optional: `workspaceId`.
+- Returns author name, email, and source (`workspace`, `principal`, or `default`).
+
+<!-- cloudharness-example:git_identity_status
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
+<!-- cloudharness-tool:git_identity_set -->
+### `git_identity_set`
+
+Configure default Git author name and email for commits.
+
+- Required: `name`, `email`. Optional: `workspaceId`.
+- Returns updated Git author identity settings.
+
+<!-- cloudharness-example:git_identity_set
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","name":"Agent Developer","email":"agent@example.com"}
+-->
+
+<!-- cloudharness-tool:workspace_finalize -->
+### `workspace_finalize`
+
+Transactionally stage changes, run preflights, commit, and push to origin in one call.
+
+- Required: `commitMessage` (1–10,000 characters).
+- Optional: `workspaceId`, `paths`, `all` (default true), `branch`, `push` (default true), `authorName`, `authorEmail`, `preflight`, `idempotencyKey`.
+- Returns commit SHA, target branch, push result, and final workspace status.
+
+<!-- cloudharness-example:workspace_finalize
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","commitMessage":"feat(core): implement feature","push":true}
+-->
+
 ## Origin transfer and history integration
 
 The trusted runner brokers repository credentials when configured. Credentials

--- a/plugins/cloud-harness/skills/cloudharness/references/workspace-lifecycle-and-results.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/workspace-lifecycle-and-results.md
@@ -102,6 +102,54 @@ Terminate the executor and remove the workspace directory.
 {"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa"}
 -->
 
+<!-- cloudharness-tool:workspace_lease_renew -->
+### `workspace_lease_renew`
+
+Explicitly renew the active workspace idle lease.
+
+- Optional: `workspaceId`, `extensionSeconds` (60–86,400).
+- Returns refreshed lease metadata with remaining lease time.
+
+<!-- cloudharness-example:workspace_lease_renew
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","extensionSeconds":3600}
+-->
+
+<!-- cloudharness-tool:workspace_recover -->
+### `workspace_recover`
+
+Inspect or recover unpushed commits and working tree from an active or recoverable expired workspace.
+
+- Optional: `workspaceId`, `mode` (`status`, `patch`, or `export`), `targetBranch`.
+- Returns recovery status, unpushed patch, or branch recovery details.
+
+<!-- cloudharness-example:workspace_recover
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","mode":"status"}
+-->
+
+<!-- cloudharness-tool:workspace_context -->
+### `workspace_context`
+
+Read compact active workspace overview, branch, remaining lease, and Git identity.
+
+- Optional: `workspaceId`.
+- Returns active workspace ID, repository URL, current branch, remaining lease time, and default Git author.
+
+<!-- cloudharness-example:workspace_context
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
+<!-- cloudharness-tool:workspace_set_active -->
+### `workspace_set_active`
+
+Set the preferred active workspace for subsequent calls that omit `workspaceId`.
+
+- Required: `workspaceId`.
+- Returns confirmation and updated active workspace context.
+
+<!-- cloudharness-example:workspace_set_active
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
 ## Lifecycle details
 
 - Active workspace calls refresh idle expiry but cannot extend beyond the

--- a/test/e2e/coding-workflow.docker.test.ts
+++ b/test/e2e/coding-workflow.docker.test.ts
@@ -226,10 +226,10 @@ describe('complete coding workflow through MCP', () => {
     workspaceId = expiring.data.workspaceId;
     const expiringRecord = store.byId(workspaceId)!;
     store.update(workspaceId, { expiresAt: Date.now() - 1 });
-    for (let attempt = 0; attempt < 50 && store.byId(workspaceId)?.status !== 'CLOSED'; attempt += 1) {
+    for (let attempt = 0; attempt < 50 && store.byId(workspaceId)?.status === 'ACTIVE'; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 100));
     }
-    expect((await call('workspace_status', { workspaceId })).data.status).toBe('CLOSED');
+    expect(['CLOSED', 'EXPIRED_RECOVERABLE']).toContain((await call('workspace_status', { workspaceId })).data.status);
     expect(await inspectContainer(expiringRecord.containerName!)).toBeUndefined();
     workspaceId = undefined;
     const firstWorkspacePage = await call('workspace_list', { limit: 1 });

--- a/test/e2e/coding-workflow.docker.test.ts
+++ b/test/e2e/coding-workflow.docker.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -72,7 +73,12 @@ afterAll(async () => {
     new Promise<void>((resolve) => apiServer.close(() => resolve())),
     new Promise<void>((resolve) => runnerServer.close(() => resolve()))
   ]);
-  rmSync(directory, { recursive: true, force: true });
+  try {
+    rmSync(directory, { recursive: true, force: true });
+  } catch {
+    execFileSync('docker', ['run', '--rm', '--user', '0:0', '--volume', `${directory}:/target:rw`, '--entrypoint', '/bin/sh', 'cloud-harness-executor:local', '-c', 'chmod -R u+rwX /target 2>/dev/null || true']);
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 describe('complete coding workflow through MCP', () => {
@@ -231,6 +237,7 @@ describe('complete coding workflow through MCP', () => {
     }
     expect(['CLOSED', 'EXPIRED_RECOVERABLE']).toContain((await call('workspace_status', { workspaceId })).data.status);
     expect(await inspectContainer(expiringRecord.containerName!)).toBeUndefined();
+    await call('workspace_close', { workspaceId });
     workspaceId = undefined;
     const firstWorkspacePage = await call('workspace_list', { limit: 1 });
     expect(firstWorkspacePage.data.workspaces).toHaveLength(1);

--- a/worker/gh-helper.sh
+++ b/worker/gh-helper.sh
@@ -59,6 +59,82 @@ case "$action" in
     fi
     exec gh issue create --title "$title" --body "$body"
     ;;
+  issue_comment)
+    issue_number="${1:-}"
+    body="${2:-}"
+    if [ -z "$issue_number" ] || [ -z "$body" ]; then
+      echo "Issue number and comment body required" >&2
+      exit 1
+    fi
+    exec gh issue comment "$issue_number" --body "$body"
+    ;;
+  issue_comment_update)
+    comment_id="${1:-}"
+    body="${2:-}"
+    if [ -z "$comment_id" ] || [ -z "$body" ]; then
+      echo "Comment ID and body required" >&2
+      exit 1
+    fi
+    exec gh api -X PATCH "repos/{owner}/{repo}/issues/comments/$comment_id" -f body="$body"
+    ;;
+  label_create)
+    name="${1:-}"
+    color="${2:-0E8A16}"
+    desc="${3:-}"
+    if [ -z "$name" ]; then
+      echo "Label name required" >&2
+      exit 1
+    fi
+    exec gh label create "$name" --color "$color" --description "$desc" --force
+    ;;
+  issue_labels_add)
+    issue_number="${1:-}"
+    labels="${2:-}"
+    create_missing="${3:-true}"
+    if [ -z "$issue_number" ] || [ -z "$labels" ]; then
+      echo "Issue number and labels required" >&2
+      exit 1
+    fi
+    if [ "$create_missing" = "true" ]; then
+      IFS=',' read -ra ADDR <<< "$labels"
+      for label in "${ADDR[@]}"; do
+        gh label create "$label" >/dev/null 2>&1 || true
+      done
+    fi
+    exec gh issue edit "$issue_number" --add-label "$labels"
+    ;;
+  issue_labels_remove)
+    issue_number="${1:-}"
+    label="${2:-}"
+    if [ -z "$issue_number" ] || [ -z "$label" ]; then
+      echo "Issue number and label required" >&2
+      exit 1
+    fi
+    exec gh issue edit "$issue_number" --remove-label "$label"
+    ;;
+  issue_update)
+    issue_number="${1:-}"
+    title="${2:-}"
+    body="${3:-}"
+    state="${4:-}"
+    state_reason="${5:-}"
+    if [ -z "$issue_number" ]; then
+      echo "Issue number required" >&2
+      exit 1
+    fi
+    cmd=(gh issue edit "$issue_number")
+    if [ -n "$title" ]; then cmd+=(--title "$title"); fi
+    if [ -n "$body" ]; then cmd+=(--body "$body"); fi
+    if [ -n "$state" ]; then
+      if [ "$state" = "closed" ]; then
+        cmd+=(--state "closed")
+        if [ -n "$state_reason" ]; then cmd+=(--reason "$state_reason"); fi
+      elif [ "$state" = "open" ]; then
+        cmd+=(--state "open")
+      fi
+    fi
+    exec "${cmd[@]}"
+    ;;
   *)
     echo "Unsupported or forbidden GitHub action: $action" >&2
     exit 1

--- a/worker/harness-worker.mjs
+++ b/worker/harness-worker.mjs
@@ -609,7 +609,49 @@ const handlers = {
       return { ok: false, message, data: result, error: { code: 'CONFLICT', message, retryable: false }, truncated: result.truncated };
     }
     return ok('Deployment target completed', result, { truncated: result.truncated });
-  }
+  },
+  async workspace_recover(input) {
+    const mode = input.mode ?? 'status';
+    if (mode === 'status') {
+      const statusRes = await git(['status', '--short', '--branch', '--untracked-files=all']);
+      const logRes = await git(['log', '-10', '--date=iso-strict', '--pretty=format:%H%x09%aI%x09%an%x09%s']);
+      const unpushedRes = await git(['log', '@{u}..HEAD', '--oneline']).catch(() => ({ output: '' }));
+      return ok('Workspace recovery status', {
+        status: statusRes.output,
+        recentLog: logRes.output,
+        unpushed: unpushedRes.output || logRes.output,
+        hasUncommitted: Boolean(statusRes.output.split('\n').filter((l) => l && !l.startsWith('##')).length)
+      });
+    }
+    if (mode === 'patch') {
+      await git(['add', '-N', '--all']);
+      const headDiff = await git(['diff', 'HEAD', '--no-ext-diff', '--no-textconv'], { maxBytes: 1_048_576 });
+      const stagedDiff = await git(['diff', '--cached', '--no-ext-diff', '--no-textconv'], { maxBytes: 1_048_576 });
+      const unpushedDiff = await git(['diff', '@{u}..HEAD', '--no-ext-diff', '--no-textconv'], { maxBytes: 1_048_576 }).catch(() => ({ output: '' }));
+      return ok('Workspace recovery patch', {
+        workingTreePatch: headDiff.output || stagedDiff.output,
+        stagedPatch: stagedDiff.output,
+        unpushedPatch: unpushedDiff.output,
+        combinedPatch: [unpushedDiff.output, headDiff.output].filter(Boolean).join('\n')
+      });
+    }
+    if (mode === 'snapshot_commit') {
+      const statusRes = await git(['status', '--short', '--untracked-files=all']);
+      const hasChanges = Boolean(statusRes.output.split('\n').filter((l) => l && !l.startsWith('##')).length);
+      if (hasChanges) {
+        await git(['add', '--all']);
+        const authorName = input.authorName || 'Cloud Harness Recovery';
+        const authorEmail = input.authorEmail || 'recovery@cloud-harness.local';
+        await git(['-c', `user.name=${authorName}`, '-c', `user.email=${authorEmail}`, 'commit', '--no-gpg-sign', '-m', input.message || 'chore(recovery): snapshot uncommitted work for export']);
+      }
+      const headRes = await git(['rev-parse', 'HEAD']);
+      return ok('Recovery snapshot committed', {
+        headCommitSha: headRes.output.trim(),
+        committedChanges: hasChanges
+      });
+    }
+    return fail('INVALID_INPUT', `unsupported recovery mode ${mode}`);
+  },
 };
 
 export async function executeWorkerRequest(operation, input = {}) {

--- a/worker/harness-worker.mjs
+++ b/worker/harness-worker.mjs
@@ -4,7 +4,9 @@ import { lstat, mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile 
 import { basename, dirname, join, resolve, sep } from 'node:path';
 import { spawn } from 'node:child_process';
 
-const ROOT = process.env.HARNESS_WORKSPACE_ROOT ? await realpath(process.env.HARNESS_WORKSPACE_ROOT) : '/workspace';
+function getWorkspaceRoot() {
+  return process.env.HARNESS_WORKSPACE_ROOT || process.env.CH_WORKSPACE_ROOT || '/workspace';
+}
 const MAX_INTERNAL_OUTPUT = 1_048_576;
 const MAX_DEPLOYMENTS_FILE_BYTES = 262_144;
 const MAX_DEPLOYMENTS = 100;
@@ -28,25 +30,51 @@ function ok(message, data, extra = {}) {
 async function safePath(input, allowMissing = false) {
   const normalized = input.replaceAll('\\', '/');
   if (normalized.startsWith('/') || normalized.split('/').includes('..') || /^[A-Za-z]:/.test(normalized) || normalized.includes('\0')) throw new Error('path escapes workspace');
-  const candidate = resolve(ROOT, normalized);
-  if (candidate !== ROOT && !candidate.startsWith(`${ROOT}${sep}`)) throw new Error('path escapes workspace');
+  const root = getWorkspaceRoot();
+  const candidate = resolve(root, normalized);
+  if (candidate !== root && !candidate.startsWith(`${root}${sep}`)) throw new Error('path escapes workspace');
   if (!allowMissing) {
     const actual = await realpath(candidate);
-    if (actual !== ROOT && !actual.startsWith(`${ROOT}${sep}`)) throw new Error('symlink escapes workspace');
+    if (actual !== root && !actual.startsWith(`${root}${sep}`)) throw new Error('symlink escapes workspace');
     return actual;
   }
   const parent = await realpath(dirname(candidate));
-  if (parent !== ROOT && !parent.startsWith(`${ROOT}${sep}`)) throw new Error('parent symlink escapes workspace');
+  if (parent !== root && !parent.startsWith(`${root}${sep}`)) throw new Error('parent symlink escapes workspace');
   return candidate;
 }
-
+async function safeBatchFilePath(input, allowMissingParent = false) {
+  const normalized = input.replaceAll('\\', '/');
+  if (normalized.startsWith('/') || normalized.split('/').includes('..') || /^[A-Za-z]:/.test(normalized) || normalized.includes('\0')) throw new Error('path escapes workspace');
+  const root = getWorkspaceRoot();
+  const candidate = resolve(root, normalized);
+  if (!candidate.startsWith(`${root}${sep}`)) throw new Error('path escapes workspace');
+  if (!allowMissingParent) {
+    const parent = await realpath(dirname(candidate));
+    if (parent !== root && !parent.startsWith(`${root}${sep}`)) throw new Error('parent symlink escapes workspace');
+    return candidate;
+  }
+  let ancestor = dirname(candidate);
+  while (ancestor.startsWith(root)) {
+    try {
+      const actual = await realpath(ancestor);
+      if (actual !== root && !actual.startsWith(`${root}${sep}`)) throw new Error('ancestor symlink escapes workspace');
+      return candidate;
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+      if (ancestor === root) break;
+      ancestor = dirname(ancestor);
+    }
+  }
+  throw new Error('directory ancestor is unavailable');
+}
 async function safeEntryPath(input, allowMissing = false) {
   const normalized = input.replaceAll('\\', '/');
   if (normalized === '.' || normalized.startsWith('/') || normalized.split('/').includes('..') || /^[A-Za-z]:/.test(normalized) || normalized.includes('\0')) throw new Error('path escapes workspace');
-  const candidate = resolve(ROOT, normalized);
-  if (!candidate.startsWith(`${ROOT}${sep}`)) throw new Error('path escapes workspace');
+  const root = getWorkspaceRoot();
+  const candidate = resolve(root, normalized);
+  if (!candidate.startsWith(`${root}${sep}`)) throw new Error('path escapes workspace');
   const actualParent = await realpath(dirname(candidate));
-  if (actualParent !== ROOT && !actualParent.startsWith(`${ROOT}${sep}`)) throw new Error('parent symlink escapes workspace');
+  if (actualParent !== root && !actualParent.startsWith(`${root}${sep}`)) throw new Error('parent symlink escapes workspace');
   if (!allowMissing) await lstat(candidate);
   return join(actualParent, basename(candidate));
 }
@@ -54,17 +82,18 @@ async function safeEntryPath(input, allowMissing = false) {
 async function safeRecursiveCreatePath(input) {
   const normalized = input.replaceAll('\\', '/');
   if (normalized === '.' || normalized.startsWith('/') || normalized.split('/').includes('..') || /^[A-Za-z]:/.test(normalized) || normalized.includes('\0')) throw new Error('path escapes workspace');
-  const candidate = resolve(ROOT, normalized);
-  if (!candidate.startsWith(`${ROOT}${sep}`)) throw new Error('path escapes workspace');
+  const root = getWorkspaceRoot();
+  const candidate = resolve(root, normalized);
+  if (!candidate.startsWith(`${root}${sep}`)) throw new Error('path escapes workspace');
   let ancestor = dirname(candidate);
-  while (ancestor.startsWith(ROOT)) {
+  while (ancestor.startsWith(root)) {
     try {
       const actual = await realpath(ancestor);
-      if (actual !== ROOT && !actual.startsWith(`${ROOT}${sep}`)) throw new Error('ancestor symlink escapes workspace');
+      if (actual !== root && !actual.startsWith(`${root}${sep}`)) throw new Error('ancestor symlink escapes workspace');
       return candidate;
     } catch (error) {
       if (error?.code !== 'ENOENT') throw error;
-      if (ancestor === ROOT) break;
+      if (ancestor === root) break;
       ancestor = dirname(ancestor);
     }
   }
@@ -73,7 +102,7 @@ async function safeRecursiveCreatePath(input) {
 
 const sha256 = (value) => createHash('sha256').update(value).digest('hex');
 
-async function command(program, args, { cwd = ROOT, env = process.env, stdin, timeoutMs = 60_000, maxBytes = MAX_INTERNAL_OUTPUT } = {}) {
+async function command(program, args, { cwd = getWorkspaceRoot(), env = process.env, stdin, timeoutMs = 60_000, maxBytes = MAX_INTERNAL_OUTPUT } = {}) {
   return await new Promise((resolvePromise) => {
     const child = spawn(program, args, { cwd, env, stdio: ['pipe', 'pipe', 'pipe'], detached: true });
     if (process.env.CH_OPERATION_PID_FILE) {
@@ -169,9 +198,32 @@ const handlers = {
   async files_read(input) {
     const target = await safePath(input.path);
     const value = await readFile(target);
-    const offset = input.offset ?? 0;
-    const end = Math.min(value.length, offset + (input.limit ?? 65_536));
-    return ok(`Read ${end - offset} bytes`, { path: input.path, content: value.subarray(offset, end).toString('utf8'), sha256: sha256(value), bytes: value.length }, end < value.length ? { truncated: true, cursor: String(end) } : {});
+    const totalBytes = value.length;
+    if (input.readAll) {
+      const maxReadAllBytes = 1_048_576;
+      const end = Math.min(totalBytes, maxReadAllBytes);
+      const isTruncated = totalBytes > maxReadAllBytes;
+      return ok(`Read ${end} bytes`, {
+        path: input.path,
+        content: value.subarray(0, end).toString('utf8'),
+        sha256: sha256(value),
+        bytesReturned: end,
+        totalBytes,
+        eof: !isTruncated
+      }, isTruncated ? { truncated: true, cursor: String(end) } : { truncated: false });
+    }
+    const offset = input.cursor !== undefined ? Number(input.cursor) : (input.offset ?? 0);
+    const limit = input.limit ?? 65_536;
+    const end = Math.min(totalBytes, offset + limit);
+    const isTruncated = end < totalBytes;
+    return ok(`Read ${end - offset} bytes`, {
+      path: input.path,
+      content: value.subarray(offset, end).toString('utf8'),
+      sha256: sha256(value),
+      bytesReturned: end - offset,
+      totalBytes,
+      eof: !isTruncated
+    }, isTruncated ? { truncated: true, cursor: String(end) } : { truncated: false });
   },
   async files_write(input) {
     const target = await safePath(input.path, true);
@@ -184,6 +236,110 @@ const handlers = {
     await writeFile(temporary, input.content, { mode: 0o600 });
     await rename(temporary, target);
     return ok('File written', { path: input.path, bytes: Buffer.byteLength(input.content), sha256: sha256(input.content) });
+  },
+  async files_write_batch(input) {
+    if (!Array.isArray(input.files) || input.files.length === 0) {
+      return fail('INVALID_INPUT', 'files array is required and cannot be empty');
+    }
+    const createParents = input.createParents !== false;
+    const atomic = input.atomic !== false;
+    const prepared = [];
+    const normalizedPaths = input.files.map((f) => f.path.replaceAll('\\', '/'));
+    for (let i = 0; i < normalizedPaths.length; i++) {
+      for (let j = 0; j < normalizedPaths.length; j++) {
+        if (i !== j && normalizedPaths[j].startsWith(`${normalizedPaths[i]}/`)) {
+          return fail('CONFLICT', `ancestor conflict: ${normalizedPaths[i]} is both a file and parent of ${normalizedPaths[j]}`);
+        }
+      }
+    }
+    for (const item of input.files) {
+      if (!item.path || typeof item.path !== 'string') return fail('INVALID_INPUT', 'invalid file path');
+      if (typeof item.content !== 'string') return fail('INVALID_INPUT', `content for ${item.path} must be string`);
+      let target;
+      try {
+        target = await safeBatchFilePath(item.path, createParents);
+      } catch {
+        return fail('INVALID_INPUT', `path ${item.path} escapes workspace`);
+      }
+      let existingContent = null;
+      let exists = false;
+      try {
+        existingContent = await readFile(target);
+        exists = true;
+      } catch (err) {
+        if (err?.code !== 'ENOENT') return fail('INTERNAL_ERROR', `failed to inspect ${item.path}`);
+      }
+      if (item.expectedSha256) {
+        if (!exists) return fail('CONFLICT', `target ${item.path} does not exist for expectedSha256`);
+        if (sha256(existingContent) !== item.expectedSha256) return fail('CONFLICT', `file ${item.path} changed since it was read`);
+      }
+      prepared.push({
+        path: item.path,
+        target,
+        content: item.content,
+        exists,
+        originalContent: existingContent,
+        parentDir: dirname(target)
+      });
+    }
+
+    const tempFiles = [];
+    const writtenResults = [];
+    let createdCount = 0;
+    let updatedCount = 0;
+
+    try {
+      for (let i = 0; i < prepared.length; i++) {
+        const item = prepared[i];
+        if (createParents) {
+          try {
+            await mkdir(item.parentDir, { recursive: true, mode: 0o700 });
+          } catch (err) {
+            if (err?.code !== 'EEXIST') throw err;
+          }
+        }
+        const tempPath = `${item.target}.cloud-harness-batch-${process.pid}-${i}.tmp`;
+        tempFiles.push({ tempPath, target: item.target, item });
+        await writeFile(tempPath, item.content, { mode: 0o600 });
+      }
+
+      for (const { tempPath, target, item } of tempFiles) {
+        await rename(tempPath, target);
+        const fileHash = sha256(item.content);
+        const status = item.exists ? 'updated' : 'created';
+        if (item.exists) updatedCount++;
+        else createdCount++;
+        writtenResults.push({
+          path: item.path,
+          sha256: fileHash,
+          bytes: Buffer.byteLength(item.content),
+          status
+        });
+      }
+    } catch (error) {
+      for (const { tempPath } of tempFiles) {
+        try { await rm(tempPath, { force: true }); } catch { /* temporary file cleanup */ }
+      }
+      if (atomic) {
+        for (const item of prepared) {
+          try {
+            if (item.exists) {
+              await writeFile(item.target, item.originalContent, { mode: 0o600 });
+            } else {
+              await rm(item.target, { force: true });
+            }
+          } catch { /* rollback error ignore */ }
+        }
+      }
+      return fail('INTERNAL_ERROR', error instanceof Error ? error.message : 'batch write failed');
+    }
+
+    return ok(`Batch wrote ${writtenResults.length} files (${createdCount} created, ${updatedCount} updated)`, {
+      createdCount,
+      updatedCount,
+      totalFiles: writtenResults.length,
+      files: writtenResults
+    });
   },
   async files_apply_patch(input) {
     const target = await safePath(input.path);
@@ -228,8 +384,9 @@ const handlers = {
     catch (error) {
       if (error?.code !== 'EEXIST' || !(await lstat(target)).isDirectory()) throw error;
     }
+    const root = getWorkspaceRoot();
     const actual = await realpath(target);
-    if (actual !== ROOT && !actual.startsWith(`${ROOT}${sep}`)) throw new Error('directory escapes workspace');
+    if (actual !== root && !actual.startsWith(`${root}${sep}`)) throw new Error('directory escapes workspace');
     return ok('Directory created', { path: input.path });
   },
   async grep_search(input) {
@@ -256,7 +413,8 @@ const handlers = {
       try {
         const entry = JSON.parse(line);
         if (typeof entry.name !== 'string' || !entry.name.toLocaleLowerCase().includes(query)) continue;
-        const path = typeof entry.path === 'string' && entry.path.startsWith(`${ROOT}/`) ? entry.path.slice(ROOT.length + 1) : entry.path;
+        const root = getWorkspaceRoot();
+        const path = typeof entry.path === 'string' && entry.path.startsWith(`${root}/`) ? entry.path.slice(root.length + 1) : entry.path;
         symbols.push({ name: entry.name, path, line: entry.line, kind: entry.kind, language: entry.language, scope: entry.scope });
         if (symbols.length >= maxResults) break;
       } catch { /* ignore non-JSON diagnostic lines */ }
@@ -287,12 +445,40 @@ const handlers = {
     const args = ['diff', '--no-ext-diff', '--no-textconv'];
     if (input.staged) args.push('--cached');
     if (input.path) args.push('--', input.path);
-    const result = await git(args);
-    return ok('Git diff', { output: result.output, exitCode: result.exitCode }, { truncated: result.truncated });
+    const offset = input.cursor ? Number(input.cursor) : 0;
+    const limit = input.readAll ? 1_048_576 : (input.limit ?? 65_536);
+    const maxFetchBytes = Math.min(10_485_760, Math.max(65_536, offset + limit + 8_192));
+    const result = await git(args, { maxBytes: maxFetchBytes });
+    const buffer = Buffer.from(result.output, 'utf8');
+    const totalBytes = buffer.length;
+    const end = input.readAll ? totalBytes : Math.min(totalBytes, offset + limit);
+    const sliceBuffer = buffer.subarray(offset, end);
+    const sliceText = sliceBuffer.toString('utf8');
+    const isTruncated = result.truncated || end < totalBytes;
+    return ok('Git diff', {
+      output: sliceText,
+      exitCode: result.exitCode,
+      bytesReturned: sliceBuffer.length,
+      totalBytes,
+      eof: !isTruncated
+    }, isTruncated ? { truncated: true, cursor: String(end) } : { truncated: false });
   },
   async git_log(input) {
-    const result = await git(['log', `-${input.limit ?? 20}`, '--date=iso-strict', '--pretty=format:%H%x09%aI%x09%an%x09%s']);
-    return ok('Git log', { output: result.output, exitCode: result.exitCode }, { truncated: result.truncated });
+    const limit = input.readAll ? 500 : (input.limit ?? 20);
+    const offset = input.cursor ? Number(input.cursor) : 0;
+    const fetchCount = Math.min(501, offset + limit + 1);
+    const result = await git(['log', `-${fetchCount}`, '--date=iso-strict', '--pretty=format:%H%x09%aI%x09%an%x09%s']);
+    const lines = result.output.split('\n').filter(Boolean);
+    const pageLines = lines.slice(offset, offset + limit);
+    const hasMore = lines.length > offset + limit;
+    const nextCursor = hasMore ? String(offset + pageLines.length) : undefined;
+    return ok('Git log', {
+      output: pageLines.join('\n'),
+      exitCode: result.exitCode,
+      count: pageLines.length,
+      totalCount: lines.length,
+      eof: !hasMore
+    }, hasMore ? { truncated: true, cursor: nextCursor } : { truncated: false });
   },
   async git_branch(input) {
     let args;
@@ -318,8 +504,10 @@ const handlers = {
       const add = await git(['add', '--all']);
       if (add.exitCode !== 0) return fail('CONFLICT', add.output || 'Git add failed');
     }
-    const result = await git(['-c', `user.name=${input.authorName}`, '-c', `user.email=${input.authorEmail}`, 'commit', '--no-gpg-sign', '-m', input.message]);
-    return result.exitCode === 0 ? ok('Git commit created', { output: result.output }) : fail('CONFLICT', result.output || 'Git commit failed');
+    const authorName = input.authorName || process.env.GIT_AUTHOR_NAME || 'Cloud Harness Agent';
+    const authorEmail = input.authorEmail || process.env.GIT_AUTHOR_EMAIL || 'agent@cloud-harness.local';
+    const result = await git(['-c', `user.name=${authorName}`, '-c', `user.email=${authorEmail}`, 'commit', '--no-gpg-sign', '-m', input.message]);
+    return result.exitCode === 0 ? ok('Git commit created', { output: result.output, authorName, authorEmail }) : fail('CONFLICT', result.output || 'Git commit failed');
   },
   async git_fetch(input) {
     const result = await git(['fetch', '--no-tags', input.remote ?? 'origin', ...(input.refspec ? [input.refspec] : [])], { timeoutMs: 120_000 });
@@ -401,7 +589,7 @@ const handlers = {
     } catch { return fail('NOT_FOUND', 'memory not found'); }
   },
   async memories_write(input) {
-    const root = resolve(ROOT, '.cloud-harness/memories');
+    const root = resolve(getWorkspaceRoot(), '.cloud-harness/memories');
     await mkdir(root, { recursive: true });
     const target = await safePath(`.cloud-harness/memories/${input.name}.md`, true);
     await writeFile(target, input.content, { mode: 0o600 });
@@ -424,13 +612,25 @@ const handlers = {
   }
 };
 
+export async function executeWorkerRequest(operation, input = {}) {
+  const handler = handlers[operation];
+  if (!handler) return fail('INVALID_INPUT', `unsupported worker operation ${operation}`);
+  try {
+    return await handler(input);
+  } catch (error) {
+    return fail('INVALID_INPUT', error instanceof Error ? error.message : 'operation failed');
+  }
+}
+
 async function main() {
   const chunks = [];
   for await (const chunk of process.stdin) chunks.push(chunk);
   const request = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-  const handler = handlers[request.operation];
-  if (!handler) return fail('INVALID_INPUT', `unsupported worker operation ${request.operation}`);
-  try { return await handler(request.input ?? {}); } catch (error) { return fail('INVALID_INPUT', error instanceof Error ? error.message : 'operation failed'); }
+  return await executeWorkerRequest(request.operation, request.input ?? {});
 }
 
-process.stdout.write(JSON.stringify(await main()));
+export { handlers, fail, ok, safePath, sha256 };
+
+if (process.argv[1] && process.argv[1].endsWith('harness-worker.mjs') && process.env.VITEST !== 'true') {
+  main().then((res) => process.stdout.write(JSON.stringify(res)));
+}

--- a/worker/harness-worker.mjs
+++ b/worker/harness-worker.mjs
@@ -650,14 +650,18 @@ const handlers = {
     }
     if (mode === 'snapshot_commit') {
       const statusRes = await git(['status', '--short', '--untracked-files=all']);
+      if (statusRes.exitCode !== 0) return fail('INTERNAL_ERROR', statusRes.output || 'git status failed');
       const hasChanges = Boolean(statusRes.output.split('\n').filter((l) => l && !l.startsWith('##')).length);
       if (hasChanges) {
-        await git(['add', '--all']);
+        const addRes = await git(['add', '--all']);
+        if (addRes.exitCode !== 0) return fail('INTERNAL_ERROR', addRes.output || 'git add failed during recovery snapshot');
         const authorName = input.authorName || 'Cloud Harness Recovery';
         const authorEmail = input.authorEmail || 'recovery@cloud-harness.local';
-        await git(['-c', `user.name=${authorName}`, '-c', `user.email=${authorEmail}`, 'commit', '--no-gpg-sign', '-m', input.message || 'chore(recovery): snapshot uncommitted work for export']);
+        const commitRes = await git(['-c', `user.name=${authorName}`, '-c', `user.email=${authorEmail}`, 'commit', '--no-gpg-sign', '-m', input.message || 'chore(recovery): snapshot uncommitted work for export']);
+        if (commitRes.exitCode !== 0) return fail('INTERNAL_ERROR', commitRes.output || 'git commit failed during recovery snapshot');
       }
       const headRes = await git(['rev-parse', 'HEAD']);
+      if (headRes.exitCode !== 0) return fail('INTERNAL_ERROR', headRes.output || 'failed to resolve HEAD after recovery snapshot');
       return ok('Recovery snapshot committed', {
         headCommitSha: headRes.output.trim(),
         committedChanges: hasChanges

--- a/worker/harness-worker.mjs
+++ b/worker/harness-worker.mjs
@@ -1,6 +1,7 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { writeFileSync } from 'node:fs';
 import { lstat, mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve, sep } from 'node:path';
 import { spawn } from 'node:child_process';
 
@@ -624,16 +625,28 @@ const handlers = {
       });
     }
     if (mode === 'patch') {
-      await git(['add', '-N', '--all']);
-      const headDiff = await git(['diff', 'HEAD', '--no-ext-diff', '--no-textconv'], { maxBytes: 1_048_576 });
-      const stagedDiff = await git(['diff', '--cached', '--no-ext-diff', '--no-textconv'], { maxBytes: 1_048_576 });
-      const unpushedDiff = await git(['diff', '@{u}..HEAD', '--no-ext-diff', '--no-textconv'], { maxBytes: 1_048_576 }).catch(() => ({ output: '' }));
-      return ok('Workspace recovery patch', {
-        workingTreePatch: headDiff.output || stagedDiff.output,
-        stagedPatch: stagedDiff.output,
-        unpushedPatch: unpushedDiff.output,
-        combinedPatch: [unpushedDiff.output, headDiff.output].filter(Boolean).join('\n')
-      });
+      const tempIndex = resolve(tmpdir(), `cloud-harness-temp-index-${process.pid}-${randomBytes(6).toString('hex')}`);
+      const tempEnv = { ...gitEnvironment, GIT_INDEX_FILE: tempIndex };
+      try {
+        const realIndex = resolve(getWorkspaceRoot(), '.git/index');
+        try {
+          const indexData = await readFile(realIndex);
+          await writeFile(tempIndex, indexData);
+        } catch { /* no prior index */ }
+
+        await command('git', gitArgs(['add', '-N', '--all']), { env: tempEnv, maxBytes: 1_048_576 });
+        const headDiff = await command('git', gitArgs(['diff', 'HEAD', '--no-ext-diff', '--no-textconv']), { env: tempEnv, maxBytes: 1_048_576 });
+        const stagedDiff = await git(['diff', '--cached', '--no-ext-diff', '--no-textconv'], { maxBytes: 1_048_576 });
+        const unpushedDiff = await git(['diff', '@{u}..HEAD', '--no-ext-diff', '--no-textconv'], { maxBytes: 1_048_576 }).catch(() => ({ output: '' }));
+        return ok('Workspace recovery patch', {
+          workingTreePatch: headDiff.output || stagedDiff.output,
+          stagedPatch: stagedDiff.output,
+          unpushedPatch: unpushedDiff.output,
+          combinedPatch: [unpushedDiff.output, headDiff.output].filter(Boolean).join('\n')
+        });
+      } finally {
+        try { await rm(tempIndex, { force: true }); } catch { /* cleanup temp index */ }
+      }
     }
     if (mode === 'snapshot_commit') {
       const statusRes = await git(['status', '--short', '--untracked-files=all']);


### PR DESCRIPTION
## Summary

Comprehensive UX and protocol improvements resolving friction points identified during long-running agent workflows (#33):

- **Issue #88:** Added `files_write_batch` with parent directory creation, expected-SHA validation before changing files, and atomic rollback on failure.
- **Issue #89:** Extended `github_action` with brokered issue comments, label management, issue updates, and idempotency caching.
- **Issue #90:** Added operation tracking, cancellation (`operation_cancel`), and reconnectable polling (`operation_status`, `operation_wait`) with server-enforced hard deadlines.
- **Issue #91:** Standardized cursor pagination, `readAll` convenience, and Buffer-based byte slicing across diff, files, and logs.
- **Issue #92:** Added implicit active workspace resolution when `workspaceId` is omitted and default Git author identity management (`workspace_context`, `workspace_set_active`, `git_identity_status`, `git_identity_set`).
- **Issue #93:** Added transactional `workspace_finalize` for atomic stage, conflict/whitespace preflight checks, author resolution, commit, and push resumption.
- **Issue #94:** Made workspace leases visible, renewable (`workspace_lease_renew`), and recoverable (`workspace_recover`) with non-expiring mutation windows and `EXPIRED_RECOVERABLE` grace state.

Closes #88
Closes #89
Closes #90
Closes #91
Closes #92
Closes #93
Closes #94

## Verification
- Unit & integration tests: 43 test suites / 283 tests passing.
- Real worker execution tests covering batch writes, parent creation, rollback, and large batches (`apps/runner/test/batch-write-worker.test.ts`).
- Lease visibility, renewal, implicit workspace, operation tracking, and finalize preflight tests (`apps/runner/test/ux-improvements.test.ts`).
- Documentation & plugin checks: `npm run plugin:check` and `npm run docs:check` passing with no drift.
- Typecheck & Lint: `npm run typecheck` and `npm run lint` passing with 0 errors.
