### PR TITLE
fix(runner): ensure large recovery buffer sizing, rootfs read-only protection, and server-owned async signals

### DIFF
--- a/apps/runner/src/operation-manager.ts
+++ b/apps/runner/src/operation-manager.ts
@@ -37,6 +37,7 @@ export type TrackedOperation = {
   offset: number;
   child?: ChildProcessWithoutNullStreams | undefined;
   container?: string | undefined;
+  abortController?: AbortController | undefined;
 };
 const id = (prefix: string) => `${prefix}_${randomBytes(24).toString('base64url')}`;
 
@@ -342,7 +343,14 @@ export class OperationManager {
     };
   }
 
-  registerGenericOperation(op: { id: string; workspaceId?: string; kind: string; deadlineMs?: number; container?: string }): TrackedOperation {
+  registerGenericOperation(op: {
+    id: string;
+    workspaceId?: string | undefined;
+    kind: string;
+    deadlineMs?: number | undefined;
+    container?: string | undefined;
+    abortController?: AbortController | undefined;
+  }): TrackedOperation {
     while (this.genericOperations.size >= 500) {
       const oldest = [...this.genericOperations.entries()]
         .filter(([, o]) => o.status === 'completed' || o.status === 'failed' || o.status === 'cancelled')
@@ -364,7 +372,8 @@ export class OperationManager {
       deadlineMs: op.deadlineMs,
       output: Buffer.alloc(0),
       offset: 0,
-      container: op.container
+      container: op.container,
+      abortController: op.abortController
     };
     this.genericOperations.set(op.id, tracked);
     return tracked;
@@ -403,6 +412,9 @@ export class OperationManager {
     if (op) {
       if (op.status === 'running' || op.status === 'queued') {
         op.status = 'cancelled';
+        if (op.abortController) {
+          try { op.abortController.abort(); } catch { /* ignore */ }
+        }
         if (op.child) {
           try { op.child.kill('SIGTERM'); } catch { /* process already exited */ }
         }

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -519,10 +519,9 @@ export class WorkspaceService {
   private async runWorker(record: WorkspaceRecord, operation: RunnerOperation, input: Record<string, unknown>, signal?: AbortSignal): Promise<RunnerResponse> {
     if (!record.containerName) throw new HarnessError('UNAVAILABLE', 'workspace executor is unavailable', 503, true);
     const timeout = typeof input.timeoutMs === 'number' ? input.timeoutMs + 5_000 : 65_000;
-    const operationId = opaqueId('op');
+    const operationId = (typeof input.operationId === 'string' && input.operationId) || opaqueId('op');
     const pidFile = `/tmp/cloud-harness-operations/${operationId}.pid`;
     const jsonMaxBytes = Math.min(67_108_864, Math.max(this.config.maxOutputBytes, 262_144) * 6 + 8_192);
-
     this.operations.registerGenericOperation({
       id: operationId,
       workspaceId: record.id,
@@ -590,13 +589,14 @@ export class WorkspaceService {
     }
     const helperName = `chm-rec-${record.id.slice(3, 15)}-${randomBytes(4).toString('hex')}`;
     const mode = writable ? 'rw' : 'ro';
+    const jsonMaxBytes = Math.min(67_108_864, Math.max(this.config.maxOutputBytes, 262_144) * 6 + 8_192);
     try {
       const result = await runDocker([
         'run', '-i', '--rm', '--name', helperName,
         '--label', 'cloud-harness.role=recover-helper', '--label', 'cloud-harness.ephemeral=true',
         '--label', `cloud-harness.instance=${this.instanceId}`, '--label', `cloud-harness.workspace=${record.id}`,
         '--network', 'none', '--user', '10001:10001',
-        ...(writable ? [] : ['--read-only']),
+        '--read-only',
         '--tmpfs', '/tmp:rw,exec,nosuid,nodev,size=64m',
         '--pids-limit', '64', '--memory', '256m', '--memory-swap', '256m', '--cpus', '1',
         '--volume', `${record.workspacePath}/repo:/workspace:${mode}`,
@@ -608,7 +608,7 @@ export class WorkspaceService {
       ], {
         stdin: JSON.stringify({ operation, input }),
         timeoutMs: 60_000,
-        maxBytes: this.config.maxOutputBytes,
+        maxBytes: jsonMaxBytes,
         ...(signal ? { signal } : {})
       });
       if (result.exitCode !== 0) throw new HarnessError('INTERNAL_ERROR', `recovery worker failed: ${result.stderr || result.stdout}`.slice(0, 2_000), 500, true);
@@ -792,10 +792,54 @@ export class WorkspaceService {
 
       return await this.runPrivilegedEphemeralExec(record, { command, cwd, timeoutMs, maxOutputBytes }, signal);
     }
+    if (validated.async === true) {
+      const operationId = opaqueId('op');
+      const serverAbortController = new AbortController();
+      this.operations.registerGenericOperation({
+        id: operationId,
+        workspaceId: record.id,
+        kind: 'exec_run',
+        deadlineMs: Date.now() + timeoutMs,
+        container: record.containerName ?? undefined,
+        abortController: serverAbortController
+      });
+      const deadlineTimer = setTimeout(() => {
+        serverAbortController.abort();
+        this.operations.updateGenericOperation(operationId, {
+          status: 'failed',
+          error: { code: 'TIMEOUT', message: 'Command execution exceeded server deadline', retryable: false }
+        });
+      }, timeoutMs);
+      deadlineTimer.unref();
+
+      void (async () => {
+        try {
+          const result = await this.runWorker(record, 'exec_run', { ...validated, async: false }, serverAbortController.signal);
+          clearTimeout(deadlineTimer);
+          this.operations.updateGenericOperation(operationId, {
+            status: result.ok ? 'completed' : 'failed',
+            result: result.data,
+            error: result.error
+          });
+        } catch (err: unknown) {
+          clearTimeout(deadlineTimer);
+          this.operations.updateGenericOperation(operationId, {
+            status: serverAbortController.signal.aborted ? 'cancelled' : 'failed',
+            error: { code: serverAbortController.signal.aborted ? 'CANCELLED' : 'INTERNAL_ERROR', message: err instanceof Error ? err.message : 'command failed', retryable: false }
+          });
+        }
+      })();
+
+      return {
+        ok: true,
+        message: 'Command started in background',
+        data: { operationId, status: 'running' },
+        truncated: false
+      };
+    }
 
     return await this.runWorker(record, 'exec_run', validated, signal);
   }
-
   private async runPrivilegedEphemeralExec(
     record: WorkspaceRecord,
     input: { command: string; cwd: string; timeoutMs: number; maxOutputBytes: number },

--- a/apps/runner/test/ux-improvements.test.ts
+++ b/apps/runner/test/ux-improvements.test.ts
@@ -194,25 +194,26 @@ describe('UX Improvements and Feature Enhancements', () => {
 
     // Register a generic operation in operation manager
     const opManager = (service as unknown as { operations: { registerGenericOperation: (op: unknown) => { id: string, status: string } } }).operations;
+    const opId = `op_${'a'.repeat(24)}`;
     const tracked = opManager.registerGenericOperation({
-      id: 'op_custom_12345',
+      id: opId,
       kind: 'build',
       deadlineMs: Date.now() + 60_000
     });
-    expect(tracked.id).toBe('op_custom_12345');
+    expect(tracked.id).toBe(opId);
 
     // Poll operation_status
-    const statusRes = await service.execute(ownerId, 'operation_status', { operationId: 'op_custom_12345' });
+    const statusRes = await service.execute(ownerId, 'operation_status', { operationId: opId });
     expect(statusRes.ok).toBe(true);
     expect((statusRes.data as Record<string, unknown>).status).toBe('running');
 
     // Cancel operation
-    const cancelRes = await service.execute(ownerId, 'operation_cancel', { operationId: 'op_custom_12345' });
+    const cancelRes = await service.execute(ownerId, 'operation_cancel', { operationId: opId });
     expect(cancelRes.ok).toBe(true);
     expect((cancelRes.data as Record<string, unknown>).status).toBe('cancelled');
 
     // Wait for operation (already terminal)
-    const waitRes = await service.execute(ownerId, 'operation_wait', { operationId: 'op_custom_12345', timeoutMs: 1000 });
+    const waitRes = await service.execute(ownerId, 'operation_wait', { operationId: opId, timeoutMs: 1000 });
     expect(waitRes.ok).toBe(false);
     expect((waitRes.data as Record<string, unknown>).status).toBe('cancelled');
   });
@@ -356,7 +357,7 @@ describe('UX Improvements and Feature Enhancements', () => {
     expect(recoverDockerCalls.length).toBeGreaterThan(0);
     const lastCallArgs = recoverDockerCalls.at(-1)![0];
     expect(lastCallArgs.some((arg: string) => arg.includes('/repo:/workspace:rw'))).toBe(true);
-    expect(lastCallArgs.includes('--read-only')).toBe(false);
+    expect(lastCallArgs.includes('--read-only')).toBe(true);
   });
 
   it('Issue #93: workspace_finalize validates preflight conflicts and enforces journal idempotency', async () => {

--- a/docs-site/reference/tools.md
+++ b/docs-site/reference/tools.md
@@ -260,6 +260,7 @@ Run one bounded shell command in the workspace and return captured output.
 | `maxOutputBytes` | `integer` | **Yes** | range: 1024–1048576, default: `262144` |
 | `privileged` | `boolean` | **Yes** | default: `false` |
 | `approvalGrantToken` | `string` | No | length: 1–128 |
+| `async` | `boolean` | **Yes** | default: `false` |
 
 ### `shell_open`
 
@@ -921,7 +922,7 @@ Query the execution state, progress, and terminal result of a long-running opera
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `operationId` | `string` | **Yes** | length: 1–128 |
+| `operationId` | `string` | **Yes** | pattern: `^op_[A-Za-z0-9_-]{20,80}$` |
 | `cursor` | `string` | No | max length: 256 |
 
 ### `operation_cancel`
@@ -934,7 +935,7 @@ Cancel an in-flight long-running operation.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `operationId` | `string` | **Yes** | length: 1–128 |
+| `operationId` | `string` | **Yes** | pattern: `^op_[A-Za-z0-9_-]{20,80}$` |
 
 ### `operation_wait`
 
@@ -946,7 +947,7 @@ Wait for a long-running operation to reach a terminal state with a timeout.
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `operationId` | `string` | **Yes** | length: 1–128 |
+| `operationId` | `string` | **Yes** | pattern: `^op_[A-Za-z0-9_-]{20,80}$` |
 | `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
 
 ### `git_identity_status`

--- a/packages/contracts/src/tool-schemas.ts
+++ b/packages/contracts/src/tool-schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { IdempotencyKeySchema, SessionIdSchema, ShellIdSchema, TaskIdSchema, WorkspaceIdSchema } from './identifiers.js';
+import { IdempotencyKeySchema, OperationIdSchema, SessionIdSchema, ShellIdSchema, TaskIdSchema, WorkspaceIdSchema } from './identifiers.js';
 import type { RunnerOperation } from './runner-api.js';
 
 const relativePath = z.string().min(1).max(1_024).refine((value) => {
@@ -87,7 +87,8 @@ const schemas = {
     timeoutMs: z.number().int().min(100).max(300_000).default(60_000),
     maxOutputBytes: z.number().int().min(1_024).max(1_048_576).default(262_144),
     privileged: z.boolean().default(false),
-    approvalGrantToken: z.string().min(1).max(128).optional()
+    approvalGrantToken: z.string().min(1).max(128).optional(),
+    async: z.boolean().default(false)
   }),
   shell_open: z.object({ ...workspace, cwd: relativePath.default('.'), idempotencyKey: IdempotencyKeySchema }),
   shell_io: z.object({ ...workspace, shellId: ShellIdSchema, input: z.string().max(65_536).optional(), cursor: z.string().max(256).optional(), waitMs: z.number().int().min(0).max(5_000).default(100) }),
@@ -101,9 +102,9 @@ const schemas = {
   tasks_status: z.object({ ...workspace, taskId: TaskIdSchema, cursor: z.string().max(256).optional() }),
   tasks_cancel: z.object({ ...workspace, taskId: TaskIdSchema }),
   tasks_graph: z.object(workspace),
-  operation_status: z.object({ operationId: z.string().min(1).max(128), cursor: z.string().max(256).optional() }),
-  operation_cancel: z.object({ operationId: z.string().min(1).max(128) }),
-  operation_wait: z.object({ operationId: z.string().min(1).max(128), timeoutMs: z.number().int().min(100).max(300_000).default(60_000) }),
+  operation_status: z.object({ operationId: OperationIdSchema, cursor: z.string().max(256).optional() }),
+  operation_cancel: z.object({ operationId: OperationIdSchema }),
+  operation_wait: z.object({ operationId: OperationIdSchema, timeoutMs: z.number().int().min(100).max(300_000).default(60_000) }),
   git_status: z.object(workspace),
   git_diff: z.object({ ...workspace, staged: z.boolean().default(false), path: relativePath.optional(), cursor: z.string().max(256).optional(), limit: z.number().int().min(1).max(500_000).default(65_536), readAll: z.boolean().optional() }),
   git_log: z.object({ ...workspace, limit: z.number().int().min(1).max(500).default(20), cursor: z.string().max(256).optional(), readAll: z.boolean().optional() }),

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -169,9 +169,10 @@ describe('contracts', () => {
   });
 
   it('validates operation status, cancel, and wait schemas', () => {
-    expect(TOOL_SCHEMA_BY_NAME.operation_status.parse({ operationId: 'op_12345' })).toMatchObject({ operationId: 'op_12345' });
-    expect(TOOL_SCHEMA_BY_NAME.operation_cancel.parse({ operationId: 'op_12345' })).toMatchObject({ operationId: 'op_12345' });
-    expect(TOOL_SCHEMA_BY_NAME.operation_wait.parse({ operationId: 'op_12345', timeoutMs: 5000 })).toMatchObject({ timeoutMs: 5000 });
+    const validOpId = `op_${'a'.repeat(24)}`;
+    expect(TOOL_SCHEMA_BY_NAME.operation_status.parse({ operationId: validOpId })).toMatchObject({ operationId: validOpId });
+    expect(TOOL_SCHEMA_BY_NAME.operation_cancel.parse({ operationId: validOpId })).toMatchObject({ operationId: validOpId });
+    expect(TOOL_SCHEMA_BY_NAME.operation_wait.parse({ operationId: validOpId, timeoutMs: 5000 })).toMatchObject({ timeoutMs: 5000 });
     expect(() => TOOL_SCHEMA_BY_NAME.operation_status.parse({ operationId: '' })).toThrow();
   });
 


### PR DESCRIPTION
## Summary

Addresses final recovery and operation tracking edge cases:
- **Recovery Buffer Sizing:** Uses `jsonMaxBytes` in `runRecoveryWorker` matching `runWorker` (up to 64MB) to prevent Docker JSON truncation on recovery outputs >256 KiB.
- **Rootfs Read-Only Protection:** Retains `--read-only` flag on the container rootfs in `runRecoveryWorker` while mounting the repository volume as `:rw` for snapshot commits.
- **Server-Owned Async Signals:** Created server-owned `AbortController` for background execution in `handleExecRun` detached from transient HTTP request signals, with deadline timer and cancellation support.
- **Schema & Identification:** Enforced `OperationIdSchema` on operation management tools and supported `async: true` on `exec_run`.

## Verification
- 50 test suites / 332 tests passing across contracts, runner, api, gateway, and integration suites.
- Full quality gates: `npm run plugin:check`, `npm run docs:check`, `npm run lint`, `npm run typecheck` passing with 0 errors.
