### PR TITLE
feat: add repository capability and authorization preflight

### DIFF
--- a/.agents/skills/cloudharness/references/workspace-lifecycle-and-results.md
+++ b/.agents/skills/cloudharness/references/workspace-lifecycle-and-results.md
@@ -88,6 +88,19 @@ Read one workspace record by opaque ID.
   record, unlike tools that require an active executor.
 - Read-only and safe to repeat.
 
+<!-- cloudharness-tool:workspace_capabilities -->
+### `workspace_capabilities`
+
+Inspect workspace and bound repository authorization capabilities without modifying state or minting tokens.
+
+- Optional: `workspaceId`.
+- Returns high-level capabilities (`repository`, `workspace`), fine-grained permissions (`contents`, `issues`, `pullRequests`), and direct operation authorizations (`gitPush`, `issueCreate`, `pullRequestCreate`, etc.).
+- Read-only and safe to repeat.
+
+<!-- cloudharness-example:workspace_capabilities
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
 <!-- cloudharness-tool:workspace_close -->
 ### `workspace_close`
 

--- a/apps/api/src/local/local-workspace-backend.ts
+++ b/apps/api/src/local/local-workspace-backend.ts
@@ -52,6 +52,66 @@ export class LocalWorkspaceBackend implements OperationBackend {
     };
   }
 
+  private getCapabilities() {
+    const gitNetwork = Boolean(this.options.gitNetwork);
+    const gitPush = Boolean(this.options.gitPush);
+    return {
+      workspaceId: this.workspaceId,
+      repository: `local://${this.canonicalRoot}`,
+      repositoryUrl: `local://${this.canonicalRoot}`,
+      capabilities: {
+        repository: {
+          read: true,
+          push: gitPush,
+          issuesRead: false,
+          issuesWrite: false,
+          pullRequestsRead: false,
+          pullRequestsWrite: false
+        },
+        workspace: {
+          mode: 'local',
+          platform: process.platform,
+          gitNetwork,
+          gitPush,
+          sandboxed: false,
+          shell: true,
+          tasks: true,
+          sessions: true,
+          deployments: true,
+          privileged: false,
+          networkMode: gitNetwork ? 'host' : 'none'
+        },
+        mode: 'local',
+        platform: process.platform,
+        gitNetwork,
+        gitPush,
+        sandboxed: false
+      },
+      permissions: {
+        contents: { read: true, write: true },
+        issues: { read: false, write: false },
+        pullRequests: { read: false, write: false }
+      },
+      operations: {
+        gitFetch: gitNetwork,
+        gitPull: gitNetwork,
+        gitPush,
+        issueList: false,
+        issueView: false,
+        issueCreate: false,
+        issueComment: false,
+        issueUpdate: false,
+        issuePublish: false,
+        labelCreate: false,
+        pullRequestList: false,
+        pullRequestView: false,
+        pullRequestCreate: false,
+        execRun: true,
+        privilegedExec: false,
+        deploymentsRun: true
+      }
+    };
+  }
   async close(): Promise<void> {
     this.status = 'CLOSED';
     await this.operationManager.stopWorkspace(this.workspaceId);
@@ -89,8 +149,8 @@ export class LocalWorkspaceBackend implements OperationBackend {
       };
     }
 
