### PR TITLE
feat(runner): add brokered GitHub issues and pull request operations (#105)

### DIFF
--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -942,7 +942,7 @@ export class WorkspaceService {
     args: string[],
     signal?: AbortSignal
   ): Promise<RunnerResponse> {
-    const isWrite = ['pr_create', 'issue_create', 'issue_comment', 'issue_comment_update', 'label_create', 'issue_labels_add', 'issue_labels_remove', 'issue_update', 'issue_publish'].includes(action);
+    const isWrite = ['pr_create', 'pr_update', 'pr_comment', 'issue_create', 'issue_comment', 'issue_comment_update', 'label_create', 'issue_labels_add', 'issue_labels_remove', 'issue_update', 'issue_publish'].includes(action);
     const permissionScope = action.startsWith('pr_') ? 'pull_requests' : 'issues';
 
     const token = await mintPrincipalRepositoryScopedToken({
@@ -1471,10 +1471,30 @@ export class WorkspaceService {
       switch (action) {
         case 'pr_list': args = [String(validated.limit ?? 20), (validated.state as string) ?? 'open']; break;
         case 'pr_view': args = [String(validated.prNumber)]; break;
-        case 'pr_create': args = [validated.title as string, (validated.body as string) ?? '', validated.head as string, (validated.base as string) ?? 'main']; break;
+        case 'pr_create': args = [
+          validated.title as string,
+          (validated.body as string) ?? '',
+          validated.head as string,
+          (validated.base as string) ?? 'main',
+          String(validated.draft ?? false),
+          ((validated.labels as string[]) ?? []).join(',')
+        ]; break;
+        case 'pr_update': args = [
+          String(validated.prNumber),
+          (validated.title as string) ?? '',
+          (validated.body as string) ?? '',
+          (validated.base as string) ?? '',
+          (validated.state as string) ?? ''
+        ]; break;
+        case 'pr_comment': args = [String(validated.prNumber), validated.body as string]; break;
         case 'issue_list': args = [String(validated.limit ?? 20), (validated.state as string) ?? 'open']; break;
         case 'issue_view': args = [String(validated.issueNumber)]; break;
-        case 'issue_create': args = [validated.title as string, (validated.body as string) ?? '']; break;
+        case 'issue_create': args = [
+          validated.title as string,
+          (validated.body as string) ?? '',
+          ((validated.labels as string[]) ?? []).join(','),
+          ((validated.assignees as string[]) ?? []).join(',')
+        ]; break;
         case 'issue_comment': args = [String(validated.issueNumber), validated.body as string]; break;
         case 'issue_comment_update': args = [String(validated.commentId), validated.body as string]; break;
         case 'label_create': args = [validated.name as string, (validated.color as string) ?? '0E8A16', (validated.description as string) ?? '']; break;
@@ -1490,7 +1510,7 @@ export class WorkspaceService {
         ]; break;
       }
       const result = await this.runBrokeredGitHubAction(record, action, args, signal);
-      if ((action === 'issue_comment' || action === 'issue_labels_add' || action === 'issue_publish') && validated.idempotencyKey && result.ok) {
+      if ((action === 'pr_comment' || action === 'issue_comment' || action === 'issue_labels_add' || action === 'issue_publish') && validated.idempotencyKey && result.ok) {
         this.store.setCommentIdempotency(ownerId, validated.idempotencyKey as string, JSON.stringify(result), fingerprint);
       }
       await this.enforceActiveLimits(record);
@@ -1870,7 +1890,7 @@ function isMutationOperation(operation: RunnerOperation, validated: Record<strin
   }
   if (operation === 'github_action') {
     const action = validated.action as string;
-    return ['pr_create', 'issue_create', 'issue_comment', 'issue_comment_update', 'label_create', 'issue_labels_add', 'issue_labels_remove', 'issue_update', 'issue_publish'].includes(action);
+    return ['pr_create', 'pr_update', 'pr_comment', 'issue_create', 'issue_comment', 'issue_comment_update', 'label_create', 'issue_labels_add', 'issue_labels_remove', 'issue_update', 'issue_publish'].includes(action);
   }
   return false;
 }

--- a/apps/runner/test/brokered-github-operations.test.ts
+++ b/apps/runner/test/brokered-github-operations.test.ts
@@ -1,0 +1,303 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { RunnerConfig } from '@cloud-harness/contracts';
+import { InMemoryGitHubInstallationStore } from '../src/github-installation-store.js';
+import { StateStore, type WorkspaceRecord } from '../src/state-store.js';
+
+const docker = vi.hoisted(() => ({
+  runDocker: vi.fn(async (args: string[]) => {
+    if (args.includes('/opt/harness/gh-helper.sh')) {
+      const action = args[args.indexOf('/opt/harness/gh-helper.sh') + 2];
+      return {
+        stdout: JSON.stringify({ action, ok: true, output: `result-of-${action}` }),
+        stderr: '',
+        exitCode: 0,
+        truncated: false
+      };
+    }
+    return { stdout: '', stderr: '', exitCode: 0, truncated: false };
+  }),
+  removeContainer: vi.fn(async () => undefined),
+  inspectContainer: vi.fn(async () => undefined),
+  terminateContainerProcessGroup: vi.fn(async () => undefined)
+}));
+
+const broker = vi.hoisted(() => ({
+  mintRepositoryToken: vi.fn(async () => undefined),
+  mintPrincipalRepositoryToken: vi.fn(),
+  mintPrincipalRepositoryScopedToken: vi.fn()
+}));
+
+vi.mock('../src/docker-engine.js', () => docker);
+vi.mock('../src/github-app-broker.js', () => broker);
+vi.mock('../src/repository-policy.js', () => ({ validateRepositoryUrl: vi.fn(async (value: string) => new URL(value)) }));
+
+import { WorkspaceService } from '../src/workspace-service.js';
+const temporaryDirectories: string[] = [];
+const openStores: StateStore[] = [];
+afterEach(() => {
+  vi.clearAllMocks();
+  for (const store of openStores.splice(0)) store.close();
+  for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function fixture() {
+  const directory = mkdtempSync(join(tmpdir(), 'cloud-harness-gh-ops-'));
+  temporaryDirectories.push(directory);
+  const workspaceId = `ws_${'c'.repeat(24)}`;
+  const workspacePath = join(directory, 'jobs', workspaceId);
+  mkdirSync(join(workspacePath, 'repo'), { recursive: true });
+
+  const config = {
+    authMode: 'cloudflare-access',
+    host: '127.0.0.1', port: 3001, serviceToken: 'runner-token-that-is-longer-than-32-characters',
+    jobsRoot: join(directory, 'jobs'), stateDb: join(directory, 'state.db'), executorImage: 'executor',
+    allowedGitHosts: ['github.com'], networkMode: 'none', wallTtlSeconds: 300, idleTtlSeconds: 180,
+    maxOutputBytes: 262_144, minFreeBytes: 0, maxWorkspaceBytes: 1_048_576, reaperIntervalSeconds: 30,
+    githubApp: {
+      appId: 123,
+      privateKey: '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----',
+      appSlug: 'cloud-harness-test'
+    }
+  } as RunnerConfig;
+
+  const store = new StateStore(config.stateDb);
+  openStores.push(store);
+  const principalSelector = { kind: 'external' as const, issuer: 'https://access.example.com', subject: 'user-github-ops' };
+  const principalId = store.resolveExternalPrincipal(principalSelector);
+
+  const installations = new InMemoryGitHubInstallationStore();
+  installations.replaceVerified(principalId, {
+    appId: 123,
+    installationId: 888,
+    accountId: 789,
+    accountLogin: 'bestagentkits',
+    status: 'active',
+    repositories: [{ owner: 'bestagentkits', repository: 'cloud-harness-mcp', contents: 'write' }]
+  }, 1_000);
+
+  const now = Date.now();
+  const record: WorkspaceRecord = {
+    id: workspaceId,
+    ownerId: principalId,
+    idempotencyKey: 'gh-ops-test',
+    repositoryUrl: 'https://github.com/bestagentkits/cloud-harness-mcp.git',
+    repositoryRef: null,
+    containerName: 'executor-container',
+    workspacePath,
+    status: 'ACTIVE',
+    networkMode: 'none',
+    createdAt: now,
+    lastActivityAt: now,
+    expiresAt: now + 60_000,
+    generation: 1,
+    error: null
+  };
+  store.create(record);
+
+  return { config, store, installations, record, workspaceId, principalId, principalSelector };
+}
+
+describe('Brokered GitHub Issues and Pull Request Operations', () => {
+  it('executes pr_create with draft flag and labels using pull_requests:write token scope', async () => {
+    const { config, store, installations, workspaceId, principalSelector } = fixture();
+    const service = new WorkspaceService(config, store, undefined, installations);
+
+    broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce('pr-scoped-write-token');
+
+    const result = await service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_create',
+      title: 'feat: add brokered github ops',
+      body: 'PR body content',
+      head: 'feat/gh-ops',
+      base: 'main',
+      draft: true,
+      labels: ['enhancement', 'vibe']
+    });
+
+    expect(result.ok).toBe(true);
+    expect(broker.mintPrincipalRepositoryScopedToken).toHaveBeenCalledWith(expect.objectContaining({
+      permissionScope: 'pull_requests',
+      requiredPermission: 'write'
+    }));
+
+    const dockerCall = docker.runDocker.mock.calls.find(([args]) => args.includes('/opt/harness/gh-helper.sh'));
+    expect(dockerCall).toBeDefined();
+    const [args, opts] = dockerCall!;
+    expect(opts?.stdin).toBe('pr-scoped-write-token\n');
+    expect(args).toContain('pr_create');
+    expect(args).toContain('feat: add brokered github ops');
+    expect(args).toContain('PR body content');
+    expect(args).toContain('feat/gh-ops');
+    expect(args).toContain('main');
+    expect(args).toContain('true');
+    expect(args).toContain('enhancement,vibe');
+  });
+
+  it('executes pr_update with title, base, and state', async () => {
+    const { config, store, installations, workspaceId, principalSelector } = fixture();
+    const service = new WorkspaceService(config, store, undefined, installations);
+
+    broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce('pr-scoped-write-token');
+
+    const result = await service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_update',
+      prNumber: 42,
+      title: 'Updated title',
+      body: 'Updated body',
+      base: 'develop',
+      state: 'closed'
+    });
+
+    expect(result.ok).toBe(true);
+    expect(broker.mintPrincipalRepositoryScopedToken).toHaveBeenCalledWith(expect.objectContaining({
+      permissionScope: 'pull_requests',
+      requiredPermission: 'write'
+    }));
+
+    const dockerCall = docker.runDocker.mock.calls.find(([args]) => args.includes('/opt/harness/gh-helper.sh'));
+    const [args] = dockerCall!;
+    expect(args).toContain('pr_update');
+    expect(args).toContain('42');
+    expect(args).toContain('Updated title');
+    expect(args).toContain('Updated body');
+    expect(args).toContain('develop');
+    expect(args).toContain('closed');
+  });
+
+  it('executes pr_comment with idempotency key caching', async () => {
+    const { config, store, installations, workspaceId, principalSelector } = fixture();
+    const service = new WorkspaceService(config, store, undefined, installations);
+
+    broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce('pr-scoped-write-token');
+
+    const result1 = await service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_comment',
+      prNumber: 42,
+      body: 'Looks good to me!',
+      idempotencyKey: 'idem_pr_comment_1'
+    });
+
+    expect(result1.ok).toBe(true);
+
+    // Second call with same idempotency key and payload returns cached response without invoking docker
+    docker.runDocker.mockClear();
+    const result2 = await service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_comment',
+      prNumber: 42,
+      body: 'Looks good to me!',
+      idempotencyKey: 'idem_pr_comment_1'
+    });
+
+    expect(result2.ok).toBe(true);
+    const ghHelperCall = docker.runDocker.mock.calls.find(([args]) => args.includes('/opt/harness/gh-helper.sh'));
+    expect(ghHelperCall).toBeUndefined();
+
+    // Call with reused idempotency key but different body throws CONFLICT
+    await expect(service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_comment',
+      prNumber: 42,
+      body: 'Different body!',
+      idempotencyKey: 'idem_pr_comment_1'
+    })).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('executes pr_list and pr_view using pull_requests:read token scope', async () => {
+    const { config, store, installations, workspaceId, principalSelector } = fixture();
+    const service = new WorkspaceService(config, store, undefined, installations);
+
+    broker.mintPrincipalRepositoryScopedToken.mockResolvedValue('pr-scoped-read-token');
+
+    const listRes = await service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_list',
+      limit: 10,
+      state: 'open'
+    });
+    expect(listRes.ok).toBe(true);
+    expect(broker.mintPrincipalRepositoryScopedToken).toHaveBeenCalledWith(expect.objectContaining({
+      permissionScope: 'pull_requests',
+      requiredPermission: 'read'
+    }));
+
+    const viewRes = await service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_view',
+      prNumber: 15
+    });
+    expect(viewRes.ok).toBe(true);
+  });
+
+  it('executes issue_create with labels and assignees using issues:write token scope', async () => {
+    const { config, store, installations, workspaceId, principalSelector } = fixture();
+    const service = new WorkspaceService(config, store, undefined, installations);
+
+    broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce('issue-scoped-write-token');
+
+    const result = await service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'issue_create',
+      title: 'Bug: fix needed',
+      body: 'Detailed repro steps',
+      labels: ['bug', 'triage'],
+      assignees: ['octocat', 'coder']
+    });
+
+    expect(result.ok).toBe(true);
+    expect(broker.mintPrincipalRepositoryScopedToken).toHaveBeenCalledWith(expect.objectContaining({
+      permissionScope: 'issues',
+      requiredPermission: 'write'
+    }));
+
+    const dockerCall = docker.runDocker.mock.calls.find(([args]) => args.includes('/opt/harness/gh-helper.sh'));
+    const [args] = dockerCall!;
+    expect(args).toContain('issue_create');
+    expect(args).toContain('Bug: fix needed');
+    expect(args).toContain('Detailed repro steps');
+    expect(args).toContain('bug,triage');
+    expect(args).toContain('octocat,coder');
+  });
+
+  it('executes issue_update with stateReason mapped properly', async () => {
+    const { config, store, installations, workspaceId, principalSelector } = fixture();
+    const service = new WorkspaceService(config, store, undefined, installations);
+
+    broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce('issue-scoped-write-token');
+
+    const result = await service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'issue_update',
+      issueNumber: 99,
+      state: 'closed',
+      stateReason: 'not_planned'
+    });
+
+    expect(result.ok).toBe(true);
+    const dockerCall = docker.runDocker.mock.calls.find(([args]) => args.includes('/opt/harness/gh-helper.sh'));
+    const [args] = dockerCall!;
+    expect(args).toContain('issue_update');
+    expect(args).toContain('99');
+    expect(args).toContain('closed');
+    expect(args).toContain('not_planned');
+  });
+
+  it('throws FORBIDDEN when no GitHub App token can be minted for the workspace', async () => {
+    const { config, store, workspaceId, principalSelector } = fixture();
+    const emptyInstallations = new InMemoryGitHubInstallationStore();
+    const service = new WorkspaceService(config, store, undefined, emptyInstallations);
+
+    broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce(undefined);
+
+    await expect(service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_list'
+    })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+});

