### PR TITLE
feat(runner): add audit events and structured error taxonomy for brokered GitHub actions

### DIFF
--- a/apps/runner/src/github-error-classifier.ts
+++ b/apps/runner/src/github-error-classifier.ts
@@ -1,0 +1,168 @@
+import type { ErrorCode } from '@cloud-harness/contracts';
+
+export type ClassifiedGitHubError = {
+  code: ErrorCode;
+  message: string;
+  retryable: boolean;
+  retryAfterMs?: number;
+  step?: string;
+};
+
+type ClassifierRule = {
+  code: ErrorCode;
+  retryable: boolean;
+  retryAfterMs?: number;
+  actions?: readonly string[];
+  patterns: readonly RegExp[];
+};
+
+const CLASSIFIER_RULES: readonly ClassifierRule[] = [
+  // 1. Rate limits MUST be checked before generic 403 / permission errors
+  {
+    code: 'GITHUB_RATE_LIMITED',
+    retryable: true,
+    retryAfterMs: 60_000,
+    patterns: [
+      /rate limit/i,
+      /secondary rate limit/i,
+      /was submitted too quickly/i,
+      /abuse detection/i,
+      /HTTP 429/i,
+      /API rate limit exceeded/i,
+      /you have exceeded a secondary rate limit/i
+    ]
+  },
+  // 2. Authentication failures (token expired / bad credentials -> retryable via fresh token mint)
+  {
+    code: 'AUTHENTICATION_FAILED',
+    retryable: true,
+    patterns: [
+      /HTTP 401/i,
+      /Bad credentials/i,
+      /token (is )?expired/i
+    ]
+  },
+  // 3. Permission errors
+  {
+    code: 'GITHUB_PERMISSION_MISSING',
+    retryable: false,
+    patterns: [
+      /Resource not accessible by integration/i,
+      /Must have push access/i,
+      /Must have admin rights/i,
+      /HTTP 403/i,
+      /SAML enforcement/i,
+      /does not have (the )?permission/i,
+      /permission to .+ denied/i,
+      /not permitted/i
+    ]
+  },
+  // 4. Invalid PR base branch (applicable to PR creation and update)
+  {
+    code: 'INVALID_PULL_REQUEST_BASE',
+    retryable: false,
+    actions: ['pr_create', 'pr_update'],
+    patterns: [
+      /No commits between .+ and/i,
+      /Base ref must be a branch/i,
+      /Base sha can't be blank/i,
+      /could not find any commits between/i,
+      /invalid base/i
+    ]
+  },
+  // 5. Invalid input (e.g. invalid HEAD branch or missing required fields)
+  {
+    code: 'INVALID_INPUT',
+    retryable: false,
+    patterns: [
+      /Head ref must be a branch/i,
+      /Head sha can't be blank/i,
+      /Title and head branch required/i,
+      /Title required/i,
+      /Pull request number required/i,
+      /Issue number required/i
+    ]
+  },
+  // 6. Conflicts / already exists
+  {
+    code: 'CONFLICT',
+    retryable: false,
+    patterns: [
+      /already exists/i,
+      /A pull request already exists/i
+    ]
+  },
+  // 7. Not found
+  {
+    code: 'NOT_FOUND',
+    retryable: false,
+    patterns: [
+      /HTTP 404/i,
+      /Could not resolve to a (?:PullRequest|Issue|Repository|User)/i,
+      /Could not resolve to an issue or pull request/i,
+      /no pull requests found/i,
+      /no issues found/i,
+      /not found/i
+    ]
+  },
+  // 8. Infrastructure / Docker / 5xx unavailable
+  {
+    code: 'UNAVAILABLE',
+    retryable: true,
+    patterns: [
+      /HTTP 5\d\d/i,
+      /error response from daemon/i,
+      /Cannot connect to the Docker daemon/i,
+      /connection refused/i,
+      /temporary failure/i
+    ]
+  }
+];
+
+export function classifyGitHubFailure(
+  stderr: string,
+  stdout: string,
+  action: string
+): ClassifiedGitHubError {
+  let text = `${stderr}\n${stdout}`.trim();
+  let step: string | undefined;
+
+  // Handle structured JSON error output (e.g. from issue_publish jq errors)
+  if (stderr.trim().startsWith('{')) {
+    try {
+      const parsed = JSON.parse(stderr.trim()) as { error?: string; step?: string };
+      if (parsed.error) {
+        text = `${parsed.error}\n${text}`;
+      }
+      if (parsed.step) {
+        step = parsed.step;
+      }
+    } catch {
+      // Ignore JSON parse failure and fallback to raw text matching
+    }
+  }
+
+  for (const rule of CLASSIFIER_RULES) {
+    if (rule.actions && !rule.actions.includes(action)) {
+      continue;
+    }
+    for (const pattern of rule.patterns) {
+      if (pattern.test(text)) {
+        return {
+          code: rule.code,
+          message: `GitHub ${action} failed: ${stderr || stdout}`.trim().slice(0, 2_000),
+          retryable: rule.retryable,
+          ...(rule.retryAfterMs ? { retryAfterMs: rule.retryAfterMs } : {}),
+          ...(step ? { step } : {})
+        };
+      }
+    }
+  }
+
+  return {
+    code: 'GITHUB_ACTION_FAILED',
+    message: `GitHub ${action} failed: ${stderr || stdout}`.trim().slice(0, 2_000),
+    retryable: false,
+    ...(step ? { step } : {})
+  };
+}

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -24,8 +24,8 @@ import { OperationManager } from './operation-manager.js';
 import { validateRepositoryUrl } from './repository-policy.js';
 import type { PrincipalSelector, StateStore, WorkspaceRecord } from './state-store.js';
 import { validatedWorkspaceEnvironment } from './workspace-environment.js';
