### PR TITLE
feat(runner): add legacy finalize idempotency migration and cross-operation protection (#14)

### DIFF
--- a/apps/runner/src/operation-manager.ts
+++ b/apps/runner/src/operation-manager.ts
@@ -615,15 +615,12 @@ export class OperationManager {
     return record;
   }
   async stopWorkspace(workspaceId: string, ownerId?: string): Promise<void> {
-    const now = Date.now();
     const activeRecords = this.records(workspaceId).filter(
       (record) => record.status === 'running' || record.status === 'queued'
     );
     const exitPromises: Promise<void>[] = [];
 
     for (const record of activeRecords) {
-      record.status = 'cancelled';
-      record.finishedAt = now;
       if (record.child && (record.child.exitCode === null && record.child.signalCode === null)) {
         const child = record.child;
         const exitPromise = new Promise<void>((resolve, reject) => {
@@ -663,11 +660,14 @@ export class OperationManager {
         try { child.kill('SIGTERM'); } catch { /* ignore */ }
       }
     }
+
     if (exitPromises.length > 0) {
       await Promise.all(exitPromises);
     }
-
+    const now = Date.now();
     for (const record of activeRecords) {
+      record.status = 'cancelled';
+      record.finishedAt = now;
       if (this.store && this.tasks.has(record.id)) {
         try {
           const current = this.store.getDurableTask(ownerId ?? record.ownerId ?? '', record.workspaceId, record.id);

--- a/apps/runner/src/principal-store.ts
+++ b/apps/runner/src/principal-store.ts
@@ -193,8 +193,8 @@ export function migratePrincipalSchema(database: DatabaseSync): void {
         SELECT f.owner_id, f.workspace_id, f.idempotency_key, 'finalize', '',
           'SUCCEEDED', f.result_json, f.created_at, f.created_at
         FROM finalize_idempotency f
-        WHERE EXISTS (SELECT 1 FROM workspaces w WHERE w.owner_id = f.owner_id AND w.id = f.workspace_id);
-
+        WHERE EXISTS (SELECT 1 FROM workspaces w WHERE w.owner_id = f.owner_id AND w.id = f.workspace_id)
+          AND EXISTS (SELECT 1 FROM principals p WHERE p.id = f.owner_id);
         UPDATE schema_meta SET version = 4;
       `);
     });

--- a/apps/runner/src/principal-store.ts
+++ b/apps/runner/src/principal-store.ts
@@ -186,6 +186,15 @@ export function migratePrincipalSchema(database: DatabaseSync): void {
         );
         CREATE INDEX IF NOT EXISTS git_op_idempotency_lookup ON git_operation_idempotency(owner_id, workspace_id, operation, created_at DESC);
 
+        INSERT OR IGNORE INTO git_operation_idempotency (
+          owner_id, workspace_id, idempotency_key, operation, request_fingerprint,
+          status, result_json, created_at, finished_at
+        )
+        SELECT f.owner_id, f.workspace_id, f.idempotency_key, 'finalize', '',
+          'SUCCEEDED', f.result_json, f.created_at, f.created_at
+        FROM finalize_idempotency f
+        WHERE EXISTS (SELECT 1 FROM workspaces w WHERE w.owner_id = f.owner_id AND w.id = f.workspace_id);
+
         UPDATE schema_meta SET version = 4;
       `);
     });

--- a/apps/runner/src/principal-store.ts
+++ b/apps/runner/src/principal-store.ts
@@ -352,7 +352,24 @@ function resolveExternalPrincipalInTransaction(
     principalId, selector.issuer, selector.subject, selector.email ?? null, selector.name ?? null,
     legacyOwnerId ?? null, now, now
   );
-  if (legacyOwnerId) database.prepare('UPDATE workspaces SET owner_id = ? WHERE owner_id = ?').run(principalId, legacyOwnerId);
+  if (legacyOwnerId) {
+    database.prepare('UPDATE workspaces SET owner_id = ? WHERE owner_id = ?').run(principalId, legacyOwnerId);
+    try {
+      database.prepare('UPDATE finalize_idempotency SET owner_id = ? WHERE owner_id = ?').run(principalId, legacyOwnerId);
+      database.prepare(`
+        INSERT OR IGNORE INTO git_operation_idempotency (
+          owner_id, workspace_id, idempotency_key, operation, request_fingerprint,
+          status, result_json, created_at, finished_at
+        )
+        SELECT f.owner_id, f.workspace_id, f.idempotency_key, 'finalize', '',
+          'SUCCEEDED', f.result_json, f.created_at, f.created_at
+        FROM finalize_idempotency f
+        WHERE f.owner_id = ?
+          AND EXISTS (SELECT 1 FROM workspaces w WHERE w.owner_id = f.owner_id AND w.id = f.workspace_id)
+          AND EXISTS (SELECT 1 FROM principals p WHERE p.id = f.owner_id);
+      `).run(principalId);
+    } catch { /* ignore if tables do not exist yet */ }
+  }
   return principalId;
 }
 

--- a/apps/runner/src/state-store.ts
+++ b/apps/runner/src/state-store.ts
@@ -660,20 +660,27 @@ export class StateStore {
   }
 
   getFinalizeIdempotency(ownerId: string, workspaceId: string, key: string): string | undefined {
+    const gitOp = this.getGitOperation(ownerId, workspaceId, key);
+    if (gitOp?.resultJson) return gitOp.resultJson;
     const row = this.database.prepare('SELECT result_json FROM finalize_idempotency WHERE owner_id = ? AND workspace_id = ? AND idempotency_key = ?').get(ownerId, workspaceId, key) as { result_json: string } | undefined;
     return row?.result_json;
   }
 
   setFinalizeIdempotency(ownerId: string, workspaceId: string, key: string, resultJson: string): void {
+    const now = Date.now();
     this.database.prepare('INSERT OR REPLACE INTO finalize_idempotency(owner_id, workspace_id, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?, ?)')
-      .run(ownerId, workspaceId, key, resultJson, Date.now());
+      .run(ownerId, workspaceId, key, resultJson, now);
+    this.database.prepare(`
+      INSERT OR REPLACE INTO git_operation_idempotency
+      (owner_id, workspace_id, idempotency_key, operation, request_fingerprint, target_ref,
+       expected_remote_oid, local_commit_sha, status, result_json, error_json, created_at, finished_at)
+      VALUES (?, ?, ?, 'finalize', '', NULL, NULL, NULL, 'SUCCEEDED', ?, NULL, ?, ?)
+    `).run(ownerId, workspaceId, key, resultJson, now, now);
   }
-
   getBatchWriteIdempotency(ownerId: string, workspaceId: string, key: string): string | undefined {
     const row = this.database.prepare('SELECT result_json FROM batch_write_idempotency WHERE owner_id = ? AND workspace_id = ? AND idempotency_key = ?').get(ownerId, workspaceId, key) as { result_json: string } | undefined;
     return row?.result_json;
   }
-
   setBatchWriteIdempotency(ownerId: string, workspaceId: string, key: string, resultJson: string): void {
     this.database.prepare('INSERT OR REPLACE INTO batch_write_idempotency(owner_id, workspace_id, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?, ?)')
       .run(ownerId, workspaceId, key, resultJson, Date.now());
@@ -1211,6 +1218,51 @@ export class StateStore {
     try {
       const existing = this.getGitOperation(record.ownerId, record.workspaceId, record.idempotencyKey);
       if (!existing) {
+        let legacyResultJson: string | undefined;
+        let legacyCreatedAt = record.createdAt;
+        if (record.operation === 'finalize') {
+          try {
+            const legacy = this.database.prepare(
+              'SELECT result_json, created_at FROM finalize_idempotency WHERE owner_id = ? AND workspace_id = ? AND idempotency_key = ?'
+            ).get(record.ownerId, record.workspaceId, record.idempotencyKey) as { result_json: string; created_at: number } | undefined;
+            if (legacy) {
+              legacyResultJson = legacy.result_json;
+              legacyCreatedAt = legacy.created_at;
+            }
+          } catch { /* ignore if table absent */ }
+        }
+
+        if (legacyResultJson) {
+          this.database.prepare(`
+            INSERT INTO git_operation_idempotency
+            (owner_id, workspace_id, idempotency_key, operation, request_fingerprint, target_ref,
+             expected_remote_oid, local_commit_sha, status, result_json, error_json, created_at, finished_at)
+            VALUES (?, ?, ?, 'finalize', '', NULL, NULL, NULL, 'SUCCEEDED', ?, NULL, ?, ?)
+          `).run(
+            record.ownerId, record.workspaceId, record.idempotencyKey,
+            legacyResultJson, legacyCreatedAt, legacyCreatedAt
+          );
+          this.database.exec('COMMIT;');
+          return {
+            action: 'REPLAY_SUCCEEDED',
+            existing: {
+              ownerId: record.ownerId,
+              workspaceId: record.workspaceId,
+              idempotencyKey: record.idempotencyKey,
+              operation: 'finalize',
+              requestFingerprint: '',
+              targetRef: null,
+              expectedRemoteOid: null,
+              localCommitSha: null,
+              status: 'SUCCEEDED',
+              resultJson: legacyResultJson,
+              errorJson: null,
+              createdAt: legacyCreatedAt,
+              finishedAt: legacyCreatedAt
+            }
+          };
+        }
+
         this.database.prepare(`
           INSERT INTO git_operation_idempotency
           (owner_id, workspace_id, idempotency_key, operation, request_fingerprint, target_ref,
@@ -1226,6 +1278,12 @@ export class StateStore {
       }
 
       this.database.exec('COMMIT;');
+      if (existing.operation !== record.operation) {
+        return { action: 'FINGERPRINT_CONFLICT', existing };
+      }
+      if (existing.operation === 'finalize' && record.operation === 'finalize' && existing.status === 'SUCCEEDED' && existing.requestFingerprint === '') {
+        return { action: 'REPLAY_SUCCEEDED', existing };
+      }
       if (existing.requestFingerprint !== record.requestFingerprint) {
         return { action: 'FINGERPRINT_CONFLICT', existing };
       }

--- a/apps/runner/src/state-store.ts
+++ b/apps/runner/src/state-store.ts
@@ -667,15 +667,8 @@ export class StateStore {
   }
 
   setFinalizeIdempotency(ownerId: string, workspaceId: string, key: string, resultJson: string): void {
-    const now = Date.now();
     this.database.prepare('INSERT OR REPLACE INTO finalize_idempotency(owner_id, workspace_id, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?, ?)')
-      .run(ownerId, workspaceId, key, resultJson, now);
-    this.database.prepare(`
-      INSERT OR REPLACE INTO git_operation_idempotency
-      (owner_id, workspace_id, idempotency_key, operation, request_fingerprint, target_ref,
-       expected_remote_oid, local_commit_sha, status, result_json, error_json, created_at, finished_at)
-      VALUES (?, ?, ?, 'finalize', '', NULL, NULL, NULL, 'SUCCEEDED', ?, NULL, ?, ?)
-    `).run(ownerId, workspaceId, key, resultJson, now, now);
+      .run(ownerId, workspaceId, key, resultJson, Date.now());
   }
   getBatchWriteIdempotency(ownerId: string, workspaceId: string, key: string): string | undefined {
     const row = this.database.prepare('SELECT result_json FROM batch_write_idempotency WHERE owner_id = ? AND workspace_id = ? AND idempotency_key = ?').get(ownerId, workspaceId, key) as { result_json: string } | undefined;

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -2030,6 +2030,8 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
       return result;
     }
     if (operation === 'workspace_finalize') {
+      const branch = (validated.branch as string | undefined) ?? await this.currentBranch(record, signal);
+      const targetRef = `refs/heads/${branch}`;
       const idempotencyKey = validated.idempotencyKey as string | undefined;
       const requestFingerprint = idempotencyKey
         ? createHash('sha256').update(JSON.stringify(validated)).digest('hex')
@@ -2042,7 +2044,7 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
           idempotencyKey,
           operation: 'finalize',
           requestFingerprint,
-          targetRef: null,
+          targetRef,
           expectedRemoteOid: null,
           localCommitSha: null,
           createdAt: Date.now()
@@ -2058,7 +2060,31 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
           const parsed = JSON.parse(claim.existing.resultJson) as RunnerResponse;
           return { ...parsed, data: { ...(typeof parsed.data === 'object' && parsed.data ? parsed.data : {}), alreadyFinalized: true } };
         }
-        if (claim.action === 'RECONCILE_REQUIRED') {
+        if (claim.action === 'RECONCILE_REQUIRED' && claim.existing) {
+          const existingOp = claim.existing;
+          if (existingOp.status === 'UNKNOWN_REMOTE_STATE' && existingOp.localCommitSha) {
+            const repositoryUrl = await validateRepositoryUrl(record.repositoryUrl, this.config.allowedGitHosts);
+            let token: string | undefined;
+            try {
+              token = await this.repositoryToken(record.ownerId, repositoryUrl, 'write');
+            } catch { /* ignore if token cannot be minted */ }
+            const remoteOid = await this.probeRemoteRefOid(record, branch, token, signal);
+            if (remoteOid && remoteOid === existingOp.localCommitSha) {
+              const successResponse: RunnerResponse = {
+                ok: true,
+                message: `Workspace finalized and pushed to ${branch} (reconciled from remote state)`,
+                data: {
+                  commitSha: existingOp.localCommitSha,
+                  branch,
+                  pushed: true,
+                  alreadyFinalized: true
+                },
+                truncated: false
+              };
+              this.store.updateGitOperationStatus(ownerId, record.id, idempotencyKey, 'SUCCEEDED', JSON.stringify(successResponse), null, existingOp.localCommitSha);
+              return successResponse;
+            }
+          }
           this.store.updateGitOperationStatus(ownerId, record.id, idempotencyKey, 'PENDING');
         }
       }
@@ -2116,7 +2142,10 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
           let pushResult: RunnerResponse | undefined;
           if (validated.push !== false) {
             try {
-              pushResult = await this.remotePush(record, { refspec: `HEAD:refs/heads/${branch}` }, signal);
+              pushResult = await this.remotePush(record, {
+                refspec: `HEAD:refs/heads/${branch}`,
+                idempotencyKey: idempotencyKey ? `${idempotencyKey}:push` : undefined
+              }, signal);
               pushed = Boolean(pushResult.ok);
             } catch (err: unknown) {
               const pushErrMsg = err instanceof Error ? err.message : 'push failed';
@@ -2125,6 +2154,16 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
               const operationDetail = err instanceof HarnessError ? err.operation : undefined;
               const repositoryDetail = err instanceof HarnessError ? err.repository : undefined;
               const requiredCapDetail = err instanceof HarnessError ? err.requiredCapability : undefined;
+              if (idempotencyKey) {
+                const isUnknown = errorCode === 'UNKNOWN_REMOTE_STATE';
+                this.store.updateGitOperationStatus(
+                  ownerId, record.id, idempotencyKey,
+                  isUnknown ? 'UNKNOWN_REMOTE_STATE' : 'FAILED',
+                  null,
+                  JSON.stringify({ message: pushErrMsg, code: errorCode }),
+                  commitSha
+                );
+              }
               return {
                 ok: false,
                 message: `Working tree clean but push failed: ${pushErrMsg}`,
@@ -2188,13 +2227,19 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
 
         const logResult = await this.runWorker(record, 'git_log', { limit: 1 }, signal);
         const commitSha = (logResult.data && typeof logResult.data === 'object' && 'output' in logResult.data && typeof logResult.data.output === 'string') ? logResult.data.output.split('\t')?.[0] || '' : '';
+        if (idempotencyKey && commitSha) {
+          this.store.updateGitOperationStatus(ownerId, record.id, idempotencyKey, 'PENDING', null, null, commitSha);
+        }
 
         // Step 5: Push if requested
         let pushResult: RunnerResponse | undefined;
         let pushed = false;
         if (validated.push !== false) {
           try {
-            pushResult = await this.remotePush(record, { refspec: `HEAD:refs/heads/${branch}` }, signal);
+            pushResult = await this.remotePush(record, {
+              refspec: `HEAD:refs/heads/${branch}`,
+              idempotencyKey: idempotencyKey ? `${idempotencyKey}:push` : undefined
+            }, signal);
             pushed = Boolean(pushResult.ok);
           } catch (pushErr: unknown) {
             const pushErrMsg = pushErr instanceof Error ? pushErr.message : 'push failed';
@@ -2203,6 +2248,16 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
             const operationDetail = pushErr instanceof HarnessError ? pushErr.operation : undefined;
             const repositoryDetail = pushErr instanceof HarnessError ? pushErr.repository : undefined;
             const requiredCapDetail = pushErr instanceof HarnessError ? pushErr.requiredCapability : undefined;
+            if (idempotencyKey) {
+              const isUnknown = errorCode === 'UNKNOWN_REMOTE_STATE';
+              this.store.updateGitOperationStatus(
+                ownerId, record.id, idempotencyKey,
+                isUnknown ? 'UNKNOWN_REMOTE_STATE' : 'FAILED',
+                null,
+                JSON.stringify({ message: pushErrMsg, code: errorCode }),
+                commitSha
+              );
+            }
             return {
               ok: false,
               message: `Commit created (${commitSha.slice(0, 7)}) but push failed: ${pushErrMsg}`,
@@ -2255,11 +2310,12 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
       }
 
       if (idempotencyKey) {
+        const commitSha = (response.data && typeof response.data === 'object' && 'commitSha' in response.data && typeof response.data.commitSha === 'string') ? response.data.commitSha : undefined;
         if (response.ok) {
-          const commitSha = (response.data && typeof response.data === 'object' && 'commitSha' in response.data && typeof response.data.commitSha === 'string') ? response.data.commitSha : undefined;
           this.store.updateGitOperationStatus(ownerId, record.id, idempotencyKey, 'SUCCEEDED', JSON.stringify(response), null, commitSha);
         } else {
-          this.store.updateGitOperationStatus(ownerId, record.id, idempotencyKey, 'FAILED', null, JSON.stringify(response.error ?? { message: response.message }));
+          const isUnknown = response.error?.code === 'UNKNOWN_REMOTE_STATE';
+          this.store.updateGitOperationStatus(ownerId, record.id, idempotencyKey, isUnknown ? 'UNKNOWN_REMOTE_STATE' : 'FAILED', null, JSON.stringify(response.error ?? { message: response.message }), commitSha);
         }
       }
       return response;

--- a/apps/runner/test/durable-tasks.test.ts
+++ b/apps/runner/test/durable-tasks.test.ts
@@ -550,11 +550,15 @@ describe('Durable Task Engine & Restart Reconciliation', () => {
       unkillableChild.stdout = new EventEmitter();
       unkillableChild.stderr = new EventEmitter();
       unkillableChild.kill = () => { /* ignores signals */ };
-
+      if (task.child) {
+        task.child.removeAllListeners();
+        try { task.child.kill(); } catch { /* ignore */ }
+      }
       (ops as unknown as { track: (t: unknown, c: unknown, b: number) => void }).track(task, unkillableChild, 65536);
       task.child = unkillableChild as unknown as ChildProcessWithoutNullStreams;
-
-      // Attempt workspace_close -> stopWorkspace hits deadline and throws 503 UNAVAILABLE
+      task.status = 'running';
+      task.exitCode = undefined;
+      // Attempt 1: workspace_close -> stopWorkspace hits deadline and throws 503 UNAVAILABLE
       await expect(
         service.execute(ownerId, 'workspace_close', { workspaceId: wsId })
       ).rejects.toThrow(/failed to terminate within teardown deadline/);
@@ -564,11 +568,32 @@ describe('Durable Task Engine & Restart Reconciliation', () => {
       expect(existsSync(logFile)).toBe(true);
 
       // Workspace status must be rolled back to EXPIRED_RECOVERABLE
-      const wsRecord = store.byId(wsId);
-      expect(wsRecord?.status).toBe('EXPIRED_RECOVERABLE');
-      expect(wsRecord?.error).toContain('Workspace stop failed');
+      const wsRecord1 = store.byId(wsId);
+      expect(wsRecord1?.status).toBe('EXPIRED_RECOVERABLE');
+      expect(wsRecord1?.error).toContain('Workspace stop failed');
+
+      // Attempt 2: retry while child is STILL unkillable -> must reject AGAIN without bypassing live child!
+      await expect(
+        service.execute(ownerId, 'workspace_close', { workspaceId: wsId })
+      ).rejects.toThrow(/failed to terminate within teardown deadline/);
+      expect(existsSync(wsPath)).toBe(true);
+
+      // Attempt 3: child is allowed to exit on signal
+      unkillableChild.kill = () => {
+        unkillableChild.exitCode = 0;
+        unkillableChild.emit('close', 0);
+        unkillableChild.emit('exit', 0);
+      };
+
+      const closeSuccess = await service.execute(ownerId, 'workspace_close', { workspaceId: wsId });
+      expect(closeSuccess.ok).toBe(true);
+
+      // Now workspace path is cleaned up and status is CLOSED
+      expect(existsSync(wsPath)).toBe(false);
+      const wsRecordFinal = store.byId(wsId);
+      expect(wsRecordFinal?.status).toBe('CLOSED');
     } finally {
       store.close();
     }
-  }, 10_000);
+  }, 20_000);
 });

--- a/apps/runner/test/git-push-durability.test.ts
+++ b/apps/runner/test/git-push-durability.test.ts
@@ -1,11 +1,11 @@
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mkdirSync } from 'node:fs';
-import { randomBytes } from 'node:crypto';
+import { randomBytes, createHash } from 'node:crypto';
 import { describe, it, expect, vi } from 'vitest';
 import { StateStore } from '../src/state-store.js';
 import { WorkspaceService } from '../src/workspace-service.js';
-import { HarnessError } from '@cloud-harness/contracts';
+import { HarnessError, TOOL_SCHEMA_BY_NAME } from '@cloud-harness/contracts';
 
 const tempDir = () => {
   const dir = join(tmpdir(), `test-git-durability-${randomBytes(8).toString('hex')}`);
@@ -331,6 +331,113 @@ describe('Remote-Git Idempotency & Error Taxonomy', () => {
           idempotencyKey: 'ik_in_flight'
         })
       ).rejects.toThrow(/already in progress|parameters/);
+    } finally {
+      store.close();
+    }
+  }, 15_000);
+
+  it('reconciles interrupted workspace_finalize from remote ref without duplicating commit or push', async () => {
+    const dir = tempDir();
+    const dbPath = join(dir, 'state.sqlite');
+    const store = new StateStore(dbPath);
+
+    const config = {
+      jobsRoot: join(dir, 'jobs'),
+      stateDb: dbPath,
+      executorImage: 'cloud-harness-executor:local',
+      allowedGitHosts: ['github.com'],
+      networkMode: 'none',
+      wallTtlSeconds: 300,
+      idleTtlSeconds: 180,
+      maxOutputBytes: 262_144,
+      minFreeBytes: 104_857_600,
+      maxWorkspaceBytes: 536_870_912,
+      reaperIntervalSeconds: 30,
+      artifactRoot: join(dir, 'artifacts'),
+      maxArtifactBytes: 16_777_216,
+      maxPrincipalArtifactBytes: 134_217_728,
+      artifactRetentionSeconds: 86_400,
+      enableRepoCache: false,
+      repoCacheRoot: join(dir, 'cache')
+    };
+
+    const service = new WorkspaceService(config, store);
+
+    try {
+      const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'test-owner-finalize' });
+      const wsId = 'ws_finalize_interrupted_test';
+
+      store.create({
+        id: wsId,
+        ownerId,
+        idempotencyKey: 'ik_ws_fin',
+        repositoryUrl: 'https://github.com/org/repo',
+        workspacePath: join(dir, 'jobs', wsId),
+        status: 'ACTIVE',
+        networkMode: 'none',
+        createdAt: Date.now(),
+        lastActivityAt: Date.now(),
+        expiresAt: Date.now() + 3600_000,
+        hardExpiresAt: Date.now() + 7200_000,
+        gitAuthorName: 'Test Author',
+        gitAuthorEmail: 'author@test.local',
+        mutationLockedUntil: null,
+        generation: 1,
+        error: null
+      });
+
+      // Mock probeRemoteRefOid to return the commit SHA (simulating push landed on remote before runner crash)
+      const knownCommitSha = '9999888877776666555544443333222211110000';
+      vi.spyOn(service as any, 'currentBranch').mockResolvedValue('main');
+      vi.spyOn(service as any, 'repositoryToken').mockResolvedValue('fake-token');
+      vi.spyOn(service as any, 'probeRemoteRefOid').mockResolvedValue(knownCommitSha);
+      // Simulate a runner crash after commit: finalize operation in UNKNOWN_REMOTE_STATE with commitSha recorded
+      const idempotencyKey = 'ik_finalize_crash_recovery';
+      const input = {
+        workspaceId: wsId,
+        commitMessage: 'fix: finalize work',
+        idempotencyKey
+      };
+      const validated = TOOL_SCHEMA_BY_NAME.workspace_finalize.parse(input);
+      const requestFingerprint = createHash('sha256').update(JSON.stringify(validated)).digest('hex');
+      store.recordGitOperationPending({
+        ownerId,
+        workspaceId: wsId,
+        idempotencyKey,
+        operation: 'finalize',
+        requestFingerprint,
+        targetRef: 'refs/heads/main',
+        expectedRemoteOid: null,
+        localCommitSha: knownCommitSha,
+        createdAt: Date.now() - 10_000
+      });
+      store.updateGitOperationStatus(
+        ownerId,
+        wsId,
+        idempotencyKey,
+        'UNKNOWN_REMOTE_STATE',
+        null,
+        JSON.stringify({ message: 'Operation interrupted by runner restart' }),
+        knownCommitSha
+      );
+
+      // Retry workspace_finalize with the same idempotency key
+      const response = await service.execute(ownerId, 'workspace_finalize', {
+        workspaceId: wsId,
+        commitMessage: 'fix: finalize work',
+        idempotencyKey
+      });
+
+      expect(response.ok).toBe(true);
+      expect(response.message).toContain('reconciled from remote state');
+      expect((response.data as any).alreadyFinalized).toBe(true);
+      expect((response.data as any).commitSha).toBe(knownCommitSha);
+      expect((response.data as any).pushed).toBe(true);
+
+      // Verify ledger status was updated to SUCCEEDED
+      const ledgerRecord = store.getGitOperation(ownerId, wsId, idempotencyKey);
+      expect(ledgerRecord?.status).toBe('SUCCEEDED');
+      expect(ledgerRecord?.localCommitSha).toBe(knownCommitSha);
     } finally {
       store.close();
     }

--- a/apps/runner/test/git-push-durability.test.ts
+++ b/apps/runner/test/git-push-durability.test.ts
@@ -390,6 +390,7 @@ describe('Remote-Git Idempotency & Error Taxonomy', () => {
 
       // Mock probeRemoteRefOid to return the commit SHA (simulating push landed on remote before runner crash)
       const knownCommitSha = '9999888877776666555544443333222211110000';
+      vi.spyOn(service as unknown as { workspaceBytes: () => Promise<number> }, 'workspaceBytes').mockResolvedValue(1024);
       vi.spyOn(service as any, 'currentBranch').mockResolvedValue('main');
       vi.spyOn(service as any, 'repositoryToken').mockResolvedValue('fake-token');
       vi.spyOn(service as any, 'probeRemoteRefOid').mockResolvedValue(knownCommitSha);

--- a/apps/runner/test/git-push-durability.test.ts
+++ b/apps/runner/test/git-push-durability.test.ts
@@ -366,6 +366,8 @@ describe('Remote-Git Idempotency & Error Taxonomy', () => {
     try {
       const ownerId = store.resolvePrincipal({ kind: 'owner', ownerId: 'test-owner-finalize' });
       const wsId = 'ws_finalize_interrupted_test';
+      const wsPath = join(dir, 'jobs', wsId);
+      mkdirSync(wsPath, { recursive: true });
 
       store.create({
         id: wsId,

--- a/apps/runner/test/state-schema-v4.test.ts
+++ b/apps/runner/test/state-schema-v4.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { describe, it, expect } from 'vitest';
 import { StateStore, downgradeStateSchemaToV3 } from '../src/state-store.js';
-import { migratePrincipalSchema } from '../src/principal-store.js';
+import { migratePrincipalSchema, applyLegacyPrincipalMapping } from '../src/principal-store.js';
 
 const tempDbPath = () => join(tmpdir(), `test-state-v4-${randomBytes(8).toString('hex')}.sqlite`);
 
@@ -397,6 +397,107 @@ describe('StateStore Schema Version 4 Migration & Durable Primitives', () => {
         createdAt: Date.now()
       });
       expect(lazyPushClaim.action).toBe('ACQUIRED');
+    } finally {
+      store.close();
+    }
+  });
+
+  it('successfully upgrades unmapped legacy owner databases to v4 and migrates finalize idempotency on principal relink', () => {
+    const dbPath = tempDbPath();
+    const store = new StateStore(dbPath);
+    try {
+      // Downgrade to v3 to simulate a legacy database
+      downgradeStateSchemaToV3(store.database);
+      expect((store.database.prepare('SELECT version FROM schema_meta').get() as { version: number }).version).toBe(3);
+
+      // Seed an unmapped legacy workspace with NO principal record
+      const legacyOwnerId = 'owner-raw-legacy-123';
+      const wsId = 'ws_unmapped_legacy';
+      store.database.prepare(`
+        INSERT INTO workspaces (
+          id, owner_id, idempotency_key, repository_url, workspace_path,
+          status, network_mode, created_at, last_activity_at, expires_at, hard_expires_at, generation
+        ) VALUES (?, ?, ?, ?, ?, 'ACTIVE', 'none', ?, ?, ?, ?, 1)
+      `).run(
+        wsId, legacyOwnerId, 'ik_ws_unmapped', 'https://github.com/org/repo', '/tmp/ws_unmapped',
+        Date.now() - 100_000, Date.now() - 100_000, Date.now() + 3600_000, Date.now() + 7200_000
+      );
+
+      // Seed legacy finalize_idempotency row for the unmapped legacy owner
+      const legacyResult = JSON.stringify({ ok: true, message: 'Unmapped finalize', commitSha: 'abcdef1234567890abcdef1234567890abcdef12' });
+      store.database.prepare(
+        'INSERT INTO finalize_idempotency(owner_id, workspace_id, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?, ?)'
+      ).run(legacyOwnerId, wsId, 'ik_unmapped_fin', legacyResult, Date.now() - 50_000);
+
+      // Upgrade to schema version 4: MUST NOT throw foreign key constraint error!
+      migratePrincipalSchema(store.database);
+      expect((store.database.prepare('SELECT version FROM schema_meta').get() as { version: number }).version).toBe(4);
+
+      // Prior to principal mapping, git_operation_idempotency should NOT have the row (since FK to principals is enforced)
+      const unmappedGitOp = store.database.prepare(
+        'SELECT * FROM git_operation_idempotency WHERE workspace_id = ? AND idempotency_key = ?'
+      ).get(wsId, 'ik_unmapped_fin');
+      expect(unmappedGitOp).toBeUndefined();
+
+      // Unmapped finalize row remains preserved in finalize_idempotency
+      const preservedRow = store.database.prepare(
+        'SELECT * FROM finalize_idempotency WHERE owner_id = ? AND workspace_id = ? AND idempotency_key = ?'
+      ).get(legacyOwnerId, wsId, 'ik_unmapped_fin') as { result_json: string } | undefined;
+      expect(preservedRow?.result_json).toBe(legacyResult);
+
+      // Apply legacy principal mapping for this owner
+      const mappedPrincipalId = applyLegacyPrincipalMapping(store.database, {
+        legacyOwnerId,
+        issuer: 'https://access.example.com',
+        subject: 'user-legacy-mapped'
+      });
+      expect(mappedPrincipalId).toMatch(/^prn_/);
+
+      // Workspace and finalize row must now be updated to the mapped principal ID
+      const mappedWs = store.byId(wsId);
+      expect(mappedWs?.ownerId).toBe(mappedPrincipalId);
+
+      // git_operation_idempotency must now have the materialized row under mappedPrincipalId
+      const mappedGitOp = store.getGitOperation(mappedPrincipalId, wsId, 'ik_unmapped_fin');
+      expect(mappedGitOp).toBeDefined();
+      expect(mappedGitOp?.status).toBe('SUCCEEDED');
+      expect(mappedGitOp?.operation).toBe('finalize');
+      expect(mappedGitOp?.resultJson).toBe(legacyResult);
+      expect(mappedGitOp?.requestFingerprint).toBe('');
+
+      // Permanent wildcard replay: acquireGitOperation returns REPLAY_SUCCEEDED regardless of fingerprint
+      const replay1 = store.acquireGitOperation({
+        ownerId: mappedPrincipalId,
+        workspaceId: wsId,
+        idempotencyKey: 'ik_unmapped_fin',
+        operation: 'finalize',
+        requestFingerprint: 'sha256_attempt_1',
+        createdAt: Date.now()
+      });
+      expect(replay1.action).toBe('REPLAY_SUCCEEDED');
+      expect(replay1.existing?.resultJson).toBe(legacyResult);
+
+      const replay2 = store.acquireGitOperation({
+        ownerId: mappedPrincipalId,
+        workspaceId: wsId,
+        idempotencyKey: 'ik_unmapped_fin',
+        operation: 'finalize',
+        requestFingerprint: 'sha256_attempt_2_different',
+        createdAt: Date.now()
+      });
+      expect(replay2.action).toBe('REPLAY_SUCCEEDED');
+      expect(replay2.existing?.resultJson).toBe(legacyResult);
+
+      // Cross-operation conflict: push or commit with the same key is rejected
+      const pushConflict = store.acquireGitOperation({
+        ownerId: mappedPrincipalId,
+        workspaceId: wsId,
+        idempotencyKey: 'ik_unmapped_fin',
+        operation: 'push',
+        requestFingerprint: 'sha256_attempt_1',
+        createdAt: Date.now()
+      });
+      expect(pushConflict.action).toBe('FINGERPRINT_CONFLICT');
     } finally {
       store.close();
     }

--- a/apps/runner/test/state-schema-v4.test.ts
+++ b/apps/runner/test/state-schema-v4.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { describe, it, expect } from 'vitest';
 import { StateStore, downgradeStateSchemaToV3 } from '../src/state-store.js';
+import { migratePrincipalSchema } from '../src/principal-store.js';
 
 const tempDbPath = () => join(tmpdir(), `test-state-v4-${randomBytes(8).toString('hex')}.sqlite`);
 
@@ -264,6 +265,138 @@ describe('StateStore Schema Version 4 Migration & Durable Primitives', () => {
       expect((store.database.prepare('SELECT version FROM schema_meta').get() as { version: number }).version).toBe(4);
       downgradeStateSchemaToV3(store.database);
       expect((store.database.prepare('SELECT version FROM schema_meta').get() as { version: number }).version).toBe(3);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('migrates legacy finalize_idempotency rows to v4 and replays without fingerprint conflict', () => {
+    const dbPath = tempDbPath();
+    const store = new StateStore(dbPath);
+    try {
+      // Downgrade to v3 to simulate a legacy database
+      downgradeStateSchemaToV3(store.database);
+      expect((store.database.prepare('SELECT version FROM schema_meta').get() as { version: number }).version).toBe(3);
+
+      const p = store.resolvePrincipal({ kind: 'owner', ownerId: 'legacy-user' });
+      const wsId = 'ws_legacy_finalize';
+      store.create({
+        id: wsId,
+        ownerId: p,
+        idempotencyKey: 'ik_ws_legacy',
+        repositoryUrl: 'https://github.com/org/repo',
+        workspacePath: '/tmp/ws_legacy',
+        status: 'ACTIVE',
+        networkMode: 'none',
+        createdAt: Date.now() - 100_000,
+        lastActivityAt: Date.now() - 100_000,
+        expiresAt: Date.now() + 3600_000,
+        hardExpiresAt: Date.now() + 7200_000,
+        gitAuthorName: null,
+        gitAuthorEmail: null,
+        mutationLockedUntil: null,
+        generation: 1,
+        error: null
+      });
+
+      // Seed legacy finalize_idempotency row
+      const legacyResult = JSON.stringify({ ok: true, message: 'Legacy finalized', commitSha: '1111222233334444555566667777888899990000' });
+      store.database.prepare(
+        'INSERT INTO finalize_idempotency(owner_id, workspace_id, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?, ?)'
+      ).run(p, wsId, 'ik_legacy_fin_1', legacyResult, Date.now() - 50_000);
+
+      // Upgrade to v4
+      migratePrincipalSchema(store.database);
+      expect((store.database.prepare('SELECT version FROM schema_meta').get() as { version: number }).version).toBe(4);
+
+      // Verify row was migrated into git_operation_idempotency
+      const migratedRow = store.getGitOperation(p, wsId, 'ik_legacy_fin_1');
+      expect(migratedRow).toBeDefined();
+      expect(migratedRow?.status).toBe('SUCCEEDED');
+      expect(migratedRow?.operation).toBe('finalize');
+      expect(migratedRow?.resultJson).toBe(legacyResult);
+      expect(migratedRow?.requestFingerprint).toBe('');
+
+      // Simulate workspace_finalize retry with computed SHA-256 fingerprint #1
+      const claim1 = store.acquireGitOperation({
+        ownerId: p,
+        workspaceId: wsId,
+        idempotencyKey: 'ik_legacy_fin_1',
+        operation: 'finalize',
+        requestFingerprint: 'sha256_fingerprint_1',
+        createdAt: Date.now()
+      });
+      expect(claim1.action).toBe('REPLAY_SUCCEEDED');
+      expect(claim1.existing?.resultJson).toBe(legacyResult);
+
+      // Verify sentinel is NOT rewritten, keeping permanent wildcard replay
+      const checkRow = store.getGitOperation(p, wsId, 'ik_legacy_fin_1');
+      expect(checkRow?.requestFingerprint).toBe('');
+
+      // Subsequent retry with a different fingerprint also succeeds (wildcard replay for legacy row)
+      const claim2 = store.acquireGitOperation({
+        ownerId: p,
+        workspaceId: wsId,
+        idempotencyKey: 'ik_legacy_fin_1',
+        operation: 'finalize',
+        requestFingerprint: 'sha256_fingerprint_2_different',
+        createdAt: Date.now()
+      });
+      expect(claim2.action).toBe('REPLAY_SUCCEEDED');
+      expect(claim2.existing?.resultJson).toBe(legacyResult);
+
+      // Cross-operation rejection: git_push reusing legacy finalize key MUST be rejected with FINGERPRINT_CONFLICT
+      const pushClaim = store.acquireGitOperation({
+        ownerId: p,
+        workspaceId: wsId,
+        idempotencyKey: 'ik_legacy_fin_1',
+        operation: 'push',
+        requestFingerprint: 'sha256_fingerprint_1',
+        createdAt: Date.now()
+      });
+      expect(pushClaim.action).toBe('FINGERPRINT_CONFLICT');
+
+      // Cross-operation rejection: git_commit reusing legacy finalize key MUST be rejected with FINGERPRINT_CONFLICT
+      const commitClaim = store.acquireGitOperation({
+        ownerId: p,
+        workspaceId: wsId,
+        idempotencyKey: 'ik_legacy_fin_1',
+        operation: 'commit',
+        requestFingerprint: 'sha256_fingerprint_1',
+        createdAt: Date.now()
+      });
+      expect(commitClaim.action).toBe('FINGERPRINT_CONFLICT');
+
+      // Test lazy fallback for unmigrated finalize row
+      store.database.prepare(
+        'INSERT INTO finalize_idempotency(owner_id, workspace_id, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?, ?)'
+      ).run(p, wsId, 'ik_lazy_fin_2', legacyResult, Date.now() - 20_000);
+
+      const lazyFinalizeClaim = store.acquireGitOperation({
+        ownerId: p,
+        workspaceId: wsId,
+        idempotencyKey: 'ik_lazy_fin_2',
+        operation: 'finalize',
+        requestFingerprint: 'sha256_lazy_fp',
+        createdAt: Date.now()
+      });
+      expect(lazyFinalizeClaim.action).toBe('REPLAY_SUCCEEDED');
+      expect(lazyFinalizeClaim.existing?.resultJson).toBe(legacyResult);
+
+      // Lazy fallback MUST NOT replay for push or commit
+      store.database.prepare(
+        'INSERT INTO finalize_idempotency(owner_id, workspace_id, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?, ?)'
+      ).run(p, wsId, 'ik_lazy_fin_3', legacyResult, Date.now() - 10_000);
+
+      const lazyPushClaim = store.acquireGitOperation({
+        ownerId: p,
+        workspaceId: wsId,
+        idempotencyKey: 'ik_lazy_fin_3',
+        operation: 'push',
+        requestFingerprint: 'sha256_lazy_push_fp',
+        createdAt: Date.now()
+      });
+      expect(lazyPushClaim.action).toBe('ACQUIRED');
     } finally {
       store.close();
     }

--- a/test/e2e/coding-workflow.docker.test.ts
+++ b/test/e2e/coding-workflow.docker.test.ts
@@ -45,7 +45,9 @@ beforeAll(async () => {
   const runnerConfig: RunnerConfig = {
     host: '127.0.0.1', port: 0, serviceToken, jobsRoot: join(directory, 'jobs'), stateDb: join(directory, 'state', 'state.db'),
     executorImage: 'cloud-harness-executor:local', allowedGitHosts: ['github.com'], networkMode: 'none', wallTtlSeconds: 300,
-    idleTtlSeconds: 180, maxOutputBytes: 262_144, minFreeBytes: 104_857_600, maxWorkspaceBytes: 536_870_912, reaperIntervalSeconds: 0.05
+    idleTtlSeconds: 180, maxOutputBytes: 262_144, minFreeBytes: 104_857_600, maxWorkspaceBytes: 536_870_912, reaperIntervalSeconds: 0.05,
+    artifactRoot: join(directory, 'artifacts'), maxArtifactBytes: 16_777_216, maxPrincipalArtifactBytes: 134_217_728,
+    artifactRetentionSeconds: 86_400, enableRepoCache: false, repoCacheRoot: join(directory, 'cache')
   };
   store = new StateStore(runnerConfig.stateDb);
   service = new WorkspaceService(runnerConfig, store);

--- a/test/integration/docker-sandbox.docker.test.ts
+++ b/test/integration/docker-sandbox.docker.test.ts
@@ -23,7 +23,9 @@ beforeAll(async () => {
     host: '127.0.0.1', port: 3001, serviceToken: 'runner-test-token-that-is-longer-than-32-characters',
     jobsRoot: join(directory, 'jobs'), stateDb: join(directory, 'state', 'state.db'), executorImage: 'cloud-harness-executor:local',
     allowedGitHosts: ['github.com'], networkMode: 'none', wallTtlSeconds: 300, idleTtlSeconds: 180,
-    maxOutputBytes: 262_144, minFreeBytes: 104_857_600, maxWorkspaceBytes: workspaceCeilingBytes, reaperIntervalSeconds: 30
+    maxOutputBytes: 262_144, minFreeBytes: 104_857_600, maxWorkspaceBytes: workspaceCeilingBytes, reaperIntervalSeconds: 30,
+    artifactRoot: join(directory, 'artifacts'), maxArtifactBytes: 16_777_216, maxPrincipalArtifactBytes: 134_217_728,
+    artifactRetentionSeconds: 86_400, enableRepoCache: false, repoCacheRoot: join(directory, 'cache')
   };
   store = new StateStore(runnerConfig.stateDb);
   service = new WorkspaceService(runnerConfig, store);


### PR DESCRIPTION
## Summary
- Unifies Git idempotency with legacy `finalize_idempotency` migration into `git_operation_idempotency` table on schema v4.
- Implements permanent wildcard replay for legacy finalize rows (`request_fingerprint = ''`) without binding/rewriting sentinel or conflicting on retries.
- Enforces strict cross-operation safety in `acquireGitOperation()` rejecting key reuse across `push`, `commit`, and `finalize`.
- Adds upgrade and replay test coverage seeded at schema v3 with legacy finalize rows.

Closes #14