--- a/docs-site/reference/tools.md
+++ b/docs-site/reference/tools.md
@@ -667,7 +667,7 @@ Execute authenticated GitHub pull request and issue operations via brokered help
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `action` | `"pr_list"` \| `"pr_view"` \| `"pr_create"` \| `"issue_list"` \| `"issue_view"` \| `"issue_create"` \| `"issue_comment"` \| `"issue_comment_update"` \| `"label_create"` \| `"issue_labels_add"` \| `"issue_labels_remove"` \| `"issue_update"` \| `"issue_publish"` | **Yes** | — |
+| `action` | `"pr_list"` \| `"pr_view"` \| `"pr_create"` \| `"pr_update"` \| `"pr_comment"` \| `"issue_list"` \| `"issue_view"` \| `"issue_create"` \| `"issue_comment"` \| `"issue_comment_update"` \| `"label_create"` \| `"issue_labels_add"` \| `"issue_labels_remove"` \| `"issue_update"` \| `"issue_publish"` | **Yes** | — |
 | `limit` | `integer` | No | range: 1–100, default: `20` |
 | `state` | `"open"` \| `"closed"` \| `"all"` | No | — |
 | `prNumber` | `integer` | No | range: 0–9007199254740991 |
@@ -675,13 +675,15 @@ Execute authenticated GitHub pull request and issue operations via brokered help
 | `body` | `string` | No | max length: 65536, default: `""` |
 | `head` | `string` | No | length: 1–256 |
 | `base` | `string` | No | length: 1–256, default: `"main"` |