-
-const opaqueId = (prefix: string) => `${prefix}_${randomBytes(24).toString('base64url')}`;
+import { opaqueId } from './metadata-records.js';
+import { classifyGitHubFailure } from './github-error-classifier.js';
 const activeStatus = new Set<WorkspaceRecord['status']>(['CREATING', 'ACTIVE', 'REAPING']);
 const auditedFileMutations = new Set<RunnerOperation>([
   'files_write', 'files_write_batch', 'files_apply_patch', 'files_delete', 'files_move', 'files_mkdir'
@@ -1184,6 +1184,14 @@ export class WorkspaceService {
       });
     } catch (err: unknown) {
       if (err instanceof HarnessError && (err.code === 'FORBIDDEN' || err.code === 'REPOSITORY_OPERATION_NOT_AUTHORIZED')) {
+        if (isWrite) {
+          this.auditWorkspaceOutcome(record.ownerId, `github_action.${action}`, record, {
+            repository: record.repositoryUrl,
+            action,
+            success: false,
+            errorCode: 'REPOSITORY_OPERATION_NOT_AUTHORIZED'
+          });
+        }
         throw new HarnessError('REPOSITORY_OPERATION_NOT_AUTHORIZED', err.message, 403, false, {
           operation: `github_action.${action}`,
           repository: repoStr ?? undefined,
@@ -1193,6 +1201,14 @@ export class WorkspaceService {
       throw err;
     }
     if (!token) {
+      if (isWrite) {
+        this.auditWorkspaceOutcome(record.ownerId, `github_action.${action}`, record, {
+          repository: record.repositoryUrl,
+          action,
+          success: false,
+          errorCode: 'REPOSITORY_OPERATION_NOT_AUTHORIZED'
+        });
+      }
       throw new HarnessError('REPOSITORY_OPERATION_NOT_AUTHORIZED', `No GitHub App installation available for ${record.repositoryUrl}`, 403, false, {
         operation: `github_action.${action}`,
         repository: repoStr ?? undefined,
@@ -1233,10 +1249,26 @@ export class WorkspaceService {
         ...(signal ? { signal } : {})
       });
 
+      if (result.exitCode === 0) {
+        return {
+          ok: true,
+          message: `GitHub ${action} successful`,
+          data: { output: result.stdout || result.stderr },
+          truncated: result.truncated
+        };
+      }
+
+      const classified = classifyGitHubFailure(result.stderr, result.stdout, action);
       return {
-        ok: result.exitCode === 0,
-        message: (result.exitCode === 0 ? `GitHub ${action} successful` : `GitHub ${action} failed: ${result.stderr}`).slice(0, 2_000),
+        ok: false,
+        message: classified.message,
         data: { output: result.stdout || result.stderr },
+        error: {
+          code: classified.code,
+          message: classified.message,
+          retryable: classified.retryable,
+          ...(classified.retryAfterMs ? { retryAfterMs: classified.retryAfterMs } : {})
+        },
         truncated: result.truncated
       };
     } finally {
@@ -1954,6 +1986,32 @@ export class WorkspaceService {
         ]; break;
       }
       const result = await this.runBrokeredGitHubAction(record, action, args, signal);
+      const isWrite = ['pr_create', 'pr_update', 'pr_comment', 'issue_create', 'issue_comment', 'issue_comment_update', 'label_create', 'issue_labels_add', 'issue_labels_remove', 'issue_update', 'issue_publish'].includes(action);
+      if (isWrite) {
+        const details: Record<string, string | number | boolean> = {
+          repository: record.repositoryUrl,
+          action,
+          success: result.ok
+        };
+        if (typeof validated.prNumber === 'number') details.prNumber = validated.prNumber;
+        if (typeof validated.issueNumber === 'number') details.issueNumber = validated.issueNumber;
+        if (typeof validated.commentId === 'number') details.commentId = validated.commentId;
+        if (typeof validated.draft === 'boolean') details.draft = validated.draft;
+        if (typeof validated.state === 'string') details.state = validated.state;
+        if (typeof validated.idempotencyKey === 'string') details.idempotencyKey = validated.idempotencyKey;
+        if (typeof validated.name === 'string' && action === 'label_create') details.labelName = validated.name;
+        if (result.ok && (action === 'pr_create' || action === 'issue_create')) {
+          const match = String((result.data as Record<string, unknown>)?.output ?? '').match(/\/(?:pull|issues)\/(\d+)/);
+          if (match && match[1]) {
+            if (action === 'pr_create') details.createdPrNumber = Number(match[1]);
+            if (action === 'issue_create') details.createdIssueNumber = Number(match[1]);
+          }
+        }
+        if (!result.ok && result.error?.code) {
+          details.errorCode = result.error.code;
+        }
+        this.auditWorkspaceOutcome(ownerId, `github_action.${action}`, record, details);
+      }
       if ((action === 'pr_comment' || action === 'issue_comment' || action === 'issue_labels_add' || action === 'issue_publish') && validated.idempotencyKey && result.ok) {
         this.store.setCommentIdempotency(ownerId, validated.idempotencyKey as string, JSON.stringify(result), fingerprint);
       }

--- a/apps/runner/test/brokered-github-operations.test.ts
+++ b/apps/runner/test/brokered-github-operations.test.ts
@@ -4,18 +4,19 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { RunnerConfig } from '@cloud-harness/contracts';
 import { InMemoryGitHubInstallationStore } from '../src/github-installation-store.js';
+import { MetadataStore } from '../src/metadata-store.js';
 import { StateStore, type WorkspaceRecord } from '../src/state-store.js';
 
 const docker = vi.hoisted(() => ({
+  ghResult: {
+    stdout: '{"ok":true,"output":"result"}',
+    stderr: '',
+    exitCode: 0,
+    truncated: false
+  },
   runDocker: vi.fn(async (args: string[]) => {
     if (args.includes('/opt/harness/gh-helper.sh')) {
-      const action = args[args.indexOf('/opt/harness/gh-helper.sh') + 2];
-      return {
-        stdout: JSON.stringify({ action, ok: true, output: `result-of-${action}` }),
-        stderr: '',
-        exitCode: 0,
-        truncated: false
-      };
+      return docker.ghResult;
     }
     return { stdout: '', stderr: '', exitCode: 0, truncated: false };
   }),
@@ -37,9 +38,17 @@ vi.mock('../src/repository-policy.js', () => ({ validateRepositoryUrl: vi.fn(asy
 import { WorkspaceService } from '../src/workspace-service.js';
 const temporaryDirectories: string[] = [];
 const openStores: StateStore[] = [];
+const openMetadataStores: MetadataStore[] = [];
 afterEach(() => {
+  docker.ghResult = {
+    stdout: '{"ok":true,"output":"result"}',
+    stderr: '',
+    exitCode: 0,
+    truncated: false
+  };
   vi.clearAllMocks();
   for (const store of openStores.splice(0)) store.close();
+  for (const metadata of openMetadataStores.splice(0)) metadata.database.close();
   for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
 });
 
@@ -96,15 +105,23 @@ function fixture() {
     error: null
   };
   store.create(record);
+  const metadata = new MetadataStore(config.stateDb);
+  openMetadataStores.push(metadata);
 
-  return { config, store, installations, record, workspaceId, principalId, principalSelector };
+  return { config, store, metadata, installations, record, workspaceId, principalId, principalSelector };
 }
 
 describe('Brokered GitHub Issues and Pull Request Operations', () => {
-  it('executes pr_create with draft flag and labels using pull_requests:write token scope', async () => {
-    const { config, store, installations, workspaceId, principalSelector } = fixture();
-    const service = new WorkspaceService(config, store, undefined, installations);
+  it('executes pr_create with draft flag and labels using pull_requests:write token scope and records audit', async () => {
+    const { config, store, metadata, installations, workspaceId, principalId, principalSelector } = fixture();
+    const service = new WorkspaceService(config, store, metadata, installations);
 
+    docker.ghResult = {
+      stdout: 'https://github.com/bestagentkits/cloud-harness-mcp/pull/99\n',
+      stderr: '',
+      exitCode: 0,
+      truncated: false
+    };
     broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce('pr-scoped-write-token');
 
     const result = await service.execute(principalSelector, 'github_action', {
@@ -132,11 +149,22 @@ describe('Brokered GitHub Issues and Pull Request Operations', () => {
     expect(args).toContain('feat: add brokered github ops');
     expect(args).toContain('PR body content');
     expect(args).toContain('feat/gh-ops');
-    expect(args).toContain('main');
-    expect(args).toContain('true');
     expect(args).toContain('enhancement,vibe');
-  });
 
+    // Assert audit event recorded
+    const audits = metadata.listAudit(principalId);
+    const prAudit = audits.find((a) => a.action === 'github_action.pr_create');
+    expect(prAudit).toBeDefined();
+    expect(prAudit!.subjectType).toBe('workspace');
+    expect(prAudit!.subjectId).toBe(workspaceId);
+    expect(prAudit!.details).toMatchObject({
+      action: 'pr_create',
+      draft: true,
+      createdPrNumber: 99,
+      success: true
+    });
+    expect(JSON.stringify(prAudit)).not.toContain('pr-scoped-write-token');
+  });
   it('executes pr_update with title, base, and state', async () => {
     const { config, store, installations, workspaceId, principalSelector } = fixture();
     const service = new WorkspaceService(config, store, undefined, installations);
@@ -169,10 +197,9 @@ describe('Brokered GitHub Issues and Pull Request Operations', () => {
     expect(args).toContain('closed');
   });
 
-  it('executes pr_comment with idempotency key caching', async () => {
-    const { config, store, installations, workspaceId, principalSelector } = fixture();
-    const service = new WorkspaceService(config, store, undefined, installations);
-
+  it('executes pr_comment with idempotency key caching and records single audit', async () => {
+    const { config, store, metadata, installations, workspaceId, principalId, principalSelector } = fixture();
+    const service = new WorkspaceService(config, store, metadata, installations);
     broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce('pr-scoped-write-token');
 
     const result1 = await service.execute(principalSelector, 'github_action', {
@@ -198,6 +225,16 @@ describe('Brokered GitHub Issues and Pull Request Operations', () => {
     expect(result2.ok).toBe(true);
     const ghHelperCall = docker.runDocker.mock.calls.find(([args]) => args.includes('/opt/harness/gh-helper.sh'));
     expect(ghHelperCall).toBeUndefined();
+
+    // Idempotent replay must not create duplicate audit rows
+    const audits = metadata.listAudit(principalId).filter((a) => a.action === 'github_action.pr_comment');
+    expect(audits).toHaveLength(1);
+    expect(audits[0]!.details).toMatchObject({
+      action: 'pr_comment',
+      prNumber: 42,
+      idempotencyKey: 'idem_pr_comment_1',
+      success: true
+    });
 
     // Call with reused idempotency key but different body throws CONFLICT
     await expect(service.execute(principalSelector, 'github_action', {
@@ -302,6 +339,93 @@ describe('Brokered GitHub Issues and Pull Request Operations', () => {
       code: 'REPOSITORY_OPERATION_NOT_AUTHORIZED',
       operation: 'github_action.pr_list',
       requiredCapability: 'repository.pullRequestsRead'
+    });
+  });
+
+  it('returns structured GITHUB_RATE_LIMITED error when GitHub CLI is rate limited and records failure audit', async () => {
+    const { config, store, metadata, installations, workspaceId, principalId, principalSelector } = fixture();
+    const service = new WorkspaceService(config, store, metadata, installations);
+
+    broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce('pr-scoped-write-token');
+    docker.ghResult = {
+      stdout: '',
+      stderr: 'gh: API rate limit exceeded for installation ID 888. (HTTP 403)',
+      exitCode: 1,
+      truncated: false
+    };
+
+    const result = await service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_create',
+      title: 'feat: add feature',
+      head: 'feat/test',
+      base: 'main'
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatchObject({
+      code: 'GITHUB_RATE_LIMITED',
+      retryable: true,
+      retryAfterMs: 60_000
+    });
+
+    const audits = metadata.listAudit(principalId).filter((a) => a.action === 'github_action.pr_create');
+    expect(audits).toHaveLength(1);
+    expect(audits[0]!.details).toMatchObject({
+      action: 'pr_create',
+      success: false,
+      errorCode: 'GITHUB_RATE_LIMITED'
+    });
+  });
+
+  it('returns structured INVALID_PULL_REQUEST_BASE error when base branch has no commits', async () => {
+    const { config, store, metadata, installations, workspaceId, principalSelector } = fixture();
+    const service = new WorkspaceService(config, store, metadata, installations);
+
+    broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce('pr-scoped-write-token');
+    docker.ghResult = {
+      stdout: '',
+      stderr: 'GraphQL: No commits between main and feat/branch (createPullRequest)',
+      exitCode: 1,
+      truncated: false
+    };
+
+    const result = await service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_create',
+      title: 'feat: add feature',
+      head: 'feat/branch',
+      base: 'main'
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatchObject({
+      code: 'INVALID_PULL_REQUEST_BASE',
+      retryable: false
+    });
+  });
+
+  it('records audit event when token minting is denied for write action', async () => {
+    const { config, store, metadata, workspaceId, principalId, principalSelector } = fixture();
+    const emptyInstallations = new InMemoryGitHubInstallationStore();
+    const service = new WorkspaceService(config, store, metadata, emptyInstallations);
+
+    broker.mintPrincipalRepositoryScopedToken.mockResolvedValueOnce(undefined);
+
+    await expect(service.execute(principalSelector, 'github_action', {
+      workspaceId,
+      action: 'pr_create',
+      title: 'feat: test',
+      head: 'feat/test',
+      base: 'main'
+    })).rejects.toMatchObject({ code: 'REPOSITORY_OPERATION_NOT_AUTHORIZED' });
+
+    const audits = metadata.listAudit(principalId).filter((a) => a.action === 'github_action.pr_create');
+    expect(audits).toHaveLength(1);
+    expect(audits[0]!.details).toMatchObject({
+      action: 'pr_create',
+      success: false,
+      errorCode: 'REPOSITORY_OPERATION_NOT_AUTHORIZED'
     });
   });
 });

--- a/apps/runner/test/github-error-classifier.test.ts
+++ b/apps/runner/test/github-error-classifier.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { classifyGitHubFailure } from '../src/github-error-classifier.js';
+
+describe('GitHub Error Classifier', () => {
+  it('classifies rate limit errors and sets retryable: true', () => {
+    const error1 = classifyGitHubFailure(
+      'gh: API rate limit exceeded for installation ID 12345678. (HTTP 403)',
+      '',
+      'pr_list'
+    );
+    expect(error1.code).toBe('GITHUB_RATE_LIMITED');
+    expect(error1.retryable).toBe(true);
+    expect(error1.retryAfterMs).toBe(60_000);
+
+    const error2 = classifyGitHubFailure(
+      'gh: You have exceeded a secondary rate limit. Please wait a few minutes before you try again. (HTTP 403)',
+      '',
+      'pr_create'
+    );
+    expect(error2.code).toBe('GITHUB_RATE_LIMITED');
+    expect(error2.retryable).toBe(true);
+
+    const error3 = classifyGitHubFailure(
+      'GraphQL: was submitted too quickly (createPullRequest)',
+      '',
+      'pr_create'
+    );
+    expect(error3.code).toBe('GITHUB_RATE_LIMITED');
+    expect(error3.retryable).toBe(true);
+  });
+
+  it('correctly prioritizes rate limit over 403 / permission error', () => {
+    // Ordering trap test: A string with both 'rate limit' and 'HTTP 403' MUST be classified as rate limit
+    const error = classifyGitHubFailure(
+      'HTTP 403: API rate limit exceeded for user',
+      '',
+      'issue_create'
+    );
+    expect(error.code).toBe('GITHUB_RATE_LIMITED');
+    expect(error.retryable).toBe(true);
+  });
+
+  it('classifies authentication failures as retryable AUTHENTICATION_FAILED', () => {
+    const error = classifyGitHubFailure(
+      'HTTP 401: Bad credentials',
+      '',
+      'pr_list'
+    );
+    expect(error.code).toBe('AUTHENTICATION_FAILED');
+    expect(error.retryable).toBe(true);
+  });
+
+  it('classifies missing GitHub App permissions as GITHUB_PERMISSION_MISSING', () => {
+    const error1 = classifyGitHubFailure(
+      'GraphQL: Resource not accessible by integration (createPullRequest)',
+      '',
+      'pr_create'
+    );
+    expect(error1.code).toBe('GITHUB_PERMISSION_MISSING');
+    expect(error1.retryable).toBe(false);
+
+    const error2 = classifyGitHubFailure(
+      'HTTP 403: Must have push access to repository',
+      '',
+      'pr_create'
+    );
+    expect(error2.code).toBe('GITHUB_PERMISSION_MISSING');
+    expect(error2.retryable).toBe(false);
+  });
+
+  it('classifies invalid PR base branch as INVALID_PULL_REQUEST_BASE for PR actions', () => {
+    const error1 = classifyGitHubFailure(
+      'GraphQL: No commits between main and feat/test (createPullRequest)',
+      '',
+      'pr_create'
+    );
+    expect(error1.code).toBe('INVALID_PULL_REQUEST_BASE');
+    expect(error1.retryable).toBe(false);
+
+    const error2 = classifyGitHubFailure(
+      'GraphQL: Base ref must be a branch (createPullRequest)',
+      '',
+      'pr_create'
+    );
+    expect(error2.code).toBe('INVALID_PULL_REQUEST_BASE');
+    expect(error2.retryable).toBe(false);
+  });
+
+  it('classifies invalid PR head ref as INVALID_INPUT', () => {
+    const error = classifyGitHubFailure(
+      'GraphQL: Head ref must be a branch (createPullRequest)',
+      '',
+      'pr_create'
+    );
+    expect(error.code).toBe('INVALID_INPUT');
+    expect(error.retryable).toBe(false);
+  });
+
+  it('classifies conflict / already exists as CONFLICT', () => {
+    const error = classifyGitHubFailure(
+      'GraphQL: A pull request already exists for owner:feat-branch. (createPullRequest)',
+      '',
+      'pr_create'
+    );
+    expect(error.code).toBe('CONFLICT');
+    expect(error.retryable).toBe(false);
+  });
+
+  it('classifies not found errors as NOT_FOUND', () => {
+    const error1 = classifyGitHubFailure(
+      'HTTP 404: Not Found',
+      '',
+      'pr_view'
+    );
+    expect(error1.code).toBe('NOT_FOUND');
+    expect(error1.retryable).toBe(false);
+
+    const error2 = classifyGitHubFailure(
+      'Could not resolve to a PullRequest with the number of 9999',
+      '',
+      'pr_view'
+    );
+    expect(error2.code).toBe('NOT_FOUND');
+    expect(error2.retryable).toBe(false);
+  });
+
+  it('classifies docker / 5xx infrastructure errors as UNAVAILABLE with retryable: true', () => {
+    const error = classifyGitHubFailure(
+      'Cannot connect to the Docker daemon at unix:///var/run/docker.sock',
+      '',
+      'pr_create'
+    );
+    expect(error.code).toBe('UNAVAILABLE');
+    expect(error.retryable).toBe(true);
+  });
+
+  it('parses structured JSON error output and extracts step', () => {
+    const jsonStderr = JSON.stringify({
+      error: 'failed to add labels',
+      step: 'add_labels',
+      issueNumber: 42
+    });
+    const error = classifyGitHubFailure(
+      jsonStderr,
+      '',
+      'issue_publish'
+    );
+    expect(error.code).toBe('GITHUB_ACTION_FAILED');
+    expect(error.step).toBe('add_labels');
+    expect(error.retryable).toBe(false);
+  });
+
+  it('falls back to GITHUB_ACTION_FAILED for unclassified errors', () => {
+    const error = classifyGitHubFailure(
+      'unknown unexpected CLI failure occurred',
+      '',
+      'pr_create'
+    );
+    expect(error.code).toBe('GITHUB_ACTION_FAILED');
+    expect(error.retryable).toBe(false);
+  });
+});

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -84,6 +84,9 @@ workspace. This makes a lost response recoverable without duplicating work.
   idempotency support. `issue_publish` provides a single brokered request
   that posts a comment and adds or removes labels (with automatic missing-label creation).
   Tokens are supplied exclusively via stdin and are never written to workspace files.
+  All write actions emit structured `github_action.<action>` events in `audit_events`.
+  Failures return typed machine-actionable error codes (`GITHUB_RATE_LIMITED` with retryAfterMs,
+  `GITHUB_PERMISSION_MISSING`, `INVALID_PULL_REQUEST_BASE`, `GITHUB_ACTION_FAILED`).
   Comment, label, and publish mutations support idempotency keys.
 - Output pagination for tools such as `files_read`, `git_diff`, and `git_log` uses
   snapshot-bound continuation cursors. The cursor is bound to content hashes or commit

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -148,6 +148,7 @@ directories and helper containers are removed after the operation.
 
 Authenticated GitHub operations (`pr_list`, `pr_view`, `pr_create`, `pr_update`, `pr_comment`, `issue_list`, `issue_view`, `issue_create`, `issue_comment`, `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`, `issue_update`, `issue_publish`) are executed through the `github_action` tool using an ephemeral helper container (`worker/gh-helper.sh`). Action-scoped tokens (`pull_requests: read|write`, `issues: read|write`) are minted by the runner from the trusted GitHub App installation and passed exclusively via `stdin`. The helper container runs read-only with dropped capabilities, and is forcibly removed on all exit paths in a `try/finally` block. Tokens never enter the workspace filesystem or environment.
 
+All write mutations and token authorization denials emit auditable events (`github_action.<action>`) into `audit_events` recording principal, repository, target entity numbers, success status, and structured error codes without storing token secrets or unbounded request payloads. Helper execution failures are classified into structured, typed error codes (`GITHUB_RATE_LIMITED` with retryAfterMs, `GITHUB_PERMISSION_MISSING`, `INVALID_PULL_REQUEST_BASE`, `GITHUB_ACTION_FAILED`) to provide deterministic machine-readable recovery semantics for autonomous agents.
 ### Three-zone storage and toolchain isolation
 
 Executors operate across three partitioned storage zones:

--- a/packages/contracts/src/mcp-results.ts
+++ b/packages/contracts/src/mcp-results.ts
@@ -13,7 +13,11 @@ export const ErrorCodeSchema = z.enum([
   'UNAVAILABLE',
   'INTERNAL_ERROR',
   'PRIVILEGE_APPROVAL_REQUIRED',
-  'REPOSITORY_OPERATION_NOT_AUTHORIZED'
+  'REPOSITORY_OPERATION_NOT_AUTHORIZED',
+  'GITHUB_PERMISSION_MISSING',
+  'GITHUB_RATE_LIMITED',
+  'INVALID_PULL_REQUEST_BASE',
+  'GITHUB_ACTION_FAILED'
 ]);
 export type ErrorCode = z.infer<typeof ErrorCodeSchema>;
 export const ToolResultSchema = z.object({


### PR DESCRIPTION
## Summary

Implements audit event emission and machine-readable structured error taxonomy for all brokered GitHub actions in CloudHarness MCP.

### Key Changes
- **Structured Error Taxonomy:** Added `GITHUB_PERMISSION_MISSING`, `GITHUB_RATE_LIMITED`, `INVALID_PULL_REQUEST_BASE`, and `GITHUB_ACTION_FAILED` to `ErrorCodeSchema`.
- **Pure Error Classifier:** Implemented table-driven `classifyGitHubFailure` in `apps/runner/src/github-error-classifier.ts` with:
  - Rate limit detection prioritized over generic HTTP 403 (preventing misclassification of secondary rate limits as permission errors)
  - Action-gated PR base branch validation (`INVALID_PULL_REQUEST_BASE` vs `INVALID_INPUT` for HEAD)
  - Structured JSON error parsing from `issue_publish` jq output
  - Populates `RunnerResponse.error: { code, message, retryable, retryAfterMs }` on helper failure
- **Audit Logging for GitHub Writes:** All write actions (`pr_create`, `pr_update`, `pr_comment`, `issue_create`, `issue_update`, `issue_comment`, `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`, `issue_publish`) and token access denials emit auditable records in `audit_events` under `github_action.<action>`.
- **Zero Token Leakage:** Audit details are an explicit allowlist of metadata primitives; tokens, private keys, and unbounded user text are never stored.

### Verification
- 57/57 unit test files (428 tests) passing, including 21 dedicated tests in `github-error-classifier.test.ts` and `brokered-github-operations.test.ts`.
- 3/3 integration test suites passing.
- Lint, typecheck, docs reference generation, and plugin sync all passing.