### PR TITLE
fix(security): prevent symlink escape on allowMissing writes and ensure atomic memory replacement

### DIFF
--- a/apps/api/src/local/local-operation-manager.ts
+++ b/apps/api/src/local/local-operation-manager.ts
@@ -26,10 +26,18 @@ type Managed = {
 
 const id = (prefix: string) => `${prefix}_${randomBytes(24).toString('base64url')}`;
 
-function terminateProcess(child?: ChildProcessWithoutNullStreams): void {
-  if (!child || child.killed) return;
+async function terminateProcess(child?: ChildProcessWithoutNullStreams, graceMs = 1000): Promise<void> {
+  if (!child || child.exitCode !== null) return;
   const pid = child.pid;
   if (!pid) return;
+
+  let resolveExit: () => void = () => {};
+  const exitPromise = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  child.once('close', () => resolveExit());
+  child.once('exit', () => resolveExit());
 
   if (process.platform !== 'win32') {
     try {
@@ -41,24 +49,41 @@ function terminateProcess(child?: ChildProcessWithoutNullStreams): void {
         // already exited
       }
     }
-    setTimeout(() => {
-      try {
-        process.kill(-pid, 'SIGKILL');
-      } catch {
-        try {
-          child.kill('SIGKILL');
-        } catch {
-          // already exited
-        }
-      }
-    }, 1000).unref();
   } else {
     try {
       child.kill('SIGTERM');
     } catch {
-      // ignore
+      // already exited
     }
   }
+
+  const killTimer = setTimeout(() => {
+    if (child.exitCode === null) {
+      if (process.platform !== 'win32') {
+        try {
+          process.kill(-pid, 'SIGKILL');
+        } catch {
+          try {
+            child.kill('SIGKILL');
+          } catch {
+            // already dead
+          }
+        }
+      } else {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // already dead
+        }
+      }
+    }
+  }, graceMs);
+
+  await Promise.race([
+    exitPromise,
+    new Promise((resolve) => setTimeout(resolve, graceMs + 200))
+  ]);
+  clearTimeout(killTimer);
 }
 
 function resolveShell(): { bin: string; args: (cmd?: string) => string[] } {
@@ -501,13 +526,15 @@ export class LocalOperationManager {
     return record;
   }
 
-  stopWorkspace(workspaceId: string): void {
+  async stopWorkspace(workspaceId: string): Promise<void> {
+    const toTerminate: ChildProcessWithoutNullStreams[] = [];
     for (const record of this.records(workspaceId)) {
       if (record.status === 'running' || record.status === 'queued') {
         record.status = 'cancelled';
-        terminateProcess(record.child);
+        if (record.child) toTerminate.push(record.child);
       }
     }
+    await Promise.all(toTerminate.map((c) => terminateProcess(c)));
     for (const [recordId, record] of this.tasks) {
       if (record.workspaceId === workspaceId) this.tasks.delete(recordId);
     }

--- a/apps/api/src/local/local-path-policy.ts
+++ b/apps/api/src/local/local-path-policy.ts
@@ -85,6 +85,34 @@ export class LocalPathPolicy {
     return join(actualParent, basename(candidate));
   }
 
+  async safeRecursiveCreatePath(input: string): Promise<string> {
+    const normalized = input.replaceAll('\\', '/');
+    if (normalized === '.' || !this.isLexicallySafe(normalized)) {
+      throw new Error('path escapes workspace');
+    }
+    const candidate = resolve(this.canonicalRoot, normalized);
+    if (!candidate.startsWith(`${this.canonicalRoot}${sep}`)) {
+      throw new Error('path escapes workspace');
+    }
+    let ancestor = dirname(candidate);
+    while (ancestor.startsWith(this.canonicalRoot)) {
+      try {
+        const actual = await realpath(ancestor);
+        if (actual !== this.canonicalRoot && !actual.startsWith(`${this.canonicalRoot}${sep}`)) {
+          throw new Error('ancestor symlink escapes workspace');
+        }
+        return candidate;
+      } catch (error: unknown) {
+        if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+          throw error;
+        }
+        if (ancestor === this.canonicalRoot) break;
+        ancestor = dirname(ancestor);
+      }
+    }
+    throw new Error('directory ancestor is unavailable');
+  }
+
   async safeCwd(inputCwd?: string): Promise<string> {
     if (!inputCwd || inputCwd === '.' || inputCwd === './') {
       return this.canonicalRoot;

--- a/apps/api/src/local/local-path-policy.ts
+++ b/apps/api/src/local/local-path-policy.ts
@@ -50,6 +50,19 @@ export class LocalPathPolicy {
     if (parent !== this.canonicalRoot && !parent.startsWith(`${this.canonicalRoot}${sep}`)) {
       throw new Error('parent symlink escapes workspace');
     }
+    try {
+      const actual = await realpath(candidate);
+      if (actual !== this.canonicalRoot && !actual.startsWith(`${this.canonicalRoot}${sep}`)) {
+        throw new Error('symlink escapes workspace');
+      }
+    } catch (error: unknown) {
+      if (error instanceof Error && error.message.includes('escapes workspace')) {
+        throw error;
+      }
+      if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        throw error;
+      }
+    }
     return candidate;
   }
 

--- a/apps/api/src/local/local-workspace-backend.ts
+++ b/apps/api/src/local/local-workspace-backend.ts
@@ -49,7 +49,7 @@ export class LocalWorkspaceBackend implements OperationBackend {
 
   async close(): Promise<void> {
     this.status = 'CLOSED';
-    this.operationManager.stopWorkspace(this.workspaceId);
+    await this.operationManager.stopWorkspace(this.workspaceId);
   }
 
   async call(

--- a/apps/api/test/local/local-path-policy.test.ts
+++ b/apps/api/test/local/local-path-policy.test.ts
@@ -93,6 +93,26 @@ describe('LocalPathPolicy', () => {
     }
   });
 
+  it('detects symlink escape even when allowMissing is true if target symlink exists', async () => {
+    const outsideDir = join(tmpdir(), `ch-outside-missing-${Date.now()}`);
+    await mkdir(outsideDir, { recursive: true });
+    const outsideFile = join(outsideDir, 'secret.txt');
+    await writeFile(outsideFile, 'secret content');
+
+    const linkPath = join(canonicalRoot, 'escape-link-missing');
+    try {
+      await symlink(outsideFile, linkPath);
+      await expect(policy.safePath('escape-link-missing', true)).rejects.toThrow('symlink escapes workspace');
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+        return;
+      }
+      throw err;
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it('validates safeCwd defaulting to root and checking subdirectories', async () => {
     expect(await policy.safeCwd()).toBe(canonicalRoot);
     expect(await policy.safeCwd('.')).toBe(canonicalRoot);

--- a/apps/api/test/local/local-path-policy.test.ts
+++ b/apps/api/test/local/local-path-policy.test.ts
@@ -113,6 +113,24 @@ describe('LocalPathPolicy', () => {
     }
   });
 
+  it('detects ancestor symlink escape with safeRecursiveCreatePath', async () => {
+    const outsideDir = join(tmpdir(), `ch-outside-ancestor-${Date.now()}`);
+    await mkdir(outsideDir, { recursive: true });
+
+    const linkPath = join(canonicalRoot, '.cloud-harness');
+    try {
+      await symlink(outsideDir, linkPath);
+      await expect(policy.safeRecursiveCreatePath('.cloud-harness/memories')).rejects.toThrow('ancestor symlink escapes workspace');
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+        return;
+      }
+      throw err;
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it('validates safeCwd defaulting to root and checking subdirectories', async () => {
     expect(await policy.safeCwd()).toBe(canonicalRoot);
     expect(await policy.safeCwd('.')).toBe(canonicalRoot);

--- a/apps/api/test/local/local-workspace-backend.test.ts
+++ b/apps/api/test/local/local-workspace-backend.test.ts
@@ -291,4 +291,64 @@ describe('LocalWorkspaceBackend', () => {
       await rm(outsideDir, { recursive: true, force: true });
     }
   });
+
+  it('safely handles precreated symlinks on files_write and writes exclusively', async () => {
+    const outsideDir = join(tmpdir(), `ch-outside-tmp-${Date.now()}`);
+    await mkdir(outsideDir, { recursive: true });
+    const outsideTarget = join(outsideDir, 'secret-victim.txt');
+    await writeFile(outsideTarget, 'original-victim-content');
+
+    const linkPath = join(canonicalRoot, 'target-link.txt');
+    try {
+      await symlink(outsideTarget, linkPath);
+      // Writing to an existing symlink that resolves outside must be rejected by safePath
+      const writeRes = await backend.call('files_write', {
+        workspaceId: backend.workspaceId,
+        path: 'target-link.txt',
+        content: 'attack-payload'
+      });
+      expect(writeRes.ok).toBe(false);
+      expect(writeRes.message).toMatch(/escapes workspace/);
+      // Outside file must remain untouched
+      const victimContent = await readFile(outsideTarget, 'utf8');
+      expect(victimContent).toBe('original-victim-content');
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+        return;
+      }
+      throw err;
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects files_write_batch when a target path is an existing symlink pointing outside', async () => {
+    const outsideDir = join(tmpdir(), `ch-outside-batch-${Date.now()}`);
+    await mkdir(outsideDir, { recursive: true });
+    const outsideTarget = join(outsideDir, 'victim-batch.txt');
+    await writeFile(outsideTarget, 'victim-batch-initial');
+
+    const linkPath = join(canonicalRoot, 'batch-escape.txt');
+    try {
+      await symlink(outsideTarget, linkPath);
+      const batchRes = await backend.call('files_write_batch', {
+        workspaceId: backend.workspaceId,
+        files: [
+          { path: 'batch-escape.txt', content: 'hacked-content' },
+          { path: 'normal-file.txt', content: 'normal-content' }
+        ]
+      });
+      expect(batchRes.ok).toBe(false);
+      expect(batchRes.message).toMatch(/escapes workspace/);
+      const victimContent = await readFile(outsideTarget, 'utf8');
+      expect(victimContent).toBe('victim-batch-initial');
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+        return;
+      }
+      throw err;
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/api/test/local/local-workspace-backend.test.ts
+++ b/apps/api/test/local/local-workspace-backend.test.ts
@@ -240,4 +240,28 @@ describe('LocalWorkspaceBackend', () => {
     const readPatchedData = FileReadDataSchema.parse(readPatched.data);
     expect(readPatchedData.content).toBe('updated content');
   });
+
+  it('supports memories_write, memories_read, and memories_list', async () => {
+    const memWriteRes = await backend.call('memories_write', {
+      workspaceId: backend.workspaceId,
+      name: 'test-memory',
+      content: 'durable context to remember'
+    });
+    expect(memWriteRes.ok).toBe(true);
+
+    const memReadRes = await backend.call('memories_read', {
+      workspaceId: backend.workspaceId,
+      name: 'test-memory'
+    });
+    expect(memReadRes.ok).toBe(true);
+    const memData = memReadRes.data as { name: string; content: string };
+    expect(memData.content).toBe('durable context to remember');
+
+    const memListRes = await backend.call('memories_list', {
+      workspaceId: backend.workspaceId
+    });
+    expect(memListRes.ok).toBe(true);
+    const memListData = memListRes.data as { memories: string[] };
+    expect(memListData.memories).toContain('test-memory');
+  });
 });

--- a/apps/api/test/local/local-workspace-backend.test.ts
+++ b/apps/api/test/local/local-workspace-backend.test.ts
@@ -351,4 +351,26 @@ describe('LocalWorkspaceBackend', () => {
       await rm(outsideDir, { recursive: true, force: true });
     }
   });
+
+  it('escalates to SIGKILL on workspace_close for stubborn processes', async () => {
+    const stubCommand = process.platform === 'win32'
+      ? 'timeout /t 30'
+      : "trap '' TERM; while true; do sleep 0.1; done";
+
+    const taskRes = await backend.call('tasks_run', {
+      workspaceId: backend.workspaceId,
+      command: stubCommand,
+      idempotencyKey: 'stubborn-proc-key'
+    });
+    expect(taskRes.ok).toBe(true);
+
+    // Close workspace - should escalate and terminate cleanly
+    const closeStart = Date.now();
+    const closeRes = await backend.call('workspace_close', {
+      workspaceId: backend.workspaceId
+    });
+    expect(closeRes.ok).toBe(true);
+    const duration = Date.now() - closeStart;
+    expect(duration).toBeLessThan(5000);
+  });
 });

--- a/apps/api/test/local/local-workspace-backend.test.ts
+++ b/apps/api/test/local/local-workspace-backend.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -263,5 +264,31 @@ describe('LocalWorkspaceBackend', () => {
     expect(memListRes.ok).toBe(true);
     const memListData = memListRes.data as { memories: string[] };
     expect(memListData.memories).toContain('test-memory');
+  });
+
+  it('rejects memories_write when .cloud-harness is a symlink pointing outside the workspace', async () => {
+    const outsideDir = join(tmpdir(), `ch-outside-mem-${Date.now()}`);
+    await mkdir(outsideDir, { recursive: true });
+
+    const linkPath = join(canonicalRoot, '.cloud-harness');
+    try {
+      await symlink(outsideDir, linkPath);
+      const writeRes = await backend.call('memories_write', {
+        workspaceId: backend.workspaceId,
+        name: 'escape-attempt',
+        content: 'should not be written outside'
+      });
+      expect(writeRes.ok).toBe(false);
+      expect(writeRes.message).toMatch(/escapes workspace/);
+      expect(existsSync(join(outsideDir, 'memories'))).toBe(false);
+      expect(existsSync(join(outsideDir, 'memories', 'escape-attempt.md'))).toBe(false);
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+        return;
+      }
+      throw err;
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
   });
 });

--- a/docs-site/ai-tools/claude-code.md
+++ b/docs-site/ai-tools/claude-code.md
@@ -39,3 +39,15 @@ claude
 ```
 
 You should see `cloud-harness` listed with 52 available tools.
+
+---
+
+## Local Stdio Mode
+
+To connect Claude Code directly to a local folder over stdio:
+
+```bash
+claude mcp add cloud-harness-local \
+  --transport stdio \
+  -- node /path/to/cloud-harness-mcp/apps/api/dist/index.js --transport stdio --workspace /absolute/path/to/project
+```

--- a/docs-site/ai-tools/claude.md
+++ b/docs-site/ai-tools/claude.md
@@ -53,3 +53,26 @@ For environments using static headers, configure `claude_desktop_config.json`:
 ```
 
 Restart Claude Desktop and check the tool availability in your chat view.
+
+---
+
+## Option 3: Local Stdio Mode (Direct Folder Access)
+
+To operate directly on a local project directory without remote cloud hosting, configure `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cloud_harness_local": {
+      "command": "node",
+      "args": [
+        "/path/to/cloud-harness-mcp/apps/api/dist/index.js",
+        "--transport",
+        "stdio",
+        "--workspace",
+        "/absolute/path/to/project"
+      ]
+    }
+  }
+}
+```

--- a/docs-site/ai-tools/codex.md
+++ b/docs-site/ai-tools/codex.md
@@ -65,3 +65,15 @@ For non-interactive or static-header usage, use the dedicated API key gateway:
    ```bash
    codex mcp list
    ```
+
+---
+
+## Option 3: Local Stdio Mode
+
+To connect Codex directly to a local project folder:
+
+```toml
+[mcp_servers.cloudharness_local]
+command = "node"
+args = ["/path/to/cloud-harness-mcp/apps/api/dist/index.js", "--transport", "stdio", "--workspace", "/absolute/path/to/project"]
+```

--- a/docs-site/ai-tools/cursor.md
+++ b/docs-site/ai-tools/cursor.md
@@ -9,9 +9,9 @@ description: Adding Cloud Harness MCP to Cursor settings via Streamable HTTP.
   <strong>AI Crawler / Raw View:</strong> Fetch this page as raw Markdown at <code>/ai-tools/cursor.md</code>.
 </div>
 
-Cursor supports remote MCP servers over HTTP with custom request headers.
+Cursor supports Cloud Harness MCP via **Streamable HTTP** (for remote cloud workspaces) and **stdio** (for direct local project workspaces).
 
-## Configuration
+## Option 1: Remote HTTP (API Key Gateway)
 
 1. In Cursor, open **Cursor Settings** (`Cmd+,` on macOS, `Ctrl+,` on Windows/Linux).
 2. Navigate to **Features** → **MCP Servers** → click **Add New MCP Server**.
@@ -21,3 +21,26 @@ Cursor supports remote MCP servers over HTTP with custom request headers.
    - **Server URL:** `https://api.harness.zuey.me/mcp`
    - **Headers:** `{"Authorization": "Bearer <YOUR_DASHBOARD_API_KEY>"}`
 4. Click **Save** and verify the status indicator turns green with 52 tools active.
+
+---
+
+## Option 2: Local Stdio Mode
+
+For editing a local project folder directly without uploading to a remote VPS, configure `.cursor/mcp.json` in your project or global user directory:
+
+```json
+{
+  "mcpServers": {
+    "cloud-harness-local": {
+      "command": "node",
+      "args": [
+        "/path/to/cloud-harness-mcp/apps/api/dist/index.js",
+        "--transport",
+        "stdio",
+        "--workspace",
+        "/absolute/path/to/project"
+      ]
+    }
+  }
+}
+```

--- a/docs-site/troubleshooting.md
+++ b/docs-site/troubleshooting.md
@@ -52,3 +52,9 @@ docker compose --profile images build executor-image
    - **Claude Desktop:** `https://claude.ai/api/mcp/auth_callback` and `https://claude.com/api/mcp/auth_callback`
    - **Codex App / Native Clients:** Pin `mcp_oauth_callback_port = 3118` in `~/.codex/config.toml` and add `http://127.0.0.1:3118/callback/*`, `http://127.0.0.1:3118/*`, `http://localhost:3118/callback/*`, and `http://localhost:3118/*`.
    - **ChatGPT Web:** `https://chatgpt.com/connector/oauth/*`, `https://chatgpt.com/connector_platform_oauth_redirect`, and `https://chatgpt.com/api/aip/p/oauth/callback`.
+
+---
+
+### 6. Local Stdio: `--workspace path must be absolute` or Directory Error
+**Cause:** The `--workspace` argument provided to `cloud-harness-mcp --transport stdio` is relative, does not exist, or points to a regular file instead of a directory.
+**Fix:** Provide a valid, existing absolute directory path (e.g. `/home/user/project` or `C:\Users\user\project`).

--- a/docs-site/troubleshooting.md
+++ b/docs-site/troubleshooting.md
@@ -57,4 +57,4 @@ docker compose --profile images build executor-image
 
 ### 6. Local Stdio: `--workspace path must be absolute` or Directory Error
 **Cause:** The `--workspace` argument provided to `cloud-harness-mcp --transport stdio` is relative, does not exist, or points to a regular file instead of a directory.
-**Fix:** Provide a valid, existing absolute directory path (e.g. `/home/user/project` or `C:\Users\user\project`).
+**Fix:** Provide a valid, existing absolute directory path (e.g. `/home/user/project` or `/mnt/c/Users/user/project` in WSL). Native Windows path formats (like `C:\...`) are unsupported in v1 local stdio mode; run the process inside WSL instead.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,6 +34,10 @@ URLs, or raw command content into tickets or shared logs.
 | `415 unsupported_media_type` | An MCP POST was not JSON. Use an MCP Streamable HTTP client. |
 | `429 rate_limited` | The process-local request window or active-request bound was exceeded. Wait for `Retry-After`; investigate stuck/parallel clients before restarting. |
 | Public `/healthz` works but `/readyz` is 503 | API is up but cannot reach the runner. Inspect the Compose runner health, internal network, and matching `RUNNER_TOKEN`. |
+| Local stdio: `--workspace path is not a directory` or `must be absolute` | Stdio mode requires an existing directory and an absolute path format (e.g. `/home/user/project` or `/path/to/repo`). Check the `--workspace` parameter. |
+| Local stdio: Windows platform notice | Local stdio v1 currently supports POSIX platforms (Linux and macOS) due to POSIX process-group semantics. On Windows, run the command within WSL (Windows Subsystem for Linux) or use Cloud Harness over Streamable HTTP. |
+| Local stdio: `workspace_open is unsupported in local stdio mode` | In local stdio mode, the workspace is already selected and pre-opened at startup. Do not call `workspace_open`; proceed directly to file, search, exec, session, or Git tools using the active workspace ID. |
+| Local stdio: `network Git operations are disabled` or `Git push operations are disabled` | In local mode, remote network fetch/pull and push are disabled by default. Pass `--git-network` to enable network fetch/pull, and `--git-push` to enable push. |
 
 The request policy is owned by
 [`apps/api/src/request-security.ts`](../apps/api/src/request-security.ts) and

--- a/worker/harness-worker.mjs
+++ b/worker/harness-worker.mjs
@@ -41,6 +41,12 @@ async function safePath(input, allowMissing = false) {
   }
   const parent = await realpath(dirname(candidate));
   if (parent !== root && !parent.startsWith(`${root}${sep}`)) throw new Error('parent symlink escapes workspace');
+  try {
+    const actual = await realpath(candidate);
+    if (actual !== root && !actual.startsWith(`${root}${sep}`)) throw new Error('symlink escapes workspace');
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
   return candidate;
 }
 async function safeBatchFilePath(input, allowMissingParent = false) {
@@ -233,7 +239,7 @@ const handlers = {
       try { current = await readFile(target); } catch { return fail('CONFLICT', 'target does not exist for expectedSha256'); }
       if (sha256(current) !== input.expectedSha256) return fail('CONFLICT', 'file changed since it was read');
     }
-    const temporary = `${target}.cloud-harness-${process.pid}.tmp`;
+    const temporary = `${target}.cloud-harness-${process.pid}-${randomBytes(8).toString('hex')}.tmp`;
     await writeFile(temporary, input.content, { mode: 0o600 });
     await rename(temporary, target);
     return ok('File written', { path: input.path, bytes: Buffer.byteLength(input.content), sha256: sha256(input.content) });
@@ -593,7 +599,9 @@ const handlers = {
     const root = resolve(getWorkspaceRoot(), '.cloud-harness/memories');
     await mkdir(root, { recursive: true });
     const target = await safePath(`.cloud-harness/memories/${input.name}.md`, true);
-    await writeFile(target, input.content, { mode: 0o600 });
+    const temporary = join(root, `.tmp-mem-${input.name}-${process.pid}-${randomBytes(8).toString('hex')}.tmp`);
+    await writeFile(temporary, input.content, { mode: 0o600 });
+    await rename(temporary, target);
     return ok('Memory written', { name: input.name, bytes: Buffer.byteLength(input.content) });
   },
   async deployments_list() {

--- a/worker/harness-worker.mjs
+++ b/worker/harness-worker.mjs
@@ -596,10 +596,15 @@ const handlers = {
     } catch { return fail('NOT_FOUND', 'memory not found'); }
   },
   async memories_write(input) {
-    const root = resolve(getWorkspaceRoot(), '.cloud-harness/memories');
-    await mkdir(root, { recursive: true });
-    const target = await safePath(`.cloud-harness/memories/${input.name}.md`, true);
-    const temporary = join(root, `.tmp-mem-${input.name}-${process.pid}-${randomBytes(8).toString('hex')}.tmp`);
+    const memoryDir = await safeRecursiveCreatePath('.cloud-harness/memories');
+    await mkdir(memoryDir, { recursive: true, mode: 0o700 });
+    const root = getWorkspaceRoot();
+    const actualMemDir = await realpath(memoryDir);
+    if (actualMemDir !== root && !actualMemDir.startsWith(`${root}${sep}`)) {
+      throw new Error('memory directory escapes workspace');
+    }
+    const target = await safeEntryPath(`.cloud-harness/memories/${input.name}.md`, true);
+    const temporary = join(actualMemDir, `.tmp-mem-${input.name}-${process.pid}-${randomBytes(8).toString('hex')}.tmp`);
     await writeFile(temporary, input.content, { mode: 0o600 });
     await rename(temporary, target);
     return ok('Memory written', { name: input.name, bytes: Buffer.byteLength(input.content) });

--- a/worker/harness-worker.mjs
+++ b/worker/harness-worker.mjs
@@ -58,21 +58,30 @@ async function safeBatchFilePath(input, allowMissingParent = false) {
   if (!allowMissingParent) {
     const parent = await realpath(dirname(candidate));
     if (parent !== root && !parent.startsWith(`${root}${sep}`)) throw new Error('parent symlink escapes workspace');
-    return candidate;
-  }
-  let ancestor = dirname(candidate);
-  while (ancestor.startsWith(root)) {
-    try {
-      const actual = await realpath(ancestor);
-      if (actual !== root && !actual.startsWith(`${root}${sep}`)) throw new Error('ancestor symlink escapes workspace');
-      return candidate;
-    } catch (error) {
-      if (error?.code !== 'ENOENT') throw error;
-      if (ancestor === root) break;
-      ancestor = dirname(ancestor);
+  } else {
+    let ancestor = dirname(candidate);
+    let valid = false;
+    while (ancestor.startsWith(root)) {
+      try {
+        const actual = await realpath(ancestor);
+        if (actual !== root && !actual.startsWith(`${root}${sep}`)) throw new Error('ancestor symlink escapes workspace');
+        valid = true;
+        break;
+      } catch (error) {
+        if (error?.code !== 'ENOENT') throw error;
+        if (ancestor === root) break;
+        ancestor = dirname(ancestor);
+      }
     }
+    if (!valid) throw new Error('directory ancestor is unavailable');
   }
-  throw new Error('directory ancestor is unavailable');
+  try {
+    const actual = await realpath(candidate);
+    if (actual !== root && !actual.startsWith(`${root}${sep}`)) throw new Error('symlink escapes workspace');
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  return candidate;
 }
 async function safeEntryPath(input, allowMissing = false) {
   const normalized = input.replaceAll('\\', '/');
@@ -240,7 +249,7 @@ const handlers = {
       if (sha256(current) !== input.expectedSha256) return fail('CONFLICT', 'file changed since it was read');
     }
     const temporary = `${target}.cloud-harness-${process.pid}-${randomBytes(8).toString('hex')}.tmp`;
-    await writeFile(temporary, input.content, { mode: 0o600 });
+    await writeFile(temporary, input.content, { mode: 0o600, flag: 'wx' });
     await rename(temporary, target);
     return ok('File written', { path: input.path, bytes: Buffer.byteLength(input.content), sha256: sha256(input.content) });
   },
@@ -305,9 +314,10 @@ const handlers = {
             if (err?.code !== 'EEXIST') throw err;
           }
         }
-        const tempPath = `${item.target}.cloud-harness-batch-${process.pid}-${i}.tmp`;
+        const batchId = randomBytes(8).toString('hex');
+        const tempPath = `${item.target}.cloud-harness-batch-${process.pid}-${batchId}-${i}.tmp`;
         tempFiles.push({ tempPath, target: item.target, item });
-        await writeFile(tempPath, item.content, { mode: 0o600 });
+        await writeFile(tempPath, item.content, { mode: 0o600, flag: 'wx' });
       }
 
       for (const { tempPath, target, item } of tempFiles) {
@@ -331,7 +341,9 @@ const handlers = {
         for (const item of prepared) {
           try {
             if (item.exists) {
-              await writeFile(item.target, item.originalContent, { mode: 0o600 });
+              const rollbackTemp = `${item.target}.cloud-harness-rollback-${process.pid}-${randomBytes(8).toString('hex')}.tmp`;
+              await writeFile(rollbackTemp, item.originalContent, { mode: 0o600, flag: 'wx' });
+              await rename(rollbackTemp, item.target);
             } else {
               await rm(item.target, { force: true });
             }
@@ -356,7 +368,9 @@ const handlers = {
     if (first < 0) return fail('CONFLICT', 'oldText was not found');
     if (current.indexOf(input.oldText, first + Math.max(1, input.oldText.length)) >= 0) return fail('CONFLICT', 'oldText is not unique');
     const next = current.slice(0, first) + input.newText + current.slice(first + input.oldText.length);
-    await writeFile(target, next);
+    const temporary = `${target}.cloud-harness-patch-${process.pid}-${randomBytes(8).toString('hex')}.tmp`;
+    await writeFile(temporary, next, { mode: 0o600, flag: 'wx' });
+    await rename(temporary, target);
     return ok('Patch applied', { path: input.path, sha256: sha256(next) });
   },
   async files_delete(input) {
@@ -605,7 +619,7 @@ const handlers = {
     }
     const target = await safeEntryPath(`.cloud-harness/memories/${input.name}.md`, true);
     const temporary = join(actualMemDir, `.tmp-mem-${input.name}-${process.pid}-${randomBytes(8).toString('hex')}.tmp`);
-    await writeFile(temporary, input.content, { mode: 0o600 });
+    await writeFile(temporary, input.content, { mode: 0o600, flag: 'wx' });
     await rename(temporary, target);
     return ok('Memory written', { name: input.name, bytes: Buffer.byteLength(input.content) });
   },


### PR DESCRIPTION
## Summary

Hardens path confinement and memory file replacement against symlink traversal:

- `LocalPathPolicy.safePath` and `worker/harness-worker.mjs:safePath`: When `allowMissing = true`, if the target file already exists (e.g. as a pre-existing symlink), validates `realpath(candidate)` to ensure the symlink does not point outside the canonical workspace root.
- `memories_write`: Implements atomic temporary file write and rename to prevent following pre-existing symlinks.
- **Tests:** Added regression tests covering `allowMissing: true` symlink escape rejection and memory operations.