-| `issueNumber` | `integer` | No | range: 0–9007199254740991 |
+| `draft` | `boolean` | No | default: `false` |
+| `labels` | string[] | No | — |
 | `idempotencyKey` | `string` | No | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
+| `issueNumber` | `integer` | No | range: 0–9007199254740991 |
+| `assignees` | string[] | No | — |
 | `commentId` | `integer` | No | range: 0–9007199254740991 |
 | `name` | `string` | No | length: 1–100 |
 | `color` | `string` | No | pattern: `^[0-9A-Fa-f]{6}$` |
 | `description` | `string` | No | max length: 200 |
-| `labels` | string[] | No | — |
 | `createMissing` | `boolean` | No | default: `true` |
 | `label` | `string` | No | length: 1–100 |
 | `stateReason` | `"completed"` \| `"not_planned"` \| `"reopened"` | No | — |

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -76,10 +76,12 @@ workspace. This makes a lost response recoverable without duplicating work.
   runner terminates and verifies the operation's process groups; the workspace
   remains active for later calls.
 - `github_action` executes authenticated GitHub CLI actions (`pr_list`, `pr_view`,
-  `pr_create`, `issue_list`, `issue_view`, `issue_create`, `issue_comment`,
+  `pr_create`, `pr_update`, `pr_comment`, `issue_list`, `issue_view`, `issue_create`, `issue_comment`,
   `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`,
   `issue_update`, `issue_publish`) through an ephemeral helper container using short-lived tokens
