### PR TITLE
docs: add local stdio mode guides and troubleshooting playbooks

### DIFF
--- a/docs-site/ai-tools/claude-code.md
+++ b/docs-site/ai-tools/claude-code.md
@@ -39,3 +39,15 @@ claude
 ```
 
 You should see `cloud-harness` listed with 52 available tools.
+
+---
+
+## Local Stdio Mode
+
+To connect Claude Code directly to a local folder over stdio:
+
+```bash
+claude mcp add cloud-harness-local \
+  --transport stdio \
+  -- node /path/to/cloud-harness-mcp/apps/api/dist/index.js --transport stdio --workspace /absolute/path/to/project
+```

--- a/docs-site/ai-tools/claude.md
+++ b/docs-site/ai-tools/claude.md
@@ -53,3 +53,26 @@ For environments using static headers, configure `claude_desktop_config.json`:
 ```
 
 Restart Claude Desktop and check the tool availability in your chat view.
+
+---
+
+## Option 3: Local Stdio Mode (Direct Folder Access)
+
+To operate directly on a local project directory without remote cloud hosting, configure `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cloud_harness_local": {
+      "command": "node",
+      "args": [
+        "/path/to/cloud-harness-mcp/apps/api/dist/index.js",
+        "--transport",
+        "stdio",
+        "--workspace",
+        "/absolute/path/to/project"
+      ]
+    }
+  }
+}
+```

--- a/docs-site/ai-tools/codex.md
+++ b/docs-site/ai-tools/codex.md
@@ -65,3 +65,15 @@ For non-interactive or static-header usage, use the dedicated API key gateway:
    ```bash
    codex mcp list
    ```
+
+---
+
+## Option 3: Local Stdio Mode
+
+To connect Codex directly to a local project folder:
+
+```toml
+[mcp_servers.cloudharness_local]
+command = "node"
+args = ["/path/to/cloud-harness-mcp/apps/api/dist/index.js", "--transport", "stdio", "--workspace", "/absolute/path/to/project"]
+```

--- a/docs-site/ai-tools/cursor.md
+++ b/docs-site/ai-tools/cursor.md
@@ -9,9 +9,9 @@ description: Adding Cloud Harness MCP to Cursor settings via Streamable HTTP.
   <strong>AI Crawler / Raw View:</strong> Fetch this page as raw Markdown at <code>/ai-tools/cursor.md</code>.
 </div>
 
-Cursor supports remote MCP servers over HTTP with custom request headers.
+Cursor supports Cloud Harness MCP via **Streamable HTTP** (for remote cloud workspaces) and **stdio** (for direct local project workspaces).
 
-## Configuration
+## Option 1: Remote HTTP (API Key Gateway)
 
 1. In Cursor, open **Cursor Settings** (`Cmd+,` on macOS, `Ctrl+,` on Windows/Linux).
 2. Navigate to **Features** → **MCP Servers** → click **Add New MCP Server**.
@@ -21,3 +21,26 @@ Cursor supports remote MCP servers over HTTP with custom request headers.
    - **Server URL:** `https://api.harness.zuey.me/mcp`
    - **Headers:** `{"Authorization": "Bearer <YOUR_DASHBOARD_API_KEY>"}`
 4. Click **Save** and verify the status indicator turns green with 52 tools active.
+
+---
+
+## Option 2: Local Stdio Mode
+
+For editing a local project folder directly without uploading to a remote VPS, configure `.cursor/mcp.json` in your project or global user directory:
+
+```json
+{
+  "mcpServers": {
+    "cloud-harness-local": {
+      "command": "node",
+      "args": [
+        "/path/to/cloud-harness-mcp/apps/api/dist/index.js",
+        "--transport",
+        "stdio",
+        "--workspace",
+        "/absolute/path/to/project"
+      ]
+    }
+  }
+}
+```