-    if (operation === 'workspace_status') {
-      if (input.workspaceId !== this.workspaceId || this.status === 'CLOSED') {
+    if (operation === 'workspace_capabilities') {
+      if (input.workspaceId && input.workspaceId !== this.workspaceId) {
         return {
           ok: false,
           message: 'workspace not found',
@@ -100,17 +160,73 @@ export class LocalWorkspaceBackend implements OperationBackend {
       }
       return {
         ok: true,
+        message: 'Workspace capabilities retrieved',
+        data: this.getCapabilities(),
+        truncated: false
+      };
+    }
+
+    if (operation === 'workspace_status') {
+      if ((input.workspaceId && input.workspaceId !== this.workspaceId) || this.status === 'CLOSED') {
+        return {
+          ok: false,
+          message: 'workspace not found',
+          error: { code: 'NOT_FOUND', message: 'workspace not found', retryable: false },
+          truncated: false
+        };
+      }
+      const caps = this.getCapabilities();
+      return {
+        ok: true,
         message: 'Workspace status retrieved',
         data: {
           ...this.getPublicRecord(),
           root: this.canonicalRoot,
-          capabilities: {
-            mode: 'local',
-            platform: process.platform,
-            gitNetwork: this.options.gitNetwork,
-            gitPush: this.options.gitPush,
-            sandboxed: false
-          }
+          capabilities: caps.capabilities,
+          permissions: caps.permissions,
+          operations: caps.operations
+        },
+        truncated: false
+      };
+    }
+
+    if (operation === 'workspace_context') {
+      if (input.workspaceId && input.workspaceId !== this.workspaceId) {
+        return {
+          ok: false,
+          message: 'workspace not found',
+          error: { code: 'NOT_FOUND', message: 'workspace not found', retryable: false },
+          truncated: false
+        };
+      }
+      if (this.status === 'CLOSED') {
+        return {
+          ok: false,
+          message: 'workspace is closed',
+          error: { code: 'NOT_FOUND', message: 'workspace is closed', retryable: false },
+          truncated: false
+        };
+      }
+      const caps = this.getCapabilities();
+      return {
+        ok: true,
+        message: 'Workspace context',
+        data: {
+          workspace: {
+            ...this.getPublicRecord(),
+            root: this.canonicalRoot,
+            capabilities: caps.capabilities,
+            permissions: caps.permissions,
+            operations: caps.operations
+          },
+          branch: 'HEAD',
+          gitIdentity: {
+            name: 'Cloud Harness Agent',
+            email: 'agent@cloud-harness.local'
+          },
+          capabilities: caps.capabilities,
+          permissions: caps.permissions,
+          operations: caps.operations
         },
         truncated: false
       };
@@ -214,13 +330,18 @@ export class LocalWorkspaceBackend implements OperationBackend {
     }
 
     if (operation === 'github_action') {
+      const action = typeof input.action === 'string' ? input.action : '';
+      const requiredCapability = action.startsWith('pr_') ? 'repository.pullRequestsWrite' : 'repository.issuesWrite';
       return {
         ok: false,
         message: 'github_action is unsupported in local mode',
         error: {
-          code: 'INVALID_INPUT',
+          code: 'REPOSITORY_OPERATION_NOT_AUTHORIZED',
           message: 'github_action is unsupported in local mode',
-          retryable: false
+          retryable: false,
+          operation: 'github_action',
+          repository: `local://${this.canonicalRoot}`,
+          requiredCapability
         },
         truncated: false
       };
@@ -499,9 +620,12 @@ export class LocalWorkspaceBackend implements OperationBackend {
           ok: false,
           message: 'Git push operations are disabled in local mode; pass --git-push to enable',
           error: {
-            code: 'FORBIDDEN',
+            code: 'REPOSITORY_OPERATION_NOT_AUTHORIZED',
             message: 'Git push operations are disabled in local mode; pass --git-push to enable',
-            retryable: false
+            retryable: false,
+            operation: 'git_push',
+            repository: `local://${this.canonicalRoot}`,
+            requiredCapability: 'repository.push'
           },
           truncated: false
         };

--- a/apps/api/src/mcp-response-text.ts
+++ b/apps/api/src/mcp-response-text.ts
@@ -78,7 +78,18 @@ export function formatToolResultText(result: ToolResult): string {
     }
   }
   if (result.error) {
-    sections.push(`Error [${result.error.code}]: ${result.error.message} (retryable: ${result.error.retryable})`);
+    const details: string[] = [];
+    if (result.error.requiredCapability) {
+      details.push(`required capability: ${result.error.requiredCapability}`);
+    }
+    if (result.error.operation) {
+      details.push(`operation: ${result.error.operation}`);
+    }
+    if (result.error.repository) {
+      details.push(`repository: ${result.error.repository}`);
+    }
+    details.push(`retryable: ${result.error.retryable}`);
+    sections.push(`Error [${result.error.code}]: ${result.error.message} (${details.join(', ')})`);
   }
   if (result.truncated && result.cursor) {
     sections.push(`[truncated — next cursor: ${result.cursor}]`);

--- a/apps/api/test/local/local-capabilities.test.ts
+++ b/apps/api/test/local/local-capabilities.test.ts
@@ -1,0 +1,151 @@
+import { mkdir, realpath, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LocalWorkspaceBackend } from '../../src/local/local-workspace-backend.js';
+import type { CliOptions } from '../../src/cli-options.js';
+
+describe('Local Workspace Capabilities', () => {
+  let tempRoot: string;
+  let canonicalRoot: string;
+  let backend: LocalWorkspaceBackend;
+
+  beforeEach(async () => {
+    tempRoot = join(tmpdir(), `ch-local-cap-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(tempRoot, { recursive: true });
+    canonicalRoot = await realpath(tempRoot);
+  });
+
+  afterEach(async () => {
+    if (backend) await backend.close();
+    try {
+      await rm(tempRoot, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('reports read-only and disabled network/push by default', async () => {
+    const options: CliOptions = {
+      transport: 'stdio',
+      workspace: canonicalRoot,
+      gitNetwork: false,
+      gitPush: false,
+      env: [],
+      help: false,
+      version: false
+    };
+    backend = new LocalWorkspaceBackend(canonicalRoot, options);
+
+    const res = await backend.call('workspace_capabilities', {});
+    expect(res.ok).toBe(true);
+    const data = res.data as {
+      capabilities: { repository: Record<string, boolean>; workspace: Record<string, unknown> };
+      permissions: { contents: { read: boolean; write: boolean } };
+      operations: Record<string, boolean>;
+    };
+
+    expect(data.capabilities.repository.read).toBe(true);
+    expect(data.capabilities.repository.push).toBe(false);
+    expect(data.capabilities.repository.issuesRead).toBe(false);
+    expect(data.capabilities.repository.pullRequestsRead).toBe(false);
+
+    expect(data.permissions.contents.read).toBe(true);
+    expect(data.permissions.contents.write).toBe(true); // local files can be edited
+
+    expect(data.operations.gitFetch).toBe(false);
+    expect(data.operations.gitPush).toBe(false);
+    expect(data.operations.execRun).toBe(true);
+  });
+
+  it('reflects --git-push and --git-network flags in capabilities and operations', async () => {
+    const options: CliOptions = {
+      transport: 'stdio',
+      workspace: canonicalRoot,
+      gitNetwork: true,
+      gitPush: true,
+      env: [],
+      help: false,
+      version: false
+    };
+    backend = new LocalWorkspaceBackend(canonicalRoot, options);
+
+    const res = await backend.call('workspace_capabilities', { workspaceId: backend.workspaceId });
+    expect(res.ok).toBe(true);
+    const data = res.data as {
+      capabilities: { repository: Record<string, boolean>; workspace: Record<string, unknown> };
+      operations: Record<string, boolean>;
+    };
+
+    expect(data.capabilities.repository.push).toBe(true);
+    expect(data.capabilities.workspace.networkMode).toBe('host');
+    expect(data.operations.gitFetch).toBe(true);
+    expect(data.operations.gitPull).toBe(true);
+    expect(data.operations.gitPush).toBe(true);
+  });
+
+  it('returns structured authorization error when git_push is attempted without --git-push', async () => {
+    const options: CliOptions = {
+      transport: 'stdio',
+      workspace: canonicalRoot,
+      gitNetwork: false,
+      gitPush: false,
+      env: [],
+      help: false,
+      version: false
+    };
+    backend = new LocalWorkspaceBackend(canonicalRoot, options);
+
+    const res = await backend.call('git_push', { workspaceId: backend.workspaceId });
+    expect(res.ok).toBe(false);
+    expect(res.error?.code).toBe('REPOSITORY_OPERATION_NOT_AUTHORIZED');
+    expect(res.error?.operation).toBe('git_push');
+    expect(res.error?.requiredCapability).toBe('repository.push');
+  });
+
+  it('returns structured authorization error when github_action is attempted in local mode', async () => {
+    const options: CliOptions = {
+      transport: 'stdio',
+      workspace: canonicalRoot,
+      gitNetwork: false,
+      gitPush: false,
+      env: [],
+      help: false,
+      version: false
+    };
+    backend = new LocalWorkspaceBackend(canonicalRoot, options);
+
+    const resPr = await backend.call('github_action', { workspaceId: backend.workspaceId, action: 'pr_create', title: 'test', head: 'feat' });
+    expect(resPr.ok).toBe(false);
+    expect(resPr.error?.code).toBe('REPOSITORY_OPERATION_NOT_AUTHORIZED');
+    expect(resPr.error?.operation).toBe('github_action');
+    expect(resPr.error?.requiredCapability).toBe('repository.pullRequestsWrite');
+
+    const resIssue = await backend.call('github_action', { workspaceId: backend.workspaceId, action: 'issue_create', title: 'test' });
+    expect(resIssue.ok).toBe(false);
+    expect(resIssue.error?.code).toBe('REPOSITORY_OPERATION_NOT_AUTHORIZED');
+    expect(resIssue.error?.operation).toBe('github_action');
+    expect(resIssue.error?.requiredCapability).toBe('repository.issuesWrite');
+  });
+
+  it('returns workspace_context with capabilities and permissions', async () => {
+    const options: CliOptions = {
+      transport: 'stdio',
+      workspace: canonicalRoot,
+      gitNetwork: false,
+      gitPush: false,
+      env: [],
+      help: false,
+      version: false
+    };
+    backend = new LocalWorkspaceBackend(canonicalRoot, options);
+
+    const res = await backend.call('workspace_context', { workspaceId: backend.workspaceId });
+    expect(res.ok).toBe(true);
+    const data = res.data as Record<string, unknown>;
+    expect(data.capabilities).toBeDefined();
+    expect(data.permissions).toBeDefined();
+    expect(data.operations).toBeDefined();
+    expect(data.branch).toBe('HEAD');
+  });
+});

--- a/apps/runner/src/app.ts
+++ b/apps/runner/src/app.ts
@@ -60,7 +60,19 @@ export function createRunnerApp(config: RunnerConfig, service: WorkspaceService,
 
 function sendRunnerError(response: Response, error: unknown): void {
   if (error instanceof HarnessError) {
-    response.status(error.status).json({ ok: false, message: error.message, error: { code: error.code, message: error.message, retryable: error.retryable }, truncated: false });
+    response.status(error.status).json({
+      ok: false,
+      message: error.message,
+      error: {
+        code: error.code,
+        message: error.message,
+        retryable: error.retryable,
+        ...(error.operation ? { operation: error.operation } : {}),
+        ...(error.repository ? { repository: error.repository } : {}),
+        ...(error.requiredCapability ? { requiredCapability: error.requiredCapability } : {})
+      },
+      truncated: false
+    });
     return;
   }
   if (error instanceof ZodError) {

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -10,7 +10,8 @@ import {
   type RunnerConfig,
   type InternalRunnerOperation,
   type RunnerOperation,
-  type RunnerResponse
+  type RunnerResponse,
+  type WorkspaceCapabilityResult
 } from '@cloud-harness/contracts';
 import { inspectContainer, removeContainer, runDocker, terminateContainerProcessGroup } from './docker-engine.js';
 import { readVerifiedWorkspaceFile } from './bounded-workspace-file-reader.js';
@@ -50,7 +51,7 @@ function availableLifecycleActions(status: WorkspaceRecord['status'], canRenewLe
   }
 }
 
-function publicRecord(record: WorkspaceRecord) {
+function publicRecord(record: WorkspaceRecord, capabilities?: WorkspaceCapabilityResult) {
   const now = Date.now();
   const remainingLeaseMs = Math.max(0, record.expiresAt - now);
   const hardRemainingMs = Math.max(0, record.hardExpiresAt - now);
@@ -88,6 +89,11 @@ function publicRecord(record: WorkspaceRecord) {
     leaseState,
     availableActions: availableLifecycleActions(record.status, canRenewLease),
     ...(leaseWarnings.length > 0 ? { leaseWarnings } : {}),
+    ...(capabilities ? {
+      capabilities: capabilities.capabilities,
+      permissions: capabilities.permissions,
+      operations: capabilities.operations
+    } : {}),
     error: record.error
   };
 }
@@ -458,7 +464,7 @@ export class WorkspaceService {
   async open(ownerId: string, input: Record<string, unknown>): Promise<RunnerResponse> {
     const parsed = TOOL_SCHEMA_BY_NAME.workspace_open.parse(input);
     const prior = this.store.byIdempotency(ownerId, parsed.idempotencyKey);
-    if (prior) return { ok: prior.status === 'ACTIVE', message: 'Idempotent workspace result', data: publicRecord(prior), truncated: false };
+    if (prior) return { ok: prior.status === 'ACTIVE', message: 'Idempotent workspace result', data: this.publicWorkspaceRecord(prior), truncated: false };
     await this.ensureCapacity(ownerId);
     const url = await validateRepositoryUrl(parsed.repositoryUrl, this.config.allowedGitHosts);
     if (parsed.ref?.startsWith('-')) throw new HarnessError('INVALID_INPUT', 'ref cannot start with a dash');
@@ -476,7 +482,7 @@ export class WorkspaceService {
       this.store.create(record);
     } catch (error) {
       const replay = this.store.byIdempotency(ownerId, parsed.idempotencyKey);
-      if (replay) return { ok: replay.status === 'ACTIVE', message: 'Idempotent workspace result', data: publicRecord(replay), truncated: false };
+      if (replay) return { ok: replay.status === 'ACTIVE', message: 'Idempotent workspace result', data: this.publicWorkspaceRecord(replay), truncated: false };
       if (this.store.list(ownerId).some((candidate) => activeStatus.has(candidate.status))) {
         throw new HarnessError('LIMIT_EXCEEDED', 'only one active workspace is allowed in this MVP', 429, true);
       }
@@ -499,7 +505,7 @@ export class WorkspaceService {
         await removeContainer(containerName);
         throw new HarnessError('CONFLICT', 'workspace creation lost its lifecycle lease', 409, true);
       }
-      return { ok: true, message: 'Workspace opened', data: publicRecord(active), truncated: false };
+      return { ok: true, message: 'Workspace opened', data: this.publicWorkspaceRecord(active), truncated: false };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'workspace creation failed';
       this.store.updateFenced(workspaceId, record.generation, ['CREATING'], { status: 'FAILED', error: message.slice(0, 2_000) });
@@ -515,12 +521,143 @@ export class WorkspaceService {
     if (!Number.isSafeInteger(offset) || offset < 0) throw new HarnessError('INVALID_INPUT', 'invalid workspace cursor');
     const page = records.slice(offset, offset + limit);
     const next = offset + page.length < records.length ? String(offset + page.length) : undefined;
-    return { ok: true, message: 'Workspaces listed', data: { workspaces: page.map(publicRecord) }, truncated: false, ...(next ? { cursor: next } : {}) };
+    return { ok: true, message: 'Workspaces listed', data: { workspaces: page.map((rec) => this.publicWorkspaceRecord(rec)) }, truncated: false, ...(next ? { cursor: next } : {}) };
   }
 
   status(ownerId: string, workspaceId?: string): RunnerResponse {
     const record = this.requireWorkspace(ownerId, workspaceId, false, true);
-    return { ok: true, message: 'Workspace status', data: publicRecord(record), truncated: false };
+    return { ok: true, message: 'Workspace status', data: this.publicWorkspaceRecord(record), truncated: false };
+  }
+
+  publicWorkspaceRecord(record: WorkspaceRecord): Record<string, unknown> {
+    return publicRecord(record, this.computeWorkspaceCapabilities(record));
+  }
+
+  private extractRepositoryName(repositoryUrl: URL): string | null {
+    if (repositoryUrl.hostname.toLowerCase() !== 'github.com') return null;
+    const parts = repositoryUrl.pathname.replace(/^\//, '').replace(/\.git$/, '').split('/');
+    if (parts.length === 2 && parts[0] && parts[1]) {
+      return `${parts[0]}/${parts[1]}`;
+    }
+    return null;
+  }
+
+  computeWorkspaceCapabilities(record: WorkspaceRecord): WorkspaceCapabilityResult {
+    let repoName: string | null = null;
+    let isGitHub = false;
+    let owner = '';
+    let repository = '';
+    try {
+      const url = new URL(record.repositoryUrl);
+      if (url.hostname.toLowerCase() === 'github.com') {
+        isGitHub = true;
+        const parts = url.pathname.replace(/^\//, '').replace(/\.git$/, '').split('/');
+        if (parts.length === 2 && parts[0] && parts[1]) {
+          owner = parts[0].toLowerCase();
+          repository = parts[1].toLowerCase();
+          repoName = `${parts[0]}/${parts[1]}`;
+        }
+      }
+    } catch {
+      // Ignore invalid url format fallback
+    }
+
+    const authMode = this.config.authMode ?? 'owner-bearer';
+    let contentsRead = true;
+    let contentsWrite = false;
+    let issuesRead = false;
+    let issuesWrite = false;
+    let pullRequestsRead = false;
+    let pullRequestsWrite = false;
+
+    if (authMode === 'cloudflare-access') {
+      if (this.githubInstallations && isGitHub && owner && repository) {
+        const grant = this.githubInstallations.getRepositoryGrant(record.ownerId, owner, repository);
+        if (grant && grant.status === 'granted') {
+          const installation = this.githubInstallations.getInstallation(record.ownerId, grant.installationId);
+          if (
+            installation &&
+            installation.status === 'active' &&
+            String(this.config.githubApp?.appId) === installation.appId
+          ) {
+            contentsRead = true;
+            contentsWrite = grant.contents === 'write';
+            issuesRead = true;
+            issuesWrite = grant.contents === 'write';
+            pullRequestsRead = true;
+            pullRequestsWrite = grant.contents === 'write';
+          }
+        }
+      }
+    } else {
+      // owner-bearer mode
+      if (isGitHub && this.config.githubApp?.installationId) {
+        contentsRead = true;
+        contentsWrite = true;
+        issuesRead = true;
+        issuesWrite = true;
+        pullRequestsRead = true;
+        pullRequestsWrite = true;
+      }
+    }
+
+    const privileged = authMode === 'cloudflare-access';
+
+    return {
+      workspaceId: record.id,
+      repository: repoName,
+      repositoryUrl: record.repositoryUrl,
+      capabilities: {
+        repository: {
+          read: contentsRead,
+          push: contentsWrite,
+          issuesRead,
+          issuesWrite,
+          pullRequestsRead,
+          pullRequestsWrite
+        },
+        workspace: {
+          shell: true,
+          tasks: true,
+          sessions: true,
+          deployments: true,
+          privileged,
+          networkMode: record.networkMode
+        }
+      },
+      permissions: {
+        contents: {
+          read: contentsRead,
+          write: contentsWrite
+        },
+        issues: {
+          read: issuesRead,
+          write: issuesWrite
+        },
+        pullRequests: {
+          read: pullRequestsRead,
+          write: pullRequestsWrite
+        }
+      },
+      operations: {
+        gitFetch: contentsRead,
+        gitPull: contentsRead,
+        gitPush: contentsWrite,
+        issueList: issuesRead,
+        issueView: issuesRead,
+        issueCreate: issuesWrite,
+        issueComment: issuesWrite,
+        issueUpdate: issuesWrite,
+        issuePublish: issuesWrite,
+        labelCreate: issuesWrite,
+        pullRequestList: pullRequestsRead,
+        pullRequestView: pullRequestsRead,
+        pullRequestCreate: pullRequestsWrite,
+        execRun: true,
+        privilegedExec: privileged,
+        deploymentsRun: true
+      }
+    };
   }
 
   private requireWorkspace(ownerId: string, workspaceId?: string, active = true, allowRecoverable = false): WorkspaceRecord {
@@ -797,8 +934,27 @@ export class WorkspaceService {
 
   private async remotePush(record: WorkspaceRecord, input: Record<string, unknown>, signal?: AbortSignal): Promise<RunnerResponse> {
     const repositoryUrl = await validateRepositoryUrl(record.repositoryUrl, this.config.allowedGitHosts);
-    const token = await this.repositoryToken(record.ownerId, repositoryUrl, 'write');
-    if (!token) throw new HarnessError('UNAVAILABLE', 'Git push requires a configured GitHub App with repository write access', 503, false);
+    const repoStr = this.extractRepositoryName(repositoryUrl);
+    let token: string | undefined;
+    try {
+      token = await this.repositoryToken(record.ownerId, repositoryUrl, 'write');
+    } catch (err: unknown) {
+      if (err instanceof HarnessError && (err.code === 'FORBIDDEN' || err.code === 'REPOSITORY_OPERATION_NOT_AUTHORIZED')) {
+        throw new HarnessError('REPOSITORY_OPERATION_NOT_AUTHORIZED', err.message, 403, false, {
+          operation: 'git_push',
+          repository: repoStr ?? undefined,
+          requiredCapability: 'repository.push'
+        });
+      }
+      throw err;
+    }
+    if (!token) {
+      throw new HarnessError('REPOSITORY_OPERATION_NOT_AUTHORIZED', 'Git push requires a configured GitHub App with repository write access', 403, false, {
+        operation: 'git_push',
+        repository: repoStr ?? undefined,
+        requiredCapability: 'repository.push'
+      });
+    }
     const requestedRefspec = input.refspec as string | undefined;
     const branch = requestedRefspec ? '' : await this.currentBranch(record, signal);
     if (!requestedRefspec && !branch) throw new HarnessError('CONFLICT', 'git_push requires refspec when HEAD is detached', 409, false);
@@ -998,17 +1154,43 @@ export class WorkspaceService {
   ): Promise<RunnerResponse> {
     const isWrite = ['pr_create', 'pr_update', 'pr_comment', 'issue_create', 'issue_comment', 'issue_comment_update', 'label_create', 'issue_labels_add', 'issue_labels_remove', 'issue_update', 'issue_publish'].includes(action);
     const permissionScope = action.startsWith('pr_') ? 'pull_requests' : 'issues';
+    const requiredCapability = permissionScope === 'pull_requests'
+      ? (isWrite ? 'repository.pullRequestsWrite' : 'repository.pullRequestsRead')
+      : (isWrite ? 'repository.issuesWrite' : 'repository.issuesRead');
+    let repoUrl: URL;
+    try {
+      repoUrl = new URL(record.repositoryUrl);
+    } catch {
+      throw new HarnessError('INVALID_INPUT', 'Invalid repository URL');
+    }
+    const repoStr = this.extractRepositoryName(repoUrl);
 
-    const token = await mintPrincipalRepositoryScopedToken({
-      config: this.config,
-      principalId: record.ownerId,
-      repositoryUrl: new URL(record.repositoryUrl),
-      installations: this.githubInstallations,
-      permissionScope,
-      requiredPermission: isWrite ? 'write' : 'read'
-    });
+    let token: string | undefined;
+    try {
+      token = await mintPrincipalRepositoryScopedToken({
+        config: this.config,
+        principalId: record.ownerId,
+        repositoryUrl: repoUrl,
+        installations: this.githubInstallations,
+        permissionScope,
+        requiredPermission: isWrite ? 'write' : 'read'
+      });
+    } catch (err: unknown) {
+      if (err instanceof HarnessError && (err.code === 'FORBIDDEN' || err.code === 'REPOSITORY_OPERATION_NOT_AUTHORIZED')) {
+        throw new HarnessError('REPOSITORY_OPERATION_NOT_AUTHORIZED', err.message, 403, false, {
+          operation: `github_action.${action}`,
+          repository: repoStr ?? undefined,
+          requiredCapability
+        });
+      }
+      throw err;
+    }
     if (!token) {
-      throw new HarnessError('FORBIDDEN', `No GitHub App installation available for ${record.repositoryUrl}`, 403);
+      throw new HarnessError('REPOSITORY_OPERATION_NOT_AUTHORIZED', `No GitHub App installation available for ${record.repositoryUrl}`, 403, false, {
+        operation: `github_action.${action}`,
+        repository: repoStr ?? undefined,
+        requiredCapability
+      });
     }
 
     const helperName = `chm-gh-${record.id.slice(3, 15)}-${randomBytes(4).toString('hex')}`;
@@ -1201,6 +1383,16 @@ export class WorkspaceService {
 
     const workspaceId = validated.workspaceId as string | undefined;
     if (operation === 'workspace_status') return this.status(ownerId, workspaceId);
+    if (operation === 'workspace_capabilities') {
+      const rec = this.requireWorkspace(ownerId, workspaceId, false, true);
+      const caps = this.computeWorkspaceCapabilities(rec);
+      return {
+        ok: true,
+        message: 'Workspace capabilities retrieved',
+        data: caps,
+        truncated: false
+      };
+    }
     if (operation === 'workspace_close') {
       const rec = this.requireWorkspace(ownerId, workspaceId, false, true);
       return await this.close(ownerId, rec.id);
@@ -1398,13 +1590,17 @@ export class WorkspaceService {
         name: record.gitAuthorName || 'Cloud Harness Agent',
         email: record.gitAuthorEmail || 'agent@cloud-harness.local'
       };
+      const caps = this.computeWorkspaceCapabilities(record);
       return {
         ok: true,
         message: 'Workspace context',
         data: {
-          workspace: publicRecord(record),
+          workspace: this.publicWorkspaceRecord(record),
           branch,
-          gitIdentity
+          gitIdentity,
+          capabilities: caps.capabilities,
+          permissions: caps.permissions,
+          operations: caps.operations
         },
         truncated: false
       };
@@ -1488,11 +1684,23 @@ export class WorkspaceService {
               pushed = Boolean(pushResult.ok);
             } catch (err: unknown) {
               const pushErrMsg = err instanceof Error ? err.message : 'push failed';
+              const errorCode = err instanceof HarnessError ? err.code : 'UNAVAILABLE';
+              const retryable = err instanceof HarnessError ? err.retryable : true;
+              const operationDetail = err instanceof HarnessError ? err.operation : undefined;
+              const repositoryDetail = err instanceof HarnessError ? err.repository : undefined;
+              const requiredCapDetail = err instanceof HarnessError ? err.requiredCapability : undefined;
               return {
                 ok: false,
                 message: `Working tree clean but push failed: ${pushErrMsg}`,
                 data: { step: 'push', commitSha, branch, pushed: false, pushError: pushErrMsg, resumeAction: 'Call git_push or workspace_finalize to retry push' },
-                error: { code: 'UNAVAILABLE', message: pushErrMsg, retryable: true },
+                error: {
+                  code: errorCode,
+                  message: pushErrMsg,
+                  retryable,
+                  operation: operationDetail,
+                  repository: repositoryDetail,
+                  requiredCapability: requiredCapDetail
+                },
                 truncated: false
               };
             }
@@ -1558,6 +1766,11 @@ export class WorkspaceService {
             pushed = Boolean(pushResult.ok);
           } catch (pushErr: unknown) {
             const pushErrMsg = pushErr instanceof Error ? pushErr.message : 'push failed';
+            const errorCode = pushErr instanceof HarnessError ? pushErr.code : 'UNAVAILABLE';
+            const retryable = pushErr instanceof HarnessError ? pushErr.retryable : true;
+            const operationDetail = pushErr instanceof HarnessError ? pushErr.operation : undefined;
+            const repositoryDetail = pushErr instanceof HarnessError ? pushErr.repository : undefined;
+            const requiredCapDetail = pushErr instanceof HarnessError ? pushErr.requiredCapability : undefined;
             return {
               ok: false,
               message: `Commit created (${commitSha.slice(0, 7)}) but push failed: ${pushErrMsg}`,
@@ -1569,7 +1782,14 @@ export class WorkspaceService {
                 pushError: pushErrMsg,
                 resumeAction: 'Call git_push or workspace_finalize to retry push'
               },
-              error: { code: 'UNAVAILABLE', message: pushErrMsg, retryable: true },
+              error: {
+                code: errorCode,
+                message: pushErrMsg,
+                retryable,
+                operation: operationDetail,
+                repository: repositoryDetail,
+                requiredCapability: requiredCapDetail
+              },
               truncated: false
             };
           }

--- a/apps/runner/test/brokered-github-operations.test.ts
+++ b/apps/runner/test/brokered-github-operations.test.ts
@@ -288,7 +288,7 @@ describe('Brokered GitHub Issues and Pull Request Operations', () => {
     expect(args).toContain('not_planned');
   });
 
-  it('throws FORBIDDEN when no GitHub App token can be minted for the workspace', async () => {
+  it('throws REPOSITORY_OPERATION_NOT_AUTHORIZED when no GitHub App token can be minted for the workspace', async () => {
     const { config, store, workspaceId, principalSelector } = fixture();
     const emptyInstallations = new InMemoryGitHubInstallationStore();
     const service = new WorkspaceService(config, store, undefined, emptyInstallations);
@@ -298,6 +298,10 @@ describe('Brokered GitHub Issues and Pull Request Operations', () => {
     await expect(service.execute(principalSelector, 'github_action', {
       workspaceId,
       action: 'pr_list'
-    })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    })).rejects.toMatchObject({
+      code: 'REPOSITORY_OPERATION_NOT_AUTHORIZED',
+      operation: 'github_action.pr_list',
+      requiredCapability: 'repository.pullRequestsRead'
+    });
   });
 });

--- a/apps/runner/test/workspace-capabilities.test.ts
+++ b/apps/runner/test/workspace-capabilities.test.ts
@@ -1,0 +1,271 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HarnessError, type RunnerConfig } from '@cloud-harness/contracts';
+import { InMemoryGitHubInstallationStore } from '../src/github-installation-store.js';
+import { StateStore, type WorkspaceRecord } from '../src/state-store.js';
+
+const docker = vi.hoisted(() => ({
+  runDocker: vi.fn(async (args: string[]) => {
+    if (args.includes('/opt/harness/worker-runner.sh')) {
+      return { stdout: JSON.stringify({ ok: true, message: 'worker complete', data: { output: 'ok' }, truncated: false }), stderr: '', exitCode: 0, truncated: false };
+    }
+    if (args.includes('branch') && args.includes('--show-current')) {
+      return { stdout: 'main\n', stderr: '', exitCode: 0, truncated: false };
+    }
+    if (args.includes('/opt/harness/git-transfer-helper.sh')) {
+      return { stdout: 'push-ok', stderr: '', exitCode: 0, truncated: false };
+    }
+    return { stdout: '', stderr: '', exitCode: 0, truncated: false };
+  }),
+  removeContainer: vi.fn(async () => undefined),
+  inspectContainer: vi.fn(async () => undefined),
+  terminateContainerProcessGroup: vi.fn(async () => undefined)
+}));
+
+const broker = vi.hoisted(() => ({
+  mintRepositoryToken: vi.fn(async () => undefined),
+  mintPrincipalRepositoryToken: vi.fn(),
+  mintPrincipalRepositoryScopedToken: vi.fn()
+}));
+
+vi.mock('../src/docker-engine.js', () => docker);
+vi.mock('../src/github-app-broker.js', () => broker);
+vi.mock('../src/repository-policy.js', () => ({ validateRepositoryUrl: vi.fn(async (value: string) => new URL(value)) }));
+
+import { WorkspaceService } from '../src/workspace-service.js';
+
+const temporaryDirectories: string[] = [];
+const openStores: StateStore[] = [];
+
+afterEach(() => {
+  vi.clearAllMocks();
+  for (const store of openStores.splice(0)) {
+    try { store.close(); } catch { /* ignore */ }
+  }
+  for (const path of temporaryDirectories.splice(0)) {
+    try { rmSync(path, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+function createFixture(options: { authMode?: 'owner-bearer' | 'cloudflare-access'; githubApp?: RunnerConfig['githubApp'] } = {}) {
+  const directory = mkdtempSync(join(tmpdir(), 'ch-cap-test-'));
+  temporaryDirectories.push(directory);
+  const workspaceId = `ws_${'c'.repeat(24)}`;
+  const workspacePath = join(directory, 'jobs', workspaceId);
+  mkdirSync(join(workspacePath, 'repo'), { recursive: true });
+
+  const config: RunnerConfig = {
+    authMode: options.authMode ?? 'owner-bearer',
+    host: '127.0.0.1',
+    port: 3001,
+    serviceToken: 'runner-token-that-is-longer-than-32-characters',
+    jobsRoot: join(directory, 'jobs'),
+    stateDb: join(directory, 'state.db'),
+    executorImage: 'executor',
+    allowedGitHosts: ['github.com'],
+    networkMode: 'none',
+    wallTtlSeconds: 300,
+    idleTtlSeconds: 180,
+    maxOutputBytes: 262_144,
+    minFreeBytes: 0,
+    maxWorkspaceBytes: 1_048_576,
+    reaperIntervalSeconds: 30,
+    githubApp: options.githubApp
+  };
+
+  const store = new StateStore(config.stateDb);
+  openStores.push(store);
+  const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'principal_1' });
+  const installations = new InMemoryGitHubInstallationStore();
+  const service = new WorkspaceService(config, store, undefined, installations);
+  const now = Date.now();
+  const record: WorkspaceRecord = {
+    id: workspaceId,
+    ownerId,
+    idempotencyKey: 'idemp-1',
+    repositoryUrl: 'https://github.com/test-org/test-repo.git',
+    repositoryRef: 'main',
+    containerName: 'cont_1',
+    workspacePath,
+    status: 'ACTIVE',
+    networkMode: 'none',
+    createdAt: now,
+    lastActivityAt: now,
+    expiresAt: now + 180_000,
+    hardExpiresAt: now + 300_000,
+    gitAuthorName: 'Test Dev',
+    gitAuthorEmail: 'dev@test.org',
+    mutationLockedUntil: null,
+    generation: 1,
+    error: null
+  };
+  store.create(record);
+
+  return { config, store, installations, service, record, workspaceId, ownerId };
+}
+
+describe('Workspace Capabilities and Authorization Preflight', () => {
+  it('computes full write capabilities in owner-bearer mode when githubApp installation is configured', async () => {
+    const { service, workspaceId } = createFixture({
+      authMode: 'owner-bearer',
+      githubApp: {
+        appId: 123,
+        installationId: 456,
+        privateKey: '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----',
+        appSlug: 'test-app'
+      }
+    });
+
+    const res = await service.execute('principal_1', 'workspace_capabilities', { workspaceId });
+    expect(res.ok).toBe(true);
+    const data = res.data as Record<string, unknown>;
+    expect(data.workspaceId).toBe(workspaceId);
+    expect(data.repository).toBe('test-org/test-repo');
+
+    const capabilities = data.capabilities as { repository: Record<string, boolean>; workspace: Record<string, unknown> };
+    expect(capabilities.repository.read).toBe(true);
+    expect(capabilities.repository.push).toBe(true);
+    expect(capabilities.repository.issuesRead).toBe(true);
+    expect(capabilities.repository.issuesWrite).toBe(true);
+    expect(capabilities.repository.pullRequestsRead).toBe(true);
+    expect(capabilities.repository.pullRequestsWrite).toBe(true);
+
+    const permissions = data.permissions as { contents: { read: boolean; write: boolean }; issues: { read: boolean; write: boolean }; pullRequests: { read: boolean; write: boolean } };
+    expect(permissions.contents.read).toBe(true);
+    expect(permissions.contents.write).toBe(true);
+    expect(permissions.issues.write).toBe(true);
+    expect(permissions.pullRequests.write).toBe(true);
+
+    const operations = data.operations as Record<string, boolean>;
+    expect(operations.gitFetch).toBe(true);
+    expect(operations.gitPush).toBe(true);
+    expect(operations.issueCreate).toBe(true);
+    expect(operations.pullRequestCreate).toBe(true);
+  });
+
+  it('computes read-only capabilities in owner-bearer mode when no githubApp installation is configured', async () => {
+    const { service, workspaceId } = createFixture({
+      authMode: 'owner-bearer'
+    });
+
+    const res = await service.execute('principal_1', 'workspace_capabilities', { workspaceId });
+    expect(res.ok).toBe(true);
+    const data = res.data as Record<string, unknown>;
+
+    const capabilities = data.capabilities as { repository: Record<string, boolean> };
+    expect(capabilities.repository.read).toBe(true);
+    expect(capabilities.repository.push).toBe(false);
+    expect(capabilities.repository.issuesRead).toBe(false);
+    expect(capabilities.repository.issuesWrite).toBe(false);
+    expect(capabilities.repository.pullRequestsRead).toBe(false);
+    expect(capabilities.repository.pullRequestsWrite).toBe(false);
+
+    const operations = data.operations as Record<string, boolean>;
+    expect(operations.gitPush).toBe(false);
+    expect(operations.issueCreate).toBe(false);
+    expect(operations.pullRequestCreate).toBe(false);
+  });
+
+  it('enforces structured error when git_push is attempted without write authorization', async () => {
+    const { service, workspaceId } = createFixture({
+      authMode: 'owner-bearer'
+    });
+
+    try {
+      await service.execute('principal_1', 'git_push', { workspaceId });
+      expect.unreachable('git_push should have thrown');
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(HarnessError);
+      const harnessErr = err as HarnessError;
+      expect(harnessErr.code).toBe('REPOSITORY_OPERATION_NOT_AUTHORIZED');
+      expect(harnessErr.operation).toBe('git_push');
+      expect(harnessErr.repository).toBe('test-org/test-repo');
+      expect(harnessErr.requiredCapability).toBe('repository.push');
+    }
+  });
+
+  it('computes permissions accurately in cloudflare-access mode based on repository grants', async () => {
+    const { service, installations, workspaceId, ownerId } = createFixture({
+      authMode: 'cloudflare-access',
+      githubApp: {
+        appId: 100,
+        privateKey: 'key',
+        appSlug: 'test-app'
+      }
+    });
+
+    // 1. Initial state: no grant
+    const resNoGrant = await service.execute('principal_1', 'workspace_capabilities', { workspaceId });
+    const dataNoGrant = resNoGrant.data as { capabilities: { repository: Record<string, boolean> } };
+    expect(dataNoGrant.capabilities.repository.push).toBe(false);
+    expect(dataNoGrant.capabilities.repository.issuesWrite).toBe(false);
+
+    // 2. Add verified read-only grant
+    installations.replaceVerified(ownerId, {
+      appId: 100,
+      installationId: 'inst_1',
+      accountId: 'acc_1',
+      accountLogin: 'test-org',
+      status: 'active',
+      repositories: [
+        { owner: 'test-org', repository: 'test-repo', contents: 'read' }
+      ]
+    }, Date.now());
+
+    const resReadGrant = await service.execute('principal_1', 'workspace_capabilities', { workspaceId });
+    const dataReadGrant = resReadGrant.data as { capabilities: { repository: Record<string, boolean> } };
+    expect(dataReadGrant.capabilities.repository.read).toBe(true);
+    expect(dataReadGrant.capabilities.repository.push).toBe(false);
+    expect(dataReadGrant.capabilities.repository.issuesRead).toBe(true);
+    expect(dataReadGrant.capabilities.repository.issuesWrite).toBe(false);
+
+    // 3. Update to write grant
+    installations.replaceVerified(ownerId, {
+      appId: 100,
+      installationId: 'inst_1',
+      accountId: 'acc_1',
+      accountLogin: 'test-org',
+      status: 'active',
+      repositories: [
+        { owner: 'test-org', repository: 'test-repo', contents: 'write' }
+      ]
+    }, Date.now());
+
+    const resWriteGrant = await service.execute('principal_1', 'workspace_capabilities', { workspaceId });
+    const dataWriteGrant = resWriteGrant.data as { capabilities: { repository: Record<string, boolean> } };
+    expect(dataWriteGrant.capabilities.repository.read).toBe(true);
+    expect(dataWriteGrant.capabilities.repository.push).toBe(true);
+    expect(dataWriteGrant.capabilities.repository.issuesRead).toBe(true);
+    expect(dataWriteGrant.capabilities.repository.issuesWrite).toBe(true);
+    expect(dataWriteGrant.capabilities.repository.pullRequestsRead).toBe(true);
+    expect(dataWriteGrant.capabilities.repository.pullRequestsWrite).toBe(true);
+  });
+
+  it('enriches workspace_status and workspace_context with capabilities', async () => {
+    const { service, workspaceId } = createFixture({
+      authMode: 'owner-bearer',
+      githubApp: {
+        appId: 123,
+        installationId: 456,
+        privateKey: 'key',
+        appSlug: 'slug'
+      }
+    });
+
+    const statusRes = await service.execute('principal_1', 'workspace_status', { workspaceId });
+    expect(statusRes.ok).toBe(true);
+    const statusData = statusRes.data as Record<string, unknown>;
+    expect(statusData.capabilities).toBeDefined();
+    expect((statusData.capabilities as { repository: Record<string, boolean> }).repository.push).toBe(true);
+    expect(statusData.permissions).toBeDefined();
+    expect(statusData.operations).toBeDefined();
+
+    const contextRes = await service.execute('principal_1', 'workspace_context', { workspaceId });
+    expect(contextRes.ok).toBe(true);
+    const contextData = contextRes.data as Record<string, unknown>;
+    expect(contextData.capabilities).toBeDefined();
+    expect((contextData.capabilities as { repository: Record<string, boolean> }).repository.push).toBe(true);
+  });
+});

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -34,7 +34,7 @@
 - [Profile & Themes](https://docs.harness.agentkit.best/dashboard/profile.md): Account details and appearance settings.
 
 ## Technical References
-- [Tools Reference](https://docs.harness.agentkit.best/reference/tools.md): Complete catalog of 64 MCP tools.
+- [Tools Reference](https://docs.harness.agentkit.best/reference/tools.md): Complete catalog of 65 MCP tools.
 - [Environment Variables](https://docs.harness.agentkit.best/reference/environment-variables.md): Configuration reference.
 - [Git Transfer Semantics](https://docs.harness.agentkit.best/reference/git-transfer.md): Origin-only push/fetch/pull helper.
 - [Sessions & Tasks](https://docs.harness.agentkit.best/reference/sessions-and-tasks.md): PTY shells, sessions, and task DAGs.

--- a/docs-site/reference/tools.md
+++ b/docs-site/reference/tools.md
@@ -1,6 +1,6 @@
 ---
 title: Tools Reference
-description: Complete machine-generated reference of all 64 MCP tools provided by Cloud Harness MCP.
+description: Complete machine-generated reference of all 65 MCP tools provided by Cloud Harness MCP.
 ---
 
 # Tools Reference
@@ -11,7 +11,7 @@ description: Complete machine-generated reference of all 64 MCP tools provided b
   <strong>AI Crawler / Raw View:</strong> Fetch this page as raw Markdown at <code>/reference/tools.md</code>.
 </div>
 
-Cloud Harness MCP exposes **64 tools** across six operational domains. Every tool executes strictly inside a sandboxed, TTL-limited Docker container with non-root privileges and default network isolation.
+Cloud Harness MCP exposes **65 tools** across six operational domains. Every tool executes strictly inside a sandboxed, TTL-limited Docker container with non-root privileges and default network isolation.
 
 ## Security & Capability Badges
 
@@ -67,6 +67,57 @@ Read the lifecycle state and metadata for one workspace.
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+
+### `workspace_capabilities`
+
+**Workspace capabilities**
+
+Inspect workspace and repository authorization capabilities without modifying state or minting tokens.
+
+**Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+
+### `workspace_context`
+
+**Workspace context**
+
+Read the active workspace ID, branch, lease time, Git identity, and repository overview.
+
+**Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+
+### `workspace_lease_renew`
+
+**Renew workspace lease**
+
+Explicitly renew the workspace idle lease duration or reactivate a recoverable expired workspace.
+
+**Attributes:** `idempotent`
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `extensionSeconds` | `integer` | No | range: 60–86400 |
+
+### `workspace_recover`
+
+**Recover workspace state**
+
+Recover a recoverable expired workspace to active state, or inspect, patch, or export unpushed work.
+
+**Attributes:** <span class="badge-destructive">destructive</span>
+
+| Parameter | Type | Required | Constraints & Notes |
+|---|---|---|---|
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `mode` | `"resume"` \| `"status"` \| `"patch"` \| `"export"` | **Yes** | default: `"resume"` |
+| `targetBranch` | `string` | No | length: 1–255 |
 
 ### `workspace_close`
 
@@ -829,45 +880,6 @@ Execute one named repository-defined deployment target with external-effect risk
 | `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
 
 ## Additional Tools
-
-### `workspace_lease_renew`
-
-**Renew workspace lease**
-
-Explicitly renew the workspace idle lease duration or reactivate a recoverable expired workspace.
-
-**Attributes:** `idempotent`
-
-| Parameter | Type | Required | Constraints & Notes |
-|---|---|---|---|
-| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `extensionSeconds` | `integer` | No | range: 60–86400 |
-
-### `workspace_recover`
-
-**Recover workspace state**
-
-Recover a recoverable expired workspace to active state, or inspect, patch, or export unpushed work.
-
-**Attributes:** <span class="badge-destructive">destructive</span>
-
-| Parameter | Type | Required | Constraints & Notes |
-|---|---|---|---|
-| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `mode` | `"resume"` \| `"status"` \| `"patch"` \| `"export"` | **Yes** | default: `"resume"` |
-| `targetBranch` | `string` | No | length: 1–255 |
-
-### `workspace_context`
-
-**Workspace context**
-
-Read the active workspace ID, branch, lease time, Git identity, and repository overview.
-
-**Attributes:** <span class="badge-ro">readOnly</span> · `idempotent`
-
-| Parameter | Type | Required | Constraints & Notes |
-|---|---|---|---|
-| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 
 ### `workspace_set_active`
 

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -192,7 +192,7 @@ command, repository, network mode, or workspace changes.
 When running Cloud Harness MCP over local stdio (`--transport stdio --workspace <path>`):
 
 1. **Pre-opened workspace:** The workspace is configured at process startup. Calling `workspace_open` returns `INVALID_INPUT` explaining that the workspace is already selected.
-2. **Lifecycle operations:** `workspace_list` lists the active local workspace. `workspace_status` returns capabilities (`mode: 'local'`, `gitNetwork`, `gitPush`, `sandboxed: false`). `workspace_close` terminates owned child processes but **never deletes the local folder**.
+2. **Lifecycle operations:** `workspace_list` lists the active local workspace. `workspace_status` and `workspace_capabilities` return structured repository and workspace capabilities (`mode: 'local'`, `gitNetwork`, `gitPush`, `sandboxed: false`, granular operations and permissions). `workspace_close` terminates owned child processes but **never deletes the local folder**.
 3. **Subprocess execution:** `exec_run`, `shell_*`, `sessions_*`, and `tasks_*` execute on the local host with the current user's permissions. Output is bounded by ring buffers and paginated with monotonic cursors.
 4. **Gated capabilities:** `git_fetch` and `git_pull` require `--git-network`. `git_push` requires `--git-push`. `github_action` and `exec_run.privileged=true` return structured unsupported errors.
 5. **Filesystem operations:** File reading, writing, patching, deletion, and searching apply within the canonical workspace root. Traversal escapes are rejected.
@@ -217,7 +217,11 @@ is absent from Docker arguments, the checkout remote, result envelopes, and the
 long-lived executor. Public clone/fetch/pull can proceed without an App token.
 Private clone/fetch/pull require repository Contents read access, while every
 push requires a configured App installation with Contents read and write
-access. The broker and leak boundary are owned by
+access. `workspace_capabilities` and `workspace_status` expose structured preflight
+information (`capabilities.repository`, `permissions`, `operations`) so clients can
+verify whether operations like `git_push` or GitHub actions are authorized before
+starting work. Unauthorized repository operations fail with `REPOSITORY_OPERATION_NOT_AUTHORIZED`
+identifying the missing capability. The broker and leak boundary are owned by
 [`apps/runner/src/github-app-broker.ts`](../apps/runner/src/github-app-broker.ts),
 [`apps/runner/test/git-transfer-leak.test.ts`](../apps/runner/test/git-transfer-leak.test.ts),
 and

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -264,3 +264,14 @@ Local stdio mode intentionally alters the trust boundary compared to the remote 
 ### Unsupported capabilities
 
 - `exec_run` with `privileged: true` and `github_action` are unsupported in local v1 and return immediate structured capability errors.
+
+## Repository capability introspection and authorization preflight
+
+To prevent late-stage workflow failures where an agent completes extensive edits before discovering that pushing or publishing is unauthorized, Cloud Harness exposes preflight authorization state:
+
+- **`workspace_capabilities` and `workspace_status`:** Inspectable at any point without modifying state, minting tokens, or launching containers. Returns structured `capabilities.repository` (`read`, `push`, `issuesRead`, `issuesWrite`, `pullRequestsRead`, `pullRequestsWrite`), `permissions`, and `operations`.
+- **Policy-driven derivation:** Capabilities reflect Cloud Harness security policy:
+  - In `owner-bearer` mode, write capabilities require a configured GitHub App installation on GitHub repositories.
+  - In `cloudflare-access` mode, write capabilities are derived from verified GitHub App installation grants bound to the authenticated principal.
+  - In local stdio mode, capabilities reflect explicit operator flags (`--git-push`, `--git-network`).
+- **Structured denial error:** Unauthorized operations reject immediately with `REPOSITORY_OPERATION_NOT_AUTHORIZED` (403, non-retryable) indicating the exact `operation`, `repository`, and `requiredCapability` (e.g. `repository.push`, `repository.issuesWrite`, `repository.pullRequestsWrite`).

--- a/packages/contracts/src/mcp-results.ts
+++ b/packages/contracts/src/mcp-results.ts
@@ -12,7 +12,8 @@ export const ErrorCodeSchema = z.enum([
   'CANCELLED',
   'UNAVAILABLE',
   'INTERNAL_ERROR',
-  'PRIVILEGE_APPROVAL_REQUIRED'
+  'PRIVILEGE_APPROVAL_REQUIRED',
+  'REPOSITORY_OPERATION_NOT_AUTHORIZED'
 ]);
 export type ErrorCode = z.infer<typeof ErrorCodeSchema>;
 export const ToolResultSchema = z.object({
@@ -34,7 +35,10 @@ export const ToolResultSchema = z.object({
           cwd: z.string().optional(),
           expiresAt: z.string()
         })
-        .optional()
+        .optional(),
+      operation: z.string().optional(),
+      repository: z.string().optional(),
+      requiredCapability: z.string().optional()
     })
     .optional(),
   truncated: z.boolean().default(false),
@@ -44,12 +48,30 @@ export const ToolResultSchema = z.object({
 export type ToolResult = z.infer<typeof ToolResultSchema>;
 
 export class HarnessError extends Error {
+  public readonly operation?: string | undefined;
+  public readonly repository?: string | undefined;
+  public readonly requiredCapability?: string | undefined;
+
   constructor(
     public readonly code: z.infer<typeof ErrorCodeSchema>,
     message: string,
     public readonly status = 400,
-    public readonly retryable = false
+    public readonly retryable = false,
+    details?: {
+      operation?: string | undefined;
+      repository?: string | undefined;
+      requiredCapability?: string | undefined;
+    }
   ) {
     super(message);
+    if (details?.operation !== undefined) {
+      this.operation = details.operation;
+    }
+    if (details?.repository !== undefined) {
+      this.repository = details.repository;
+    }
+    if (details?.requiredCapability !== undefined) {
+      this.requiredCapability = details.requiredCapability;
+    }
   }
 }

--- a/packages/contracts/src/runner-api.ts
+++ b/packages/contracts/src/runner-api.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { ToolResultSchema } from './mcp-results.js';
 
 export const RunnerOperationSchema = z.enum([
-  'workspace_open', 'workspace_list', 'workspace_status', 'workspace_close',
+  'workspace_open', 'workspace_list', 'workspace_status', 'workspace_capabilities', 'workspace_close',
   'workspace_lease_renew', 'workspace_recover', 'workspace_context', 'workspace_set_active',
   'workspace_finalize',
   'files_list', 'files_read', 'files_write', 'files_write_batch', 'files_apply_patch', 'files_delete', 'files_move', 'files_mkdir', 'grep_search',
@@ -50,3 +50,64 @@ export type ExternalPrincipal = z.infer<typeof ExternalPrincipalSchema>;
 export type RunnerPrincipalSelector = z.infer<typeof RunnerPrincipalSelectorSchema>;
 export type RunnerRequest = z.infer<typeof RunnerRequestSchema>;
 export type RunnerResponse = z.infer<typeof RunnerResponseSchema>;
+
+export const RepositoryCapabilitiesSchema = z.object({
+  read: z.boolean(),
+  push: z.boolean(),
+  issuesRead: z.boolean(),
+  issuesWrite: z.boolean(),
+  pullRequestsRead: z.boolean(),
+  pullRequestsWrite: z.boolean()
+}).strict();
+
+export const WorkspaceCapabilitiesSchema = z.object({
+  shell: z.boolean(),
+  tasks: z.boolean(),
+  sessions: z.boolean(),
+  deployments: z.boolean(),
+  privileged: z.boolean().default(false),
+  networkMode: z.string()
+}).passthrough();
+
+export const RepositoryPermissionsSchema = z.object({
+  contents: z.object({ read: z.boolean(), write: z.boolean() }).strict(),
+  issues: z.object({ read: z.boolean(), write: z.boolean() }).strict(),
+  pullRequests: z.object({ read: z.boolean(), write: z.boolean() }).strict()
+}).strict();
+
+export const RepositoryOperationsSchema = z.object({
+  gitFetch: z.boolean(),
+  gitPull: z.boolean(),
+  gitPush: z.boolean(),
+  issueList: z.boolean(),
+  issueView: z.boolean(),
+  issueCreate: z.boolean(),
+  issueComment: z.boolean(),
+  issueUpdate: z.boolean(),
+  issuePublish: z.boolean(),
+  labelCreate: z.boolean(),
+  pullRequestList: z.boolean(),
+  pullRequestView: z.boolean(),
+  pullRequestCreate: z.boolean(),
+  execRun: z.boolean(),
+  privilegedExec: z.boolean(),
+  deploymentsRun: z.boolean()
+}).passthrough();
+
+export const WorkspaceCapabilityResultSchema = z.object({
+  workspaceId: z.string(),
+  repository: z.string().nullable(),
+  repositoryUrl: z.string(),
+  capabilities: z.object({
+    repository: RepositoryCapabilitiesSchema,
+    workspace: WorkspaceCapabilitiesSchema
+  }).passthrough(),
+  permissions: RepositoryPermissionsSchema,
+  operations: RepositoryOperationsSchema
+}).passthrough();
+
+export type RepositoryCapabilities = z.infer<typeof RepositoryCapabilitiesSchema>;
+export type WorkspaceCapabilities = z.infer<typeof WorkspaceCapabilitiesSchema>;
+export type RepositoryPermissions = z.infer<typeof RepositoryPermissionsSchema>;
+export type RepositoryOperations = z.infer<typeof RepositoryOperationsSchema>;
+export type WorkspaceCapabilityResult = z.infer<typeof WorkspaceCapabilityResultSchema>;

--- a/packages/contracts/src/tool-schemas.ts
+++ b/packages/contracts/src/tool-schemas.ts
@@ -35,6 +35,7 @@ const schemas = {
   }),
   workspace_list: z.object(pagination),
   workspace_status: z.object(workspace),
+  workspace_capabilities: z.object(workspace),
   workspace_close: z.object(workspace),
   workspace_lease_renew: z.object({ ...workspace, extensionSeconds: z.number().int().min(60).max(86_400).optional() }),
   workspace_recover: z.object({ ...workspace, mode: z.enum(['resume', 'status', 'patch', 'export']).default('resume'), targetBranch: gitArgument.optional() }),
@@ -309,7 +310,7 @@ export type ToolSpec = {
 };
 
 const titles: Record<RunnerOperation, string> = {
-  workspace_open: 'Open workspace', workspace_list: 'List workspaces', workspace_status: 'Workspace status', workspace_close: 'Close workspace',
+  workspace_open: 'Open workspace', workspace_list: 'List workspaces', workspace_status: 'Workspace status', workspace_capabilities: 'Workspace capabilities', workspace_close: 'Close workspace',
   workspace_lease_renew: 'Renew workspace lease', workspace_recover: 'Recover workspace state', workspace_context: 'Workspace context', workspace_set_active: 'Set active workspace',
   workspace_finalize: 'Finalize workspace commit and push',
   files_list: 'List files', files_read: 'Read file', files_write: 'Write file', files_write_batch: 'Write batch files', files_apply_patch: 'Apply text patch', files_delete: 'Delete file or directory', files_move: 'Move file or directory', files_mkdir: 'Create directory', grep_search: 'Search workspace',
@@ -330,6 +331,7 @@ const descriptions: Record<RunnerOperation, string> = {
   workspace_open: 'Clone an approved HTTPS repository and start an owner-bound, TTL-limited coding workspace.',
   workspace_list: 'List owner-visible workspace records with bounded cursor pagination.',
   workspace_status: 'Read the lifecycle state and metadata for one workspace.',
+  workspace_capabilities: 'Inspect workspace and repository authorization capabilities without modifying state or minting tokens.',
   workspace_close: 'Stop a workspace executor and permanently remove all workspace files, including unpushed commits.',
   workspace_lease_renew: 'Explicitly renew the workspace idle lease duration or reactivate a recoverable expired workspace.',
   workspace_recover: 'Recover a recoverable expired workspace to active state, or inspect, patch, or export unpushed work.',
@@ -394,7 +396,7 @@ const descriptions: Record<RunnerOperation, string> = {
 };
 
 const readOnly = new Set<RunnerOperation>([
-  'workspace_list', 'workspace_status', 'workspace_context',
+  'workspace_list', 'workspace_status', 'workspace_capabilities', 'workspace_context',
   'files_list', 'files_read', 'grep_search', 'symbols_search', 'symbols_references',
   'sessions_list', 'tasks_list', 'tasks_status', 'tasks_graph',
   'operation_status', 'operation_wait',
@@ -410,7 +412,7 @@ const destructive = new Set<RunnerOperation>([
   'worktrees_remove', 'skills_run', 'hooks_run', 'memories_write', 'deployments_run', 'github_action'
 ]);
 const idempotent = new Set<RunnerOperation>([
-  'workspace_open', 'workspace_list', 'workspace_status', 'workspace_close', 'workspace_lease_renew', 'workspace_context', 'workspace_set_active', 'workspace_finalize',
+  'workspace_open', 'workspace_list', 'workspace_status', 'workspace_capabilities', 'workspace_close', 'workspace_lease_renew', 'workspace_context', 'workspace_set_active', 'workspace_finalize',
   'files_list', 'files_read', 'files_write', 'files_write_batch', 'files_apply_patch', 'files_mkdir', 'grep_search', 'symbols_search', 'symbols_references',
   'shell_open', 'shell_close', 'sessions_list', 'sessions_open', 'sessions_close',
   'tasks_list', 'tasks_run', 'tasks_status', 'tasks_cancel', 'tasks_graph',

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { ApiConfigSchema, RunnerConfigSchema, RunnerRequestSchema, TOOL_SCHEMA_BY_NAME, WorkspaceIdSchema } from '../src/index.js';
-
+import {
+  ApiConfigSchema,
+  HarnessError,
+  RunnerConfigSchema,
+  RunnerRequestSchema,
+  TOOL_SCHEMA_BY_NAME,
+  ToolResultSchema,
+  WorkspaceCapabilityResultSchema,
+  WorkspaceIdSchema
+} from '../src/index.js';
 const commonApiConfig = {
   runnerToken: 'another-token-that-is-long-enough-1234',
   runnerUrl: 'http://runner:3001',
@@ -268,8 +276,7 @@ describe('contracts', () => {
     })).toMatchObject({ workspaceId: validWs, action: 'pr_list', limit: 5 });
   });
 
-  it('validates workspace lease renew, recovery, context, and git identity schemas', () => {
-    expect(TOOL_SCHEMA_BY_NAME.workspace_lease_renew.parse({})).toMatchObject({});
+  it('validates workspace lease renew, recovery, context, capabilities, and git identity schemas', () => {
     expect(TOOL_SCHEMA_BY_NAME.workspace_lease_renew.parse({ extensionSeconds: 3600 })).toMatchObject({ extensionSeconds: 3600 });
     expect(TOOL_SCHEMA_BY_NAME.workspace_recover.parse({})).toMatchObject({ mode: 'resume' });
     expect(TOOL_SCHEMA_BY_NAME.workspace_recover.parse({ mode: 'resume' })).toMatchObject({ mode: 'resume' });
@@ -277,7 +284,90 @@ describe('contracts', () => {
     expect(TOOL_SCHEMA_BY_NAME.workspace_recover.parse({ mode: 'status' })).toMatchObject({ mode: 'status' });
     expect(TOOL_SCHEMA_BY_NAME.workspace_recover.parse({ mode: 'export', targetBranch: 'backup' })).toMatchObject({ mode: 'export', targetBranch: 'backup' });
     expect(TOOL_SCHEMA_BY_NAME.workspace_context.parse({})).toBeDefined();
+    expect(TOOL_SCHEMA_BY_NAME.workspace_capabilities.parse({})).toBeDefined();
+    expect(TOOL_SCHEMA_BY_NAME.workspace_capabilities.parse({ workspaceId: 'ws_aaaaaaaaaaaaaaaaaaaa' })).toMatchObject({ workspaceId: 'ws_aaaaaaaaaaaaaaaaaaaa' });
     expect(TOOL_SCHEMA_BY_NAME.git_identity_status.parse({})).toBeDefined();
     expect(TOOL_SCHEMA_BY_NAME.git_identity_set.parse({ name: 'Dev', email: 'dev@example.com' })).toMatchObject({ name: 'Dev', email: 'dev@example.com' });
+  });
+
+  it('validates REPOSITORY_OPERATION_NOT_AUTHORIZED and structured error details', () => {
+    const errorResult = ToolResultSchema.parse({
+      ok: false,
+      message: 'Not authorized to push',
+      error: {
+        code: 'REPOSITORY_OPERATION_NOT_AUTHORIZED',
+        message: 'Git push is not authorized for repository',
+        retryable: false,
+        operation: 'git_push',
+        repository: 'owner/repo',
+        requiredCapability: 'repository.push'
+      }
+    });
+    expect(errorResult.error?.code).toBe('REPOSITORY_OPERATION_NOT_AUTHORIZED');
+    expect(errorResult.error?.operation).toBe('git_push');
+    expect(errorResult.error?.repository).toBe('owner/repo');
+    expect(errorResult.error?.requiredCapability).toBe('repository.push');
+
+    const err = new HarnessError('REPOSITORY_OPERATION_NOT_AUTHORIZED', 'Push forbidden', 403, false, {
+      operation: 'git_push',
+      repository: 'owner/repo',
+      requiredCapability: 'repository.push'
+    });
+    expect(err.code).toBe('REPOSITORY_OPERATION_NOT_AUTHORIZED');
+    expect(err.operation).toBe('git_push');
+    expect(err.repository).toBe('owner/repo');
+    expect(err.requiredCapability).toBe('repository.push');
+  });
+
+  it('validates capability result schemas', () => {
+    const parsed = WorkspaceCapabilityResultSchema.parse({
+      workspaceId: 'ws_123',
+      repository: 'owner/repo',
+      repositoryUrl: 'https://github.com/owner/repo',
+      capabilities: {
+        repository: {
+          read: true,
+          push: true,
+          issuesRead: false,
+          issuesWrite: false,
+          pullRequestsRead: false,
+          pullRequestsWrite: false
+        },
+        workspace: {
+          shell: true,
+          tasks: true,
+          sessions: true,
+          deployments: true,
+          privileged: false,
+          networkMode: 'none'
+        }
+      },
+      permissions: {
+        contents: { read: true, write: true },
+        issues: { read: false, write: false },
+        pullRequests: { read: false, write: false }
+      },
+      operations: {
+        gitFetch: true,
+        gitPull: true,
+        gitPush: true,
+        issueList: false,
+        issueView: false,
+        issueCreate: false,
+        issueComment: false,
+        issueUpdate: false,
+        issuePublish: false,
+        labelCreate: false,
+        pullRequestList: false,
+        pullRequestView: false,
+        pullRequestCreate: false,
+        execRun: true,
+        privilegedExec: false,
+        deploymentsRun: true
+      }
+    });
+    expect(parsed.capabilities.repository.push).toBe(true);
+    expect(parsed.permissions.contents.write).toBe(true);
+    expect(parsed.operations.gitPush).toBe(true);
   });
 });

--- a/plans/2026-08-29-104-add-repository-capability-and-authorization/phase-01-contracts-and-schemas.md
+++ b/plans/2026-08-29-104-add-repository-capability-and-authorization/phase-01-contracts-and-schemas.md
@@ -1,0 +1,23 @@
+# Phase 1: Contracts and Schemas
+
+## Objectives
+1. Add `REPOSITORY_OPERATION_NOT_AUTHORIZED` to `ErrorCodeSchema` in `packages/contracts/src/mcp-results.ts`.
+2. Extend `ToolResultSchema.error` with optional fields:
+   - `operation?: string`
+   - `repository?: string`
+   - `requiredCapability?: string`
+3. Update `HarnessError` to optionally accept structured error details (`operation`, `repository`, `requiredCapability`).
+4. Add `'workspace_capabilities'` to `RunnerOperationSchema` in `packages/contracts/src/runner-api.ts`.
+5. Add `workspace_capabilities` schema to `TOOL_SCHEMA_BY_NAME` in `packages/contracts/src/tool-schemas.ts`:
+   - `workspace_capabilities: z.object(workspace)`
+6. Add capability Zod schemas and TypeScript types in `@cloud-harness/contracts`:
+   - `RepositoryCapabilitiesSchema` / `RepositoryCapabilities`
+   - `WorkspaceCapabilitiesSchema` / `WorkspaceCapabilities`
+   - `RepositoryPermissionsSchema` / `RepositoryPermissions`
+   - `RepositoryOperationsSchema` / `RepositoryOperations`
+   - `WorkspaceCapabilityResultSchema` / `WorkspaceCapabilityResult`
+7. Update `TOOL_SPECS`, titles, descriptions, `readOnly` set, and `idempotent` set to include `workspace_capabilities`.
+8. Update contract unit tests in `packages/contracts/test/contracts.test.ts`.
+
+## Verification
+- `npm test -w @cloud-harness/contracts`

--- a/plans/2026-08-29-104-add-repository-capability-and-authorization/phase-02-runner-and-local-capabilities.md
+++ b/plans/2026-08-29-104-add-repository-capability-and-authorization/phase-02-runner-and-local-capabilities.md
@@ -1,0 +1,35 @@
+# Phase 2: Runner and Local Capability Resolution & Authorization Errors
+
+## Objectives
+1. Implement `computeWorkspaceCapabilities` helper in `apps/runner/src/workspace-service.ts`:
+   - Accepts `record: WorkspaceRecord` and optional principal identity.
+   - Parses repository URL (if GitHub: extracts `owner/repository`).
+   - Checks `authMode` (`owner-bearer` vs `cloudflare-access`).
+   - For `cloudflare-access`: queries `githubInstallations.getRepositoryGrant(ownerId, owner, repository)` and corresponding installation status and appId match.
+   - For `owner-bearer`: checks `config.githubApp.installationId`.
+   - Computes:
+     - `capabilities.repository`: `{ read, push, issuesRead, issuesWrite, pullRequestsRead, pullRequestsWrite }`
+     - `capabilities.workspace`: `{ shell: true, tasks: true, sessions: true, deployments: true, privileged: boolean, networkMode }`
+     - `permissions`: `{ contents: { read, write }, issues: { read, write }, pullRequests: { read, write } }`
+     - `operations`: `{ gitFetch, gitPull, gitPush, issueList, issueView, issueCreate, issueComment, issueUpdate, issuePublish, labelCreate, pullRequestList, pullRequestView, pullRequestCreate, execRun, privilegedExec, deploymentsRun }`
+2. Implement `workspace_capabilities` handler in `WorkspaceService.execute`.
+3. Enrich responses of `workspace_open`, `workspace_status`, and `workspace_context` with `capabilities`, `permissions`, and `operations`.
+4. Update `remotePush` and `runBrokeredGitHubAction` in `apps/runner/src/workspace-service.ts`:
+   - In `remotePush`: if token cannot be minted or push is not authorized, throw `HarnessError` with:
+     - `code: 'REPOSITORY_OPERATION_NOT_AUTHORIZED'` (or `'FORBIDDEN'` with details)
+     - `operation: 'git_push'`
+     - `repository: '${owner}/${repository}'`
+     - `requiredCapability: 'repository.push'`
+   - In `runBrokeredGitHubAction`: if token cannot be minted, return/throw structured error with:
+     - `operation: action`
+     - `repository: '${owner}/${repository}'`
+     - `requiredCapability: permissionScope === 'pull_requests' ? (isWrite ? 'repository.pullRequestsWrite' : 'repository.pullRequestsRead') : (isWrite ? 'repository.issuesWrite' : 'repository.issuesRead')`
+5. Implement `workspace_capabilities` in `apps/api/src/local/local-workspace-backend.ts`:
+   - Returns local capability matrix reflecting `options.gitPush` and `options.gitNetwork`.
+   - Returns structured error with `requiredCapability: 'repository.push'` when `git_push` is attempted without `--git-push`.
+   - Updates `workspace_status` to include the standard `capabilities`, `permissions`, and `operations` schema.
+6. Update `apps/api/src/mcp-response-text.ts`:
+   - If `error.requiredCapability` is present, format `(required capability: ${error.requiredCapability})` in human-readable text.
+
+## Verification
+- Unit and integration tests for runner and local capabilities.

--- a/plans/2026-08-29-104-add-repository-capability-and-authorization/phase-03-tests-and-verification.md
+++ b/plans/2026-08-29-104-add-repository-capability-and-authorization/phase-03-tests-and-verification.md
@@ -1,0 +1,24 @@
+# Phase 3: Tests and Verification
+
+## Objectives
+1. Contract tests in `packages/contracts/test/contracts.test.ts`:
+   - Validate `workspace_capabilities` schema accepts `{ workspaceId?: string }`.
+   - Validate `ErrorCodeSchema` accepts `'REPOSITORY_OPERATION_NOT_AUTHORIZED'`.
+   - Validate `ToolResultSchema` parses `error` with `operation`, `repository`, and `requiredCapability`.
+2. Unit tests in `apps/runner/test/workspace-capabilities.test.ts`:
+   - Test capability resolution in `owner-bearer` mode with GitHub App installation (push=true, PRs/issues=true).
+   - Test capability resolution in `owner-bearer` mode without GitHub App installation (push=false, PRs/issues=false).
+   - Test capability resolution in `cloudflare-access` mode with `write` grant (push=true, PRs/issues=true).
+   - Test capability resolution in `cloudflare-access` mode with `read` grant (push=false, PRs/issues=false).
+   - Test capability resolution in `cloudflare-access` mode with no grant (push=false, PRs/issues=false).
+   - Test `workspace_open`, `workspace_status`, and `workspace_context` response data contain capabilities.
+   - Test structured error when `git_push` is executed without write authorization (contains `code: 'REPOSITORY_OPERATION_NOT_AUTHORIZED'`, `operation: 'git_push'`, `requiredCapability: 'repository.push'`).
+   - Test structured error when `github_action` is executed without grant.
+3. Unit tests in `apps/api/test/local/local-capabilities.test.ts`:
+   - Test `workspace_capabilities` with `--git-push` enabled vs disabled.
+   - Test `workspace_capabilities` with `--git-network` enabled vs disabled.
+   - Test `git_push` unauthorized error returns structured error with `requiredCapability: 'repository.push'`.
+4. Run complete unit and integration tests (`npm test`).
+
+## Verification
+- `npm test` passing with 100% green tests across all suites.

--- a/plans/2026-08-29-104-add-repository-capability-and-authorization/phase-04-docs-and-skill-sync.md
+++ b/plans/2026-08-29-104-add-repository-capability-and-authorization/phase-04-docs-and-skill-sync.md
@@ -1,0 +1,21 @@
+# Phase 4: Documentation, Skill Sync, and Docs Reference
+
+## Objectives
+1. Update `docs/mcp-api.md`:
+   - Document `workspace_capabilities` tool in the tool inventory and lifecycle semantics.
+   - Document capability introspection in `workspace_open`, `workspace_status`, and `workspace_context`.
+   - Document structured authorization error format with `REPOSITORY_OPERATION_NOT_AUTHORIZED` and `requiredCapability`.
+2. Update `docs/security-model.md`:
+   - Document repository capability and preflight authorization model.
+3. Update `scripts/build-docs-reference.mjs`:
+   - Add `workspace_capabilities` to the `Workspace Lifecycle` category.
+4. Run `npm run docs:reference` to regenerate `docs-site/reference/tools.md` and `docs-site/public/llms.txt`.
+5. Update `.agents/skills/cloudharness/references/workspace-lifecycle-and-results.md`:
+   - Add `workspace_capabilities` tool documentation and example.
+6. Run `npm run plugin:sync` to synchronize `plugins/cloud-harness/skills/cloudharness`.
+7. Run `npm run verify` (checks plugin sync, lint, typecheck, tests, and build).
+
+## Verification
+- `npm run plugin:check`
+- `npm run docs:check` (if applicable)
+- `npm run verify`

--- a/plans/2026-08-29-104-add-repository-capability-and-authorization/plan.md
+++ b/plans/2026-08-29-104-add-repository-capability-and-authorization/plan.md
@@ -1,0 +1,73 @@
+# Plan: feat: add repository capability and authorization preflight (Issue #104)
+
+## Summary
+Add workspace and repository capability introspection and structured authorization preflight errors to Cloud Harness MCP. This enables AI coding agents to determine upfront whether repository write operations (such as `git_push`, pull request creation, and issue management) are authorized before performing expensive modification workflows, and ensures authorization denials provide structured, machine-readable error metadata.
+
+## Context & Architecture
+CloudHarness is a private, single-owner remote coding harness supporting both Docker-isolated remote runners (`WorkspaceService`) and local stdio execution (`LocalWorkspaceBackend`). Authorization relies on:
+1. Workspace execution policy and network mode (`none` vs `bridge` vs `host`).
+2. GitHub App credentials and principal-bound repository grants in `cloudflare-access` mode, or configured installation in `owner-bearer` mode.
+3. Local startup authorization flags (`--git-push`, `--git-network`) in local stdio mode.
+
+Prior to this feature, authorization was discovered lazily at operation execution time (e.g. `git_push` failing after changes were already committed). This plan adds:
+- `workspace_capabilities` MCP tool and capability introspection on `workspace_open`, `workspace_status`, and `workspace_context`.
+- High-level capability objects (`capabilities.repository`, `capabilities.workspace`) matching Issue #104 expected behavior.
+- Fine-grained permission and operation matrices (`permissions`, `operations`) matching Issue #104 suggested API.
+- Structured authorization error payload (`code: 'REPOSITORY_OPERATION_NOT_AUTHORIZED'`, `operation`, `repository`, `requiredCapability`) on operation denial.
+
+## Phases
+
+### Phase 1: Contracts and Schemas
+- Add `'REPOSITORY_OPERATION_NOT_AUTHORIZED'` to `ErrorCodeSchema` in `packages/contracts/src/mcp-results.ts`.
+- Extend `ToolResultSchema.error` with optional `operation`, `repository`, `requiredCapability` fields.
+- Update `HarnessError` to optionally accept structured error details.
+- Add `'workspace_capabilities'` to `RunnerOperationSchema` in `packages/contracts/src/runner-api.ts`.
+- Define `workspace_capabilities` input schema in `packages/contracts/src/tool-schemas.ts` (`z.object({ workspaceId: WorkspaceIdSchema.optional() })`).
+- Define TypeScript types and Zod schemas for `RepositoryCapabilities`, `WorkspaceCapabilities`, `RepositoryPermissions`, `RepositoryOperations`, and `WorkspaceCapabilityResult`.
+- Update `TOOL_SPECS`, titles, descriptions, and tool hints (`readOnly: true`, `idempotent: true`).
+- Update `packages/contracts/test/contracts.test.ts`.
+
+### Phase 2: Runner and Local Capability Resolution & Authorization Errors
+- Implement `computeWorkspaceCapabilities` helper in runner (`apps/runner/src/workspace-service.ts`):
+  - Resolves repository info (`owner/repo`), GitHub App installation status, grant contents permissions (`read` vs `write`), and operational capabilities without network side-effects or token minting.
+  - Dispatches `workspace_capabilities` operation in `WorkspaceService.execute` alongside `workspace_status` before `touch()`.
+  - Enriches `workspace_open` (including idempotent replay paths), `workspace_status`, and `workspace_context` response data with `capabilities`, `permissions`, and `operations`.
+- Update `remotePush` and `runBrokeredGitHubAction` in `apps/runner/src/workspace-service.ts`:
+  - When unauthorized or token cannot be minted, return/throw structured `HarnessError` with `code: 'REPOSITORY_OPERATION_NOT_AUTHORIZED'`, `operation: 'git_push'` or `github_action.<action>`, `repository: 'owner/repo'`, and `requiredCapability: 'repository.push'` or `repository.<action>`.
+- Update `sendRunnerError` in `apps/runner/src/app.ts`:
+  - Propagate `operation`, `repository`, and `requiredCapability` from `HarnessError` into the HTTP JSON error response so runner client receives structured error metadata.
+- Implement `workspace_capabilities` in `apps/api/src/local/local-workspace-backend.ts`:
+  - Returns local capability matrix reflecting `--git-push` and `--git-network` options.
+  - Aligns `capabilities.workspace` with local-mode flags (`mode: 'local'`, `platform`, `sandboxed: false`, `gitNetwork`, `gitPush`).
+  - Enriches `workspace_status` with standard capability metadata.
+  - Returns structured authorization errors with `requiredCapability: 'repository.push'` when `git_push` is denied.
+- Update `apps/api/src/mcp-response-text.ts` to include `requiredCapability` in human-readable text output.
+
+### Phase 3: Tests and Verification
+- Unit tests in `packages/contracts/test/contracts.test.ts` for schemas, error codes, and capability types.
+- Unit tests in `apps/runner/test/workspace-capabilities.test.ts`:
+  - `workspace_capabilities` in `owner-bearer` mode with and without GitHub App installation.
+  - `workspace_capabilities` in `cloudflare-access` mode for read-only vs read-write repository grants.
+  - Capability inclusion in `workspace_open` (initial and replay), `workspace_status`, and `workspace_context`.
+  - Structured authorization errors on denied `git_push` and `github_action`.
+  - Error propagation through `sendRunnerError` in `apps/runner/src/app.ts`.
+- Unit tests in `apps/api/test/local/local-capabilities.test.ts` for local stdio capability introspection and error payloads.
+- Run full unit and integration test suite (`npm test`).
+
+### Phase 4: Documentation, Skill Sync, and Docs Reference
+- Update `docs/mcp-api.md` and `docs/security-model.md` with `workspace_capabilities` and structured authorization error contracts.
+- Update `scripts/build-docs-reference.mjs` to categorize `workspace_capabilities` under `Workspace Lifecycle`.
+- Run `npm run docs:reference` to regenerate `docs-site/reference/tools.md` and `docs-site/public/llms.txt`.
+- Update `.agents/skills/cloudharness/references/workspace-lifecycle-and-results.md`.
+- Run `npm run plugin:sync` to sync the packaged plugin skill.
+- Run `npm run verify` to ensure all repo gates pass.
+## Acceptance Criteria
+- [x] Agents can query repository/workspace capabilities before modifying the repository via `workspace_capabilities`, `workspace_open`, `workspace_status`, or `workspace_context`.
+- [x] Git push permission is represented explicitly in `capabilities.repository.push`, `permissions.contents.write`, and `operations.gitPush`.
+- [x] GitHub Issues permissions are represented explicitly in `capabilities.repository.issuesRead`, `capabilities.repository.issuesWrite`, `permissions.issues`, and `operations.issue*`.
+- [x] Pull Request permissions are represented explicitly in `capabilities.repository.pullRequestsRead`, `capabilities.repository.pullRequestsWrite`, `permissions.pullRequests`, and `operations.pullRequest*`.
+- [x] Capabilities are scoped to the workspace's bound repository.
+- [x] Capabilities reflect CloudHarness policy, not merely upstream GitHub permissions.
+- [x] Authorization failures identify the missing capability with structured `code`, `operation`, `repository`, and `requiredCapability`.
+- [x] Capability results are machine-readable and stable enough for agent planning.
+- [x] Tests cover read-only and read/write repositories across `owner-bearer`, `cloudflare-access`, and `local` modes.

--- a/plugins/cloud-harness/skills/cloudharness/references/workspace-lifecycle-and-results.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/workspace-lifecycle-and-results.md
@@ -88,6 +88,19 @@ Read one workspace record by opaque ID.
   record, unlike tools that require an active executor.
 - Read-only and safe to repeat.
 
+<!-- cloudharness-tool:workspace_capabilities -->
+### `workspace_capabilities`
+
+Inspect workspace and bound repository authorization capabilities without modifying state or minting tokens.
+
+- Optional: `workspaceId`.
+- Returns high-level capabilities (`repository`, `workspace`), fine-grained permissions (`contents`, `issues`, `pullRequests`), and direct operation authorizations (`gitPush`, `issueCreate`, `pullRequestCreate`, etc.).
+- Read-only and safe to repeat.
+
+<!-- cloudharness-example:workspace_capabilities
+{"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa"}
+-->
+
 <!-- cloudharness-tool:workspace_close -->
 ### `workspace_close`
 

--- a/scripts/build-docs-reference.mjs
+++ b/scripts/build-docs-reference.mjs
@@ -20,7 +20,7 @@ const CATEGORIES = [
   {
     title: 'Workspace Lifecycle',
     description: 'Tools for opening, inspecting, listing, and closing isolated TTL-bound workspaces.',
-    names: ['workspace_open', 'workspace_list', 'workspace_status', 'workspace_close']
+    names: ['workspace_open', 'workspace_list', 'workspace_status', 'workspace_capabilities', 'workspace_context', 'workspace_lease_renew', 'workspace_recover', 'workspace_close']
   },
   {
     title: 'Files and Code Intelligence',


### PR DESCRIPTION
## Summary
Resolves #104

Adds repository and workspace capability introspection and structured authorization preflight errors to Cloud Harness MCP. This enables AI coding agents to verify whether repository operations (e.g. \`git_push\`, GitHub issue and PR management) are authorized before performing expensive modification workflows, eliminating late-stage push failures.

## Key Changes
- **New MCP Tool & Runner Operation:** Added \`workspace_capabilities\` tool and corresponding operation in \`RunnerOperationSchema\` and \`WorkspaceService\`.
- **Capability Enrichment:** Enriched \`workspace_open\`, \`workspace_status\`, and \`workspace_context\` with structured \`capabilities\` (\`repository\`, \`workspace\`), \`permissions\` (\`contents\`, \`issues\`, \`pullRequests\`), and \`operations\` matrices.
- **Structured Denial Error:** Added \`REPOSITORY_OPERATION_NOT_AUTHORIZED\` (HTTP 403, non-retryable) with machine-readable \`operation\`, \`repository\`, and \`requiredCapability\` metadata.
- **Preflight Enforcements:** Preflight authorization checks enforced in \`git_push\`, \`workspace_finalize\`, and \`github_action\` before performing any git transfers or brokered operations.
- **Dual Backend Support:** Implemented across both Docker runner (\`WorkspaceService\` supporting \`owner-bearer\` and \`cloudflare-access\` modes) and local stdio backend (\`LocalWorkspaceBackend\` supporting \`--git-push\` and \`--git-network\` flags).
- **Documentation & Skills:** Updated \`docs/mcp-api.md\`, \`docs/security-model.md\`, \`docs-site/reference/tools.md\`, and \`.agents/skills/cloudharness/\`.

## Verification
- Added test suite \`apps/runner/test/workspace-capabilities.test.ts\` covering \`owner-bearer\`, \`cloudflare-access\`, grant transitions, and structured error payloads.
- Added test suite \`apps/api/test/local/local-capabilities.test.ts\` covering local capability introspection and structured error payloads.
- Full test suite passed (61 test files, 426 tests).
- \`npm run verify\` passed (plugin sync, lint, typecheck, tests, build).
- \`npm run verify:compose\` passed.