-  minted from the configured GitHub App. `issue_publish` provides a single brokered request
+  minted from the configured GitHub App. `pr_create` supports draft PRs and labels; `pr_update` supports
+  updating title, body, base branch, and closing or reopening PRs; `pr_comment` adds comments with
+  idempotency support. `issue_publish` provides a single brokered request
   that posts a comment and adds or removes labels (with automatic missing-label creation).
   Tokens are supplied exclusively via stdin and are never written to workspace files.
   Comment, label, and publish mutations support idempotency keys.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -146,7 +146,7 @@ directories and helper containers are removed after the operation.
 
 ### Brokered GitHub actions
 
-Authenticated GitHub operations (`pr_list`, `pr_view`, `pr_create`, `issue_list`, `issue_view`, `issue_create`, `issue_comment`, `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`, `issue_update`, `issue_publish`) are executed through the `github_action` tool using an ephemeral helper container (`worker/gh-helper.sh`). Action-scoped tokens (`pull_requests: read|write`, `issues: read|write`) are minted by the runner from the trusted GitHub App installation and passed exclusively via `stdin`. The helper container runs read-only with dropped capabilities, and is forcibly removed on all exit paths in a `try/finally` block. Tokens never enter the workspace filesystem or environment.
+Authenticated GitHub operations (`pr_list`, `pr_view`, `pr_create`, `pr_update`, `pr_comment`, `issue_list`, `issue_view`, `issue_create`, `issue_comment`, `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`, `issue_update`, `issue_publish`) are executed through the `github_action` tool using an ephemeral helper container (`worker/gh-helper.sh`). Action-scoped tokens (`pull_requests: read|write`, `issues: read|write`) are minted by the runner from the trusted GitHub App installation and passed exclusively via `stdin`. The helper container runs read-only with dropped capabilities, and is forcibly removed on all exit paths in a `try/finally` block. Tokens never enter the workspace filesystem or environment.
 
 ### Three-zone storage and toolchain isolation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "packages/*",
         "docs-site"
       ],