--- a/docs-site/troubleshooting.md
+++ b/docs-site/troubleshooting.md
@@ -52,3 +52,9 @@ docker compose --profile images build executor-image
    - **Claude Desktop:** `https://claude.ai/api/mcp/auth_callback` and `https://claude.com/api/mcp/auth_callback`
    - **Codex App / Native Clients:** Pin `mcp_oauth_callback_port = 3118` in `~/.codex/config.toml` and add `http://127.0.0.1:3118/callback/*`, `http://127.0.0.1:3118/*`, `http://localhost:3118/callback/*`, and `http://localhost:3118/*`.
    - **ChatGPT Web:** `https://chatgpt.com/connector/oauth/*`, `https://chatgpt.com/connector_platform_oauth_redirect`, and `https://chatgpt.com/api/aip/p/oauth/callback`.
+
+---
+
+### 6. Local Stdio: `--workspace path must be absolute` or Directory Error
+**Cause:** The `--workspace` argument provided to `cloud-harness-mcp --transport stdio` is relative, does not exist, or points to a regular file instead of a directory.
+**Fix:** Provide a valid, existing absolute directory path (e.g. `/home/user/project` or `C:\Users\user\project`).

--- a/docs-site/troubleshooting.md
+++ b/docs-site/troubleshooting.md
@@ -57,4 +57,4 @@ docker compose --profile images build executor-image
 
 ### 6. Local Stdio: `--workspace path must be absolute` or Directory Error
 **Cause:** The `--workspace` argument provided to `cloud-harness-mcp --transport stdio` is relative, does not exist, or points to a regular file instead of a directory.
-**Fix:** Provide a valid, existing absolute directory path (e.g. `/home/user/project` or `C:\Users\user\project`).
+**Fix:** Provide a valid, existing absolute directory path (e.g. `/home/user/project` or `/mnt/c/Users/user/project` in WSL). Native Windows path formats (like `C:\...`) are unsupported in v1 local stdio mode; run the process inside WSL instead.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,6 +34,10 @@ URLs, or raw command content into tickets or shared logs.
 | `415 unsupported_media_type` | An MCP POST was not JSON. Use an MCP Streamable HTTP client. |
 | `429 rate_limited` | The process-local request window or active-request bound was exceeded. Wait for `Retry-After`; investigate stuck/parallel clients before restarting. |
 | Public `/healthz` works but `/readyz` is 503 | API is up but cannot reach the runner. Inspect the Compose runner health, internal network, and matching `RUNNER_TOKEN`. |
+| Local stdio: `--workspace path is not a directory` or `must be absolute` | Stdio mode requires an existing directory and an absolute path format (e.g. `/home/user/project` or `/path/to/repo`). Check the `--workspace` parameter. |
+| Local stdio: Windows platform notice | Local stdio v1 currently supports POSIX platforms (Linux and macOS) due to POSIX process-group semantics. On Windows, run the command within WSL (Windows Subsystem for Linux) or use Cloud Harness over Streamable HTTP. |
+| Local stdio: `workspace_open is unsupported in local stdio mode` | In local stdio mode, the workspace is already selected and pre-opened at startup. Do not call `workspace_open`; proceed directly to file, search, exec, session, or Git tools using the active workspace ID. |
+| Local stdio: `network Git operations are disabled` or `Git push operations are disabled` | In local mode, remote network fetch/pull and push are disabled by default. Pass `--git-network` to enable network fetch/pull, and `--git-push` to enable push. |
 
 The request policy is owned by
 [`apps/api/src/request-security.ts`](../apps/api/src/request-security.ts) and


### PR DESCRIPTION
## Summary

Updates both internal markdown documentation and the official docs-site to provide setup guides and troubleshooting playbooks for Local Stdio mode:

- **AI Client Setup Guides:** Added Local Stdio configuration options to `docs-site/ai-tools/cursor.md`, `docs-site/ai-tools/claude.md`, `docs-site/ai-tools/claude-code.md`, and `docs-site/ai-tools/codex.md`.
- **Troubleshooting Playbooks:** Added local stdio directory resolution, Windows platform guidance, and capability opt-in troubleshooting entries to `docs/troubleshooting.md` and `docs-site/troubleshooting.md`.
- **Validation:** Clean docs reference check, link check, docs build, and full verification suite.