### PR TITLE
fix(runner): ensure awaitable process exit barrier and MCP Tasks compatibility matrix (#14)

### DIFF
--- a/apps/runner/src/operation-manager.ts
+++ b/apps/runner/src/operation-manager.ts
@@ -624,30 +624,39 @@ export class OperationManager {
     for (const record of activeRecords) {
       record.status = 'cancelled';
       record.finishedAt = now;
-      if (record.child && !record.child.killed) {
+      if (record.child && (record.child.exitCode === null && record.child.signalCode === null)) {
         const child = record.child;
         const exitPromise = new Promise<void>((resolve) => {
           let resolved = false;
+          let killTimer: NodeJS.Timeout | undefined;
+          let deadlineTimer: NodeJS.Timeout | undefined;
           const done = () => {
             if (!resolved) {
               resolved = true;
+              if (killTimer) clearTimeout(killTimer);
+              if (deadlineTimer) clearTimeout(deadlineTimer);
               resolve();
             }
           };
           child.once('close', done);
           child.once('exit', done);
-          setTimeout(() => {
-            if (!resolved) {
+
+          killTimer = setTimeout(() => {
+            killTimer = undefined;
+            if (!resolved && (child.exitCode === null && child.signalCode === null)) {
               try { child.kill('SIGKILL'); } catch { /* ignore */ }
-              done();
             }
-          }, 1_000).unref();
+          }, 1_500);
+
+          deadlineTimer = setTimeout(() => {
+            deadlineTimer = undefined;
+            done();
+          }, 3_500);
         });
         exitPromises.push(exitPromise);
         try { child.kill('SIGTERM'); } catch { /* ignore */ }
       }
     }
-
     if (exitPromises.length > 0) {
       await Promise.all(exitPromises);
     }

--- a/docs-site/reference/environment-variables.md
+++ b/docs-site/reference/environment-variables.md
@@ -45,6 +45,8 @@ Copy `.env.example` to `.env` and replace all `change-me` placeholder secrets be
 | `MAX_ARTIFACT_BYTES` | `16777216` | **Required** | Required configuration. |
 | `MAX_PRINCIPAL_ARTIFACT_BYTES` | `134217728` | **Required** | Required configuration. |
 | `ARTIFACT_RETENTION_SECONDS` | `86400` | **Required** | Required configuration. |
+| `REPO_CACHE_ROOT` | `/var/lib/cloud-harness/cache/repos` | **Required** | Required configuration. |
+| `ENABLE_REPO_CACHE` | `false` | Optional | Optional configuration. |
 | `EXECUTOR_IMAGE` | `cloud-harness-executor:local` | **Required** | Required configuration. |
 | `ALLOWED_GIT_HOSTS` | `github.com` | **Required** | Required configuration. |
 | `WORKSPACE_NETWORK_MODE` | `none` | **Required** | Required configuration. |

--- a/docs-site/reference/sessions-and-tasks.md
+++ b/docs-site/reference/sessions-and-tasks.md
@@ -23,3 +23,18 @@ For complex multi-stage builds or benchmarks:
 - `tasks_status`: Polls execution status and outputs of tasks.
 - `tasks_cancel`: Cancels running or pending graph stages.
 - `tasks_graph`: Inspects dependency topology.
+## MCP Tasks Extension Compatibility Matrix (2026-07-28 Revision)
+
+The official Model Context Protocol specification ([Tasks Extension Overview](https://modelcontextprotocol.io/extensions/tasks/overview), 2026-07-28 revision) defines task management as an optional protocol extension (`io.modelcontextprotocol/tasks`) with `tasks/get`, `tasks/update`, `tasks/cancel`, and progress notifications.
+
+| Host / Client | Extension Support Status | Capability Handshake | Decision |
+| :--- | :--- | :--- | :--- |
+| **Claude Desktop** | Absent from official matrix | Not verified | Maintain canonical `tasks_*` tools |
+| **Cursor** | Absent from official matrix | Not verified | Maintain canonical `tasks_*` tools |
+| **Codex** | Absent from official matrix | Not verified | Maintain canonical `tasks_*` tools |
+| **ChatGPT Web** | Absent from official matrix | Not verified | Maintain canonical `tasks_*` tools |
+| **Generic Streamable HTTP** | Absent from official matrix | Not verified | Maintain canonical `tasks_*` tools |
+
+*Reference: [Official Extension Client Matrix](https://modelcontextprotocol.io/extensions/client-matrix).*
+
+**Decision:** Cloud Harness MCP keeps its stable, verified tool contracts (`tasks_run`, `tasks_status`, `tasks_list`, `tasks_cancel`, `tasks_graph`) as canonical. Standard MCP Tasks facade integration remains evaluated and **default-off** to prevent protocol drift until official client host runtime support is verified across the ecosystem matrix.

--- a/docs-site/reference/tools.md
+++ b/docs-site/reference/tools.md
@@ -675,6 +675,8 @@ Create an unsigned local Git commit with default or explicit author and message.
 | `authorName` | `string` | No | length: 1–200 |
 | `authorEmail` | `string` | No | format: `email`, pattern: `^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$` |
 | `all` | `boolean` | **Yes** | default: `false` |
+| `expectedHeadOid` | `string` | No | pattern: `^(?:[0-9a-f]{40}|[0-9a-f]{64})$` |
+| `idempotencyKey` | `string` | No | length: 1–256 |
 
 ### `git_identity_status`
 
@@ -767,6 +769,7 @@ Push a constrained branch refspec to origin, with optional explicit force-with-l
 | `refspec` | `string` | No | length: 1–512 |
 | `forceWithLease` | `boolean` | **Yes** | default: `false` |
 | `expectedRemoteOid` | `string` | No | pattern: `^(?:[0-9a-f]{40}|[0-9a-f]{64})$` |
+| `idempotencyKey` | `string` | No | length: 1–256 |
 
 ### `git_merge`
 

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -158,11 +158,15 @@ workspace. This makes a lost response recoverable without duplicating work.
   maintains isolated bare mirror caches (`chmod 0700`) per principal and clones using
   `git clone --reference-if-able <cache_path> --dissociate`, ensuring workspace object databases become
   completely independent after clone with automatic fallback to blobless clone.
-- **MCP Tasks Specification Evaluation:** The official Model Context Protocol specification
-  (2026-07-28 revision) transitioned Tasks into an optional extension (`io.modelcontextprotocol/tasks`)
-  negotiated via per-request server capabilities and dynamic discovery. Cloud Harness MCP maintains
-  its stable, verified public task tool contracts (`tasks_run`, `tasks_status`, `tasks_list`, `tasks_cancel`,
-  `tasks_graph`) as canonical. Standard MCP Tasks facade integration remains evaluated and default-off
+- **MCP Tasks Specification Evaluation (2026-07-28 Revision):** The official Model Context Protocol specification
+  ([Overview](https://modelcontextprotocol.io/extensions/tasks/overview), 2026-07-28 revision) transitioned Tasks from
+  basic utilities into an optional extension (`io.modelcontextprotocol/tasks`) negotiated via per-request server capabilities
+  and `server/discover`. The specification defines methods (`tasks/get`, `tasks/update`, `tasks/cancel`), polymorphic
+  tool results (`resultType: "task"`), and progress notifications (`notifications/tasks/progress`).
+  According to the official [Extension Client Matrix](https://modelcontextprotocol.io/extensions/client-matrix), major host
+  clients (Claude Desktop, Cursor, Codex, ChatGPT Web) do not yet advertise or verify Tasks extension capability handshake.
+  Cloud Harness MCP maintains its stable, verified public task tool contracts (`tasks_run`, `tasks_status`, `tasks_list`,
+  `tasks_cancel`, `tasks_graph`) as canonical. Standard MCP Tasks facade integration remains evaluated and **default-off**
   until official client host runtime support is verified across the ecosystem matrix.
 - Retained artifact snapshots (`artifacts_snapshot`, `artifacts_list`, `artifacts_read`,
   `artifacts_restore`, `artifacts_delete`) allow agents to explicitly retain selected


### PR DESCRIPTION
## Outcome
Hardens process exit barrier in `stopWorkspace`, resolves race windows during teardown artifact spooling, and documents the official MCP Tasks Extension Compatibility Matrix.

Ref: #14

## Changes
1. **Awaitable Process Exit Barrier (`operation-manager.ts`)**:
   - Checks `child.exitCode === null && child.signalCode === null` to verify actual process execution state instead of `.killed`.
   - Sends `SIGTERM`, escalates to `SIGKILL` after 1.5s if not exited, and awaits process termination before teardown proceeds.
2. **MCP Tasks Extension Compatibility Matrix (`docs/mcp-api.md`, `docs-site/reference/sessions-and-tasks.md`)**:
   - Documents the 2026-07-28 extension specification (`io.modelcontextprotocol/tasks`), protocol methods, and host matrix evaluation across major clients.
   - Formalizes the default-off decision preserving canonical `tasks_*` tools.
3. **Docs Synchronization (`docs/operations.md`, `docs/troubleshooting.md`, `docs-site/`)**:
   - Removes stale references describing tasks as volatile runtime state.
   - Synchronizes generated references (`tools.md`, `environment-variables.md`, `llms.txt`).
4. **Verification**:
   - 65 test files, 478 unit tests passing.
   - Clean typechecking and ESLint.
   - Compose boundaries verified.