+      "bin": {
+        "cloud-harness-mcp": "apps/api/dist/index.js"
+      },
       "devDependencies": {
         "@eslint/js": "9.39.5",
         "@modelcontextprotocol/client": "2.0.0",
@@ -45,6 +48,9 @@
         "express": "5.2.1",
         "pino": "10.3.1",
         "zod": "4.4.3"
+      },
+      "bin": {
+        "cloud-harness-mcp": "dist/index.js"
       }
     },
     "apps/api-key-gateway": {

--- a/packages/contracts/src/tool-schemas.ts
+++ b/packages/contracts/src/tool-schemas.ts
@@ -168,7 +168,29 @@ const schemas = {
       title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes'),
       body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').default(''),
       head: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'head cannot contain null bytes'),
-      base: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'base cannot contain null bytes').default('main')
+      base: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'base cannot contain null bytes').default('main'),
+      draft: z.boolean().default(false),
+      labels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional()
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('pr_update'),
+      prNumber: z.number().int().positive(),
+      title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes').optional(),
+      body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').optional(),
+      base: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'base cannot contain null bytes').optional(),
+      state: z.enum(['open', 'closed']).optional()
+    }).superRefine((input, context) => {
+      if (!input.title && !input.body && !input.base && !input.state) {
+        context.addIssue({ code: 'custom', path: ['title'], message: 'at least one of title, body, base, or state is required' });
+      }
+    }),
+    z.object({
+      ...workspace,
+      action: z.literal('pr_comment'),
+      prNumber: z.number().int().positive(),
+      body: z.string().min(1).max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes'),
+      idempotencyKey: IdempotencyKeySchema.optional()
     }),
     z.object({
       ...workspace,
@@ -185,7 +207,9 @@ const schemas = {
       ...workspace,
       action: z.literal('issue_create'),
       title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes'),
-      body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').default('')
+      body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').default(''),
+      labels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional(),
+      assignees: z.array(z.string().regex(/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/, 'invalid GitHub username')).max(10).optional()
     }),
     z.object({
       ...workspace,

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -204,6 +204,70 @@ describe('contracts', () => {
     })).toMatchObject({ action: 'issue_update', state: 'closed' });
   });
 
+  it('validates pull request and extended issue schemas in github_action', () => {
+    expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'pr_create',
+      title: 'feat: add brokered github operations',
+      body: 'PR body',
+      head: 'feat/gh-ops',
+      base: 'main',
+      draft: true,
+      labels: ['enhancement']
+    })).toMatchObject({
+      action: 'pr_create',
+      title: 'feat: add brokered github operations',
+      draft: true,
+      labels: ['enhancement']
+    });
+
+    expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'pr_update',
+      prNumber: 10,
+      title: 'Updated title',
+      state: 'closed'
+    })).toMatchObject({ action: 'pr_update', prNumber: 10, title: 'Updated title', state: 'closed' });
+
+    expect(() => TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'pr_update',
+      prNumber: 10
+    })).toThrow();
+
+    expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'pr_comment',
+      prNumber: 10,
+      body: 'LGTM!',
+      idempotencyKey: 'idem_key_123'
+    })).toMatchObject({ action: 'pr_comment', prNumber: 10, body: 'LGTM!' });
+
+    expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'issue_create',
+      title: 'New bug report',
+      body: 'Bug description',
+      labels: ['bug', 'p1'],
+      assignees: ['octocat']
+    })).toMatchObject({
+      action: 'issue_create',
+      title: 'New bug report',
+      labels: ['bug', 'p1'],
+      assignees: ['octocat']
+    });
+
+    const validWs = `ws_${'a'.repeat(24)}`;
+    expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
+      workspaceId: validWs,
+      action: 'issue_list',
+      limit: 5,
+      state: 'open'
+    })).toMatchObject({ workspaceId: validWs, action: 'issue_list', limit: 5 });
+
+    expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
+      workspaceId: validWs,
+      action: 'pr_list',
+      limit: 5,
+      state: 'all'
+    })).toMatchObject({ workspaceId: validWs, action: 'pr_list', limit: 5 });
+  });
+
   it('validates workspace lease renew, recovery, context, and git identity schemas', () => {
     expect(TOOL_SCHEMA_BY_NAME.workspace_lease_renew.parse({ extensionSeconds: 3600 })).toMatchObject({ extensionSeconds: 3600 });
     expect(TOOL_SCHEMA_BY_NAME.workspace_recover.parse({ mode: 'patch' })).toMatchObject({ mode: 'patch' });

--- a/plans/260829-1600-brokered-github-issues-and-pull-requests/phase-01-contracts-and-schemas.md
+++ b/plans/260829-1600-brokered-github-issues-and-pull-requests/phase-01-contracts-and-schemas.md
@@ -1,0 +1,17 @@
+# Phase 1: Contracts and Tool Schemas
+
+## Requirements
+- Extend `github_action` discriminated union in `packages/contracts/src/tool-schemas.ts`:
+  1. `pr_create`: add `draft: z.boolean().default(false)` and optional `labels: z.array(z.string()).optional()`.
+  2. `pr_update`: add discriminated union schema for `action: 'pr_update'`, requiring `prNumber: z.number().int().positive()`, and optional `title`, `body`, `base`, `state: z.enum(['open', 'closed'])`, with refinement requiring at least one field.
+  3. `pr_comment`: add schema for `action: 'pr_comment'`, requiring `prNumber: z.number().int().positive()`, `body: z.string().min(1).max(65_536)`, and optional `idempotencyKey`.
+  4. `issue_create`: add optional `labels: z.array(z.string()).optional()` and `assignees: z.array(z.string()).optional()`.
+- Add test coverage in `packages/contracts/test/contracts.test.ts`.
+
+## Files to modify
+- `packages/contracts/src/tool-schemas.ts`
+- `packages/contracts/test/contracts.test.ts`
+
+## Validation
+- `npm run build -w @cloud-harness/contracts`
+- `vitest run packages/contracts/test/contracts.test.ts`

--- a/plans/260829-1600-brokered-github-issues-and-pull-requests/phase-02-worker-gh-helper-and-runner-service.md
+++ b/plans/260829-1600-brokered-github-issues-and-pull-requests/phase-02-worker-gh-helper-and-runner-service.md
@@ -1,0 +1,21 @@
+# Phase 2: Worker Helper and Runner Service
+
+## Requirements
+- Update `worker/gh-helper.sh`:
+  1. `pr_create`: handle draft flag (`--draft`) and optional labels (`--label`).
+  2. `pr_update`: implement `gh pr edit "$pr_number"` (title, body, base) and `gh pr close` / `gh pr reopen` when state changes.
+  3. `pr_comment`: implement `gh pr comment "$pr_number" --body "$body"`.
+  4. `issue_create`: support optional `--label` and `--assignee`.
+- Update `apps/runner/src/workspace-service.ts`:
+  1. Add argument translation for `pr_create`, `pr_update`, `pr_comment`.
+  2. Register `pr_update` and `pr_comment` in `isWrite` and permission scope resolver (`action.startsWith('pr_') ? 'pull_requests' : 'issues'`).
+  3. Support comment idempotency caching for `pr_comment`.
+  4. Ensure destructive/write operations audit decision and maintain zero-leakage token passing.
+
+## Files to modify
+- `worker/gh-helper.sh`
+- `apps/runner/src/workspace-service.ts`
+
+## Validation
+- `npm run typecheck -w @cloud-harness/runner`
+- `npm run test:unit`

--- a/plans/260829-1600-brokered-github-issues-and-pull-requests/phase-03-tests-and-verification.md
+++ b/plans/260829-1600-brokered-github-issues-and-pull-requests/phase-03-tests-and-verification.md
@@ -1,0 +1,19 @@
+# Phase 3: Tests and Verification
+
+## Requirements
+- Add comprehensive unit tests in `apps/runner/test/brokered-github-operations.test.ts` or `ux-improvements.test.ts` covering:
+  1. `pr_create` with draft flag and labels.
+  2. `pr_update` updating title, body, base, and closing/reopening PR.
+  3. `pr_comment` adding comment and verifying idempotency key behavior.
+  4. `issue_create` with labels and assignees.
+  5. Permission scopes (`pull_requests: write`, `issues: write`).
+  6. Idempotency key conflict / mismatch detection.
+  7. Ephemeral helper invocation and zero-token leakage guarantees.
+
+## Files to modify/create
+- `apps/runner/test/brokered-github-operations.test.ts`
+- `packages/contracts/test/contracts.test.ts`
+
+## Validation
+- `npm run test:unit`
+- `npm run test:integration`

--- a/plans/260829-1600-brokered-github-issues-and-pull-requests/phase-04-documentation-and-sync.md
+++ b/plans/260829-1600-brokered-github-issues-and-pull-requests/phase-04-documentation-and-sync.md
@@ -1,0 +1,17 @@
+# Phase 4: Documentation and Sync
+
+## Requirements
+- Update `docs/mcp-api.md` to document all supported `github_action` operations: `pr_list`, `pr_view`, `pr_create`, `pr_update`, `pr_comment`, `issue_list`, `issue_view`, `issue_create`, `issue_comment`, `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`, `issue_update`, `issue_publish`.
+- Update `docs/security-model.md` to document the security boundaries, token scopes, and isolation of PR and issue actions.
+- Run `npm run docs:reference` and `npm run plugin:sync` to keep docs-site and skill manifests in sync.
+- Verify full build and verification gates.
+
+## Files to modify
+- `docs/mcp-api.md`
+- `docs/security-model.md`
+- `docs-site/reference/tools.md`
+
+## Validation
+- `npm run docs:reference`
+- `npm run plugin:check`
+- `npm run verify`

--- a/plans/260829-1600-brokered-github-issues-and-pull-requests/plan.md
+++ b/plans/260829-1600-brokered-github-issues-and-pull-requests/plan.md
@@ -1,0 +1,24 @@
+# Plan: Brokered GitHub Issues and Pull Request Operations
+
+## Overview
+Implement typed, brokered GitHub Pull Request and Issue operations for CloudHarness MCP workspaces, enabling complete autonomous end-to-end workflows (inspect -> edit -> commit -> push -> PR / issue creation/management) without exposing credentials inside the workspace executor.
+
+## Status
+- **Status:** completed
+- **Mode:** official
+- **Route:** feature
+- **Issue:** #105
+- **Branch:** mrgoonie/feat-add-brokered-github-issues-and-pull-request
+
+## Phases
+1. [Phase 1: Contracts and Tool Schemas](phase-01-contracts-and-schemas.md) - Extend `github_action` schemas with `pr_update`, `pr_comment`, `pr_create.draft`, and `issue_create` metadata.
+2. [Phase 2: Worker Helper and Runner Execution](phase-02-worker-gh-helper-and-runner-service.md) - Update `worker/gh-helper.sh` and `apps/runner/src/workspace-service.ts` with action handlers, idempotency tracking, and write categorization.
+3. [Phase 3: Unit and Integration Test Suite](phase-03-tests-and-verification.md) - Comprehensive unit tests for contract validation, runner execution, idempotency, and error handling.
+4. [Phase 4: Documentation and Plugin Sync](phase-04-documentation-and-sync.md) - Update `docs/mcp-api.md`, `docs/security-model.md`, `docs-site/`, and run reference generators.
+
+## Acceptance Criteria
+- [x] `github_action` supports `pr_list`, `pr_view`, `pr_create` (including draft PRs), `pr_update` (title, body, base, state), and `pr_comment` (with idempotency support).
+- [x] `github_action` supports `issue_list`, `issue_view`, `issue_create` (with labels/assignees), `issue_update`, `issue_comment`, `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`, and `issue_publish`.
+- [x] Security guarantees preserved: tokens never leak to executor workspace, target repo strictly bound to workspace, least-privilege token scopes.
+- [x] All unit and integration tests pass.
+- [x] Public documentation and docs site updated in sync.

--- a/test/integration/gh-helper.docker.test.ts
+++ b/test/integration/gh-helper.docker.test.ts
@@ -48,4 +48,28 @@ describe('brokered GitHub helper', () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('Title required for issue creation');
   });
+
+  it('rejects pr_update when pull request number is missing', () => {
+    const result = spawnSync('docker', [
+      'run', '-i', '--rm', '--network', 'none', '--user', '10001:10001',
+      '--entrypoint', '/opt/harness/gh-helper.sh',
+      'cloud-harness-executor:local',
+      'pr_update'
+    ], { input: 'dummy_token\n', encoding: 'utf8' });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Pull request number required');
+  });
+
+  it('rejects pr_comment when pull request number or body is missing', () => {
+    const result = spawnSync('docker', [
+      'run', '-i', '--rm', '--network', 'none', '--user', '10001:10001',
+      '--entrypoint', '/opt/harness/gh-helper.sh',
+      'cloud-harness-executor:local',
+      'pr_comment'
+    ], { input: 'dummy_token\n', encoding: 'utf8' });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Pull request number and comment body required');
+  });
 });

--- a/worker/gh-helper.sh
+++ b/worker/gh-helper.sh
@@ -31,11 +31,65 @@ case "$action" in
     body="${2:-}"
     head="${3:-}"
     base="${4:-main}"
+    draft="${5:-false}"
+    labels="${6:-}"
     if [ -z "$title" ] || [ -z "$head" ]; then
       echo "Title and head branch required for pull request creation" >&2
       exit 1
     fi
-    exec gh pr create --title "$title" --body "$body" --head "$head" --base "$base"
+    cmd=(gh pr create --title "$title" --body "$body" --head "$head" --base "$base")
+    if [ "$draft" = "true" ]; then
+      cmd+=(--draft)
+    fi
+    if [ -n "$labels" ]; then
+      cmd+=(--label "$labels")
+    fi
+    exec "${cmd[@]}"
+    ;;
+  pr_update)
+    pr_number="${1:-}"
+    title="${2:-}"
+    body="${3:-}"
+    base="${4:-}"
+    state="${5:-}"
+    if [ -z "$pr_number" ]; then
+      echo "Pull request number required" >&2
+      exit 1
+    fi
+    edit_needed=false
+    cmd=(gh pr edit "$pr_number")
+    if [ -n "$title" ]; then cmd+=(--title "$title"); edit_needed=true; fi
+    if [ -n "$body" ]; then cmd+=(--body "$body"); edit_needed=true; fi
+    if [ -n "$base" ]; then cmd+=(--base "$base"); edit_needed=true; fi
+    if [ "$edit_needed" = "true" ]; then
+      if ! "${cmd[@]}" >/dev/null; then
+        echo "Failed to edit pull request $pr_number" >&2
+        exit 1
+      fi
+    fi
+    if [ -n "$state" ]; then
+      if [ "$state" = "closed" ]; then
+        if ! gh pr close "$pr_number" >/dev/null; then
+          echo "Failed to close pull request $pr_number" >&2
+          exit 1
+        fi
+      elif [ "$state" = "open" ]; then
+        if ! gh pr reopen "$pr_number" >/dev/null; then
+          echo "Failed to reopen pull request $pr_number" >&2
+          exit 1
+        fi
+      fi
+    fi
+    exec gh pr view "$pr_number" --json number,title,body,state,author,reviews,comments,url
+    ;;
+  pr_comment)
+    pr_number="${1:-}"
+    body="${2:-}"
+    if [ -z "$pr_number" ] || [ -z "$body" ]; then
+      echo "Pull request number and comment body required" >&2
+      exit 1
+    fi
+    exec gh pr comment "$pr_number" --body "$body"
     ;;
   issue_list)
     limit="${1:-20}"
@@ -53,11 +107,20 @@ case "$action" in
   issue_create)
     title="${1:-}"
     body="${2:-}"
+    labels="${3:-}"
+    assignees="${4:-}"
     if [ -z "$title" ]; then
       echo "Title required for issue creation" >&2
       exit 1
     fi
-    exec gh issue create --title "$title" --body "$body"
+    cmd=(gh issue create --title "$title" --body "$body")
+    if [ -n "$labels" ]; then
+      cmd+=(--label "$labels")
+    fi
+    if [ -n "$assignees" ]; then
+      cmd+=(--assignee "$assignees")
+    fi
+    exec "${cmd[@]}"
     ;;
   issue_comment)
     issue_number="${1:-}"
@@ -122,18 +185,38 @@ case "$action" in
       echo "Issue number required" >&2
       exit 1
     fi
+    edit_needed=false
     cmd=(gh issue edit "$issue_number")
-    if [ -n "$title" ]; then cmd+=(--title "$title"); fi
-    if [ -n "$body" ]; then cmd+=(--body "$body"); fi
-    if [ -n "$state" ]; then
-      if [ "$state" = "closed" ]; then
-        cmd+=(--state "closed")
-        if [ -n "$state_reason" ]; then cmd+=(--reason "$state_reason"); fi
-      elif [ "$state" = "open" ]; then
-        cmd+=(--state "open")
+    if [ -n "$title" ]; then cmd+=(--title "$title"); edit_needed=true; fi
+    if [ -n "$body" ]; then cmd+=(--body "$body"); edit_needed=true; fi
+    if [ "$edit_needed" = "true" ]; then
+      if ! "${cmd[@]}" >/dev/null; then
+        echo "Failed to edit issue $issue_number" >&2
+        exit 1
       fi
     fi
-    exec "${cmd[@]}"
+    if [ -n "$state" ]; then
+      if [ "$state" = "closed" ]; then
+        close_cmd=(gh issue close "$issue_number")
+        if [ -n "$state_reason" ]; then
+          if [ "$state_reason" = "not_planned" ] || [ "$state_reason" = "not planned" ]; then
+            close_cmd+=(--reason "not planned")
+          elif [ "$state_reason" = "completed" ]; then
+            close_cmd+=(--reason "completed")
+          fi
+        fi
+        if ! "${close_cmd[@]}" >/dev/null; then
+          echo "Failed to close issue $issue_number" >&2
+          exit 1
+        fi
+      elif [ "$state" = "open" ]; then
+        if ! gh issue reopen "$issue_number" >/dev/null; then
+          echo "Failed to reopen issue $issue_number" >&2
+          exit 1
+        fi
+      fi
+    fi
+    exec gh issue view "$issue_number" --json number,title,body,state,author,labels,comments,url
     ;;
   issue_publish)
     issue_number="${1:-}"


### PR DESCRIPTION
## Summary

Closes #105

Implements typed, brokered GitHub Pull Request and Issue operations for CloudHarness MCP workspaces, enabling complete autonomous end-to-end workflows (inspect -> edit -> commit -> push -> PR / issue creation/management) without exposing credentials inside the workspace executor.

### Key Changes
- **Contracts & Schemas:** Extended `github_action` tool schema in `packages/contracts` with:
  - `pr_update`: edit title, body, base branch, or close/reopen PR
  - `pr_comment`: add comments with idempotency key support
  - `pr_create`: added `draft` flag and `labels` support
  - `issue_create`: added `labels` and `assignees` support
- **Worker Helper:** Updated `worker/gh-helper.sh` to handle new PR actions and draft/label flags; fixed pre-existing bug in `issue_update` to use `gh issue close --reason` / `gh issue reopen` instead of non-existent `gh issue edit --state`.
- **Runner Execution:** Updated `apps/runner/src/workspace-service.ts` with action argument translation, write permission scoping (`pull_requests: write`, `issues: write`), mutation serialization, and comment idempotency caching for `pr_comment`.
- **Testing:** Added 7 unit tests in `apps/runner/test/brokered-github-operations.test.ts`, expanded contract tests, and added helper validation tests.
- **Documentation:** Updated `docs/mcp-api.md`, `docs/security-model.md`, and generated reference docs.

### Security Guarantees
- Raw tokens are never written to workspace files or logs; tokens are piped directly via stdin to the ephemeral helper container.
- Repository is strictly workspace-bound via `GH_REPO` derived from the workspace record.
- Tokens follow least-privilege scoping (`pull_requests` vs `issues` and `write` vs `read`).

### Verification
- 51/51 unit test files passed (381 tests).
- 3/3 integration test files passed.
- Lint, typecheck, docs reference generation, and plugin sync all passed.