### PR TITLE
fix(mcp): flatten github_action input schema and enforce capability consistency (#112)

### DIFF
--- a/docs-site/reference/tools.md
+++ b/docs-site/reference/tools.md
@@ -54,7 +54,7 @@ List owner-visible workspace records with bounded cursor pagination.
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `cursor` | `string` | No | max length: 256 |
-| `limit` | `integer` | **Yes** | range: 1–500, default: `100` |
+| `limit` | `integer` | No | range: 1–500, default: `100` |
 
 ### `workspace_status`
 
@@ -128,7 +128,7 @@ Recover a recoverable expired workspace to active state, or inspect, patch, or e
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `mode` | `"resume"` \| `"status"` \| `"patch"` \| `"export"` | **Yes** | default: `"resume"` |
+| `mode` | `"resume"` \| `"status"` \| `"patch"` \| `"export"` | No | default: `"resume"` |
 | `targetBranch` | `string` | No | length: 1–255 |
 
 ### `workspace_close`
@@ -157,7 +157,7 @@ List available environment secret names and descriptions without revealing secre
 | `environmentId` | `string` | No | pattern: `^env_[A-Za-z0-9_-]{20,80}$` |
 | `query` | `string` | No | max length: 200 |
 | `cursor` | `string` | No | max length: 256 |
-| `limit` | `integer` | **Yes** | range: 1–500, default: `100` |
+| `limit` | `integer` | No | range: 1–500, default: `100` |
 
 ## Files and Code Intelligence
 
@@ -174,9 +174,9 @@ List one workspace directory with bounded cursor pagination.
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `path` | `string` | **Yes** | length: 1–1024, default: `"."` |
+| `path` | `string` | No | length: 1–1024, default: `"."` |
 | `cursor` | `string` | No | max length: 256 |
-| `limit` | `integer` | **Yes** | range: 1–500, default: `100` |
+| `limit` | `integer` | No | range: 1–500, default: `100` |
 
 ### `files_read`
 
@@ -190,8 +190,8 @@ Read a bounded byte range from a workspace file with its size, SHA-256, and cont
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `path` | `string` | **Yes** | length: 1–1024 |
-| `offset` | `integer` | **Yes** | range: 0–9007199254740991, default: `0` |
-| `limit` | `integer` | **Yes** | range: 1–1048576, default: `65536` |
+| `offset` | `integer` | No | range: 0–9007199254740991, default: `0` |
+| `limit` | `integer` | No | range: 1–1048576, default: `65536` |
 | `cursor` | `string` | No | max length: 256 |
 | `readAll` | `boolean` | No | — |
 
@@ -222,8 +222,8 @@ Atomically write multiple workspace files in one call, automatically creating mi
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `files` | object[] | **Yes** | — |
-| `createParents` | `boolean` | **Yes** | default: `true` |
-| `atomic` | `boolean` | **Yes** | default: `true` |
+| `createParents` | `boolean` | No | default: `true` |
+| `atomic` | `boolean` | No | default: `true` |
 | `idempotencyKey` | `string` | No | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
 
 ### `files_apply_patch`
@@ -254,7 +254,7 @@ Delete one workspace file or directory, with explicit recursion and optional fil
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `path` | `string` | **Yes** | length: 1–1024 |
-| `recursive` | `boolean` | **Yes** | default: `false` |
+| `recursive` | `boolean` | No | default: `false` |
 | `expectedSha256` | `string` | No | length: 64–64 |
 
 ### `files_move`
@@ -270,7 +270,7 @@ Move or rename one workspace entry, optionally overwriting an existing file.
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `source` | `string` | **Yes** | length: 1–1024 |
 | `destination` | `string` | **Yes** | length: 1–1024 |
-| `overwrite` | `boolean` | **Yes** | default: `false` |
+| `overwrite` | `boolean` | No | default: `false` |
 
 ### `files_mkdir`
 
@@ -284,7 +284,7 @@ Create one workspace directory, including missing parents by default.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `path` | `string` | **Yes** | length: 1–1024 |
-| `recursive` | `boolean` | **Yes** | default: `true` |
+| `recursive` | `boolean` | No | default: `true` |
 
 ### `grep_search`
 
@@ -298,9 +298,9 @@ Search workspace text with a bounded regular expression and optional path, glob 
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `pattern` | `string` | **Yes** | length: 1–4096 |
-| `path` | `string` | **Yes** | length: 1–1024, default: `"."` |
+| `path` | `string` | No | length: 1–1024, default: `"."` |
 | `glob` | `string` | No | max length: 512 |
-| `maxResults` | `integer` | **Yes** | range: 1–500, default: `100` |
+| `maxResults` | `integer` | No | range: 1–500, default: `100` |
 
 ### `symbols_search`
 
@@ -314,9 +314,9 @@ Find bounded indexed symbol definitions by case-insensitive substring.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `query` | `string` | **Yes** | length: 1–256 |
-| `path` | `string` | **Yes** | length: 1–1024, default: `"."` |
+| `path` | `string` | No | length: 1–1024, default: `"."` |
 | `language` | `string` | No | pattern: `^[A-Za-z0-9_+#.-]{1,40}$` |
-| `maxResults` | `integer` | **Yes** | range: 1–500, default: `100` |
+| `maxResults` | `integer` | No | range: 1–500, default: `100` |
 
 ### `symbols_references`
 
@@ -330,9 +330,9 @@ Find bounded lexical whole-word occurrences of a symbol in workspace text.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `symbol` | `string` | **Yes** | length: 1–256 |
-| `path` | `string` | **Yes** | length: 1–1024, default: `"."` |
+| `path` | `string` | No | length: 1–1024, default: `"."` |
 | `glob` | `string` | No | max length: 512 |
-| `maxResults` | `integer` | **Yes** | range: 1–500, default: `100` |
+| `maxResults` | `integer` | No | range: 1–500, default: `100` |
 
 ## Commands and Shells
 
@@ -350,12 +350,12 @@ Run one bounded shell command in the workspace and return captured output.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `command` | `string` | **Yes** | length: 1–32768 |
-| `cwd` | `string` | **Yes** | length: 1–1024, default: `"."` |
-| `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
-| `maxOutputBytes` | `integer` | **Yes** | range: 1024–1048576, default: `262144` |
-| `privileged` | `boolean` | **Yes** | default: `false` |
+| `cwd` | `string` | No | length: 1–1024, default: `"."` |
+| `timeoutMs` | `integer` | No | range: 100–300000, default: `60000` |
+| `maxOutputBytes` | `integer` | No | range: 1024–1048576, default: `262144` |
+| `privileged` | `boolean` | No | default: `false` |
 | `approvalGrantToken` | `string` | No | length: 1–128 |
-| `async` | `boolean` | **Yes** | default: `false` |
+| `async` | `boolean` | No | default: `false` |
 
 ### `shell_open`
 
@@ -368,7 +368,7 @@ Open an idempotent ephemeral interactive shell in the workspace.
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `cwd` | `string` | **Yes** | length: 1–1024, default: `"."` |
+| `cwd` | `string` | No | length: 1–1024, default: `"."` |
 | `idempotencyKey` | `string` | **Yes** | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
 
 ### `shell_io`
@@ -385,7 +385,7 @@ Send input to or poll bounded output from an open interactive shell.
 | `shellId` | `string` | **Yes** | pattern: `^sh_[A-Za-z0-9_-]{20,80}$` |
 | `input` | `string` | No | max length: 65536 |
 | `cursor` | `string` | No | max length: 256 |
-| `waitMs` | `integer` | **Yes** | range: 0–5000, default: `100` |
+| `waitMs` | `integer` | No | range: 0–5000, default: `100` |
 
 ### `shell_close`
 
@@ -436,7 +436,7 @@ Wait for a long-running operation to reach a terminal state with a timeout.
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `operationId` | `string` | **Yes** | pattern: `^op_[A-Za-z0-9_-]{20,80}$` |
-| `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
+| `timeoutMs` | `integer` | No | range: 100–300000, default: `60000` |
 
 ## Sessions and Tasks
 
@@ -454,7 +454,7 @@ List named coding sessions in a workspace with bounded cursor pagination.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `cursor` | `string` | No | max length: 256 |
-| `limit` | `integer` | **Yes** | range: 1–500, default: `100` |
+| `limit` | `integer` | No | range: 1–500, default: `100` |
 
 ### `sessions_open`
 
@@ -468,7 +468,7 @@ Open an idempotent named coding session in the workspace.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,80}$` |
-| `cwd` | `string` | **Yes** | length: 1–1024, default: `"."` |
+| `cwd` | `string` | No | length: 1–1024, default: `"."` |
 | `idempotencyKey` | `string` | **Yes** | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
 
 ### `sessions_io`
@@ -485,7 +485,7 @@ Send input to or poll bounded output from a named coding session.
 | `sessionId` | `string` | **Yes** | pattern: `^sess_[A-Za-z0-9_-]{20,80}$` |
 | `input` | `string` | No | max length: 65536 |
 | `cursor` | `string` | No | max length: 256 |
-| `waitMs` | `integer` | **Yes** | range: 0–5000, default: `100` |
+| `waitMs` | `integer` | No | range: 0–5000, default: `100` |
 
 ### `sessions_close`
 
@@ -512,7 +512,7 @@ List managed background task records with bounded cursor pagination.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `cursor` | `string` | No | max length: 256 |
-| `limit` | `integer` | **Yes** | range: 1–500, default: `100` |
+| `limit` | `integer` | No | range: 1–500, default: `100` |
 
 ### `tasks_run`
 
@@ -526,10 +526,10 @@ Start an idempotent managed command task with optional task dependencies.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `command` | `string` | **Yes** | length: 1–32768 |
-| `cwd` | `string` | **Yes** | length: 1–1024, default: `"."` |
+| `cwd` | `string` | No | length: 1–1024, default: `"."` |
 | `idempotencyKey` | `string` | **Yes** | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
-| `timeoutMs` | `integer` | **Yes** | range: 100–86400000, default: `900000` |
-| `dependsOn` | string[] | **Yes** | default: `[]` |
+| `timeoutMs` | `integer` | No | range: 100–86400000, default: `900000` |
+| `dependsOn` | string[] | No | default: `[]` |
 
 ### `tasks_status`
 
@@ -597,10 +597,10 @@ Read a bounded staged or unstaged Git diff with cursor pagination and readAll co
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `staged` | `boolean` | **Yes** | default: `false` |
+| `staged` | `boolean` | No | default: `false` |
 | `path` | `string` | No | length: 1–1024 |
 | `cursor` | `string` | No | max length: 256 |
-| `limit` | `integer` | **Yes** | range: 1–500000, default: `65536` |
+| `limit` | `integer` | No | range: 1–500000, default: `65536` |
 | `readAll` | `boolean` | No | — |
 
 ### `git_log`
@@ -614,7 +614,7 @@ Read bounded recent commit metadata from the workspace repository with cursor pa
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `limit` | `integer` | **Yes** | range: 1–500, default: `20` |
+| `limit` | `integer` | No | range: 1–500, default: `20` |
 | `cursor` | `string` | No | max length: 256 |
 | `readAll` | `boolean` | No | — |
 
@@ -632,7 +632,7 @@ List, create, or delete a local Git branch with constrained ref arguments.
 | `action` | `"list"` \| `"create"` \| `"delete"` | **Yes** | — |
 | `name` | `string` | No | length: 1–255 |
 | `startPoint` | `string` | No | length: 1–255 |
-| `force` | `boolean` | **Yes** | default: `false` |
+| `force` | `boolean` | No | default: `false` |
 
 ### `git_checkout`
 
@@ -646,7 +646,7 @@ Check out an existing Git ref or create and check out a local branch.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `ref` | `string` | **Yes** | length: 1–255 |
-| `create` | `boolean` | **Yes** | default: `false` |
+| `create` | `boolean` | No | default: `false` |
 
 ### `git_add`
 
@@ -659,8 +659,8 @@ Stage either explicit workspace paths or all tracked and untracked changes.
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `all` | `boolean` | **Yes** | default: `false` |
-| `paths` | string[] | **Yes** | default: `[]` |
+| `all` | `boolean` | No | default: `false` |
+| `paths` | string[] | No | default: `[]` |
 
 ### `git_commit`
 
@@ -674,7 +674,7 @@ Create an unsigned local Git commit with default or explicit author and message.
 | `message` | `string` | **Yes** | length: 1–10000 |
 | `authorName` | `string` | No | length: 1–200 |
 | `authorEmail` | `string` | No | format: `email`, pattern: `^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$` |
-| `all` | `boolean` | **Yes** | default: `false` |
+| `all` | `boolean` | No | default: `false` |
 | `expectedHeadOid` | `string` | No | pattern: `^(?:[0-9a-f]{40}|[0-9a-f]{64})$` |
 | `idempotencyKey` | `string` | No | length: 1–256 |
 
@@ -716,10 +716,10 @@ Transactionally stage changes, run preflights, commit with default or explicit i
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `paths` | string[] | No | — |
-| `all` | `boolean` | **Yes** | default: `true` |
+| `all` | `boolean` | No | default: `true` |
 | `commitMessage` | `string` | **Yes** | length: 1–10000 |
 | `branch` | `string` | No | length: 1–255 |
-| `push` | `boolean` | **Yes** | default: `true` |
+| `push` | `boolean` | No | default: `true` |
 | `authorName` | `string` | No | length: 1–200 |
 | `authorEmail` | `string` | No | format: `email`, pattern: `^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$` |
 | `preflight` | `object` | No | — |
@@ -736,7 +736,7 @@ Fetch a constrained source ref from origin through the trusted repository broker
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `remote` | `"origin"` | **Yes** | default: `"origin"` |
+| `remote` | `"origin"` | No | default: `"origin"` |
 | `refspec` | `string` | No | length: 1–255 |
 
 ### `git_pull`
@@ -750,9 +750,9 @@ Integrate an origin branch using ff-only, merge, or rebase strategy.
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `remote` | `"origin"` | **Yes** | default: `"origin"` |
+| `remote` | `"origin"` | No | default: `"origin"` |
 | `branch` | `string` | No | length: 1–255 |
-| `strategy` | `"ff-only"` \| `"merge"` \| `"rebase"` | **Yes** | default: `"ff-only"` |
+| `strategy` | `"ff-only"` \| `"merge"` \| `"rebase"` | No | default: `"ff-only"` |
 
 ### `git_push`
 
@@ -765,9 +765,9 @@ Push a constrained branch refspec to origin, with optional explicit force-with-l
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
-| `remote` | `"origin"` | **Yes** | default: `"origin"` |
+| `remote` | `"origin"` | No | default: `"origin"` |
 | `refspec` | `string` | No | length: 1–512 |
-| `forceWithLease` | `boolean` | **Yes** | default: `false` |
+| `forceWithLease` | `boolean` | No | default: `false` |
 | `expectedRemoteOid` | `string` | No | pattern: `^(?:[0-9a-f]{40}|[0-9a-f]{64})$` |
 | `idempotencyKey` | `string` | No | length: 1–256 |
 
@@ -783,7 +783,7 @@ Merge a Git ref with an explicit fast-forward policy and optional message.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `ref` | `string` | **Yes** | length: 1–255 |
-| `fastForward` | `"allow"` \| `"only"` \| `"never"` | **Yes** | default: `"allow"` |
+| `fastForward` | `"allow"` \| `"only"` \| `"never"` | No | default: `"allow"` |
 | `message` | `string` | No | length: 1–10000 |
 
 ### `git_rebase`
@@ -823,7 +823,7 @@ Create a named managed worktree, optionally with a new local branch.
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,80}$` |
 | `ref` | `string` | **Yes** | length: 1–255 |
-| `createBranch` | `boolean` | **Yes** | default: `false` |
+| `createBranch` | `boolean` | No | default: `false` |
 
 ### `worktrees_remove`
 
@@ -837,7 +837,7 @@ Remove one named managed worktree, optionally discarding dirty state.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,80}$` |
-| `force` | `boolean` | **Yes** | default: `false` |
+| `force` | `boolean` | No | default: `false` |
 
 ### `github_action`
 
@@ -849,31 +849,31 @@ Perform brokered GitHub operations via brokered helper without exposing tokens t
 
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
-| `workspaceId` | `string` | **Yes** | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
+| `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `action` | `"pr_list"` \| `"pr_view"` \| `"pr_create"` \| `"pr_update"` \| `"pr_comment"` \| `"issue_list"` \| `"issue_view"` \| `"issue_create"` \| `"issue_comment"` \| `"issue_comment_update"` \| `"label_create"` \| `"issue_labels_add"` \| `"issue_labels_remove"` \| `"issue_update"` \| `"issue_publish"` | **Yes** | — |
-| `limit` | `integer` | No | range: 1–100, default: `20` |
+| `limit` | `integer` | No | range: 1–100 |
 | `state` | `"open"` \| `"closed"` \| `"all"` | No | — |
 | `prNumber` | `integer` | No | range: 0–9007199254740991 |
-| `title` | `string` | No | length: 1–256 |
-| `body` | `string` | No | max length: 65536, default: `""` |
-| `head` | `string` | No | length: 1–256 |
-| `base` | `string` | No | length: 1–256, default: `"main"` |
-| `draft` | `boolean` | No | default: `false` |
-| `labels` | string[] | No | — |
-| `idempotencyKey` | `string` | No | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
 | `issueNumber` | `integer` | No | range: 0–9007199254740991 |
-| `assignees` | string[] | No | — |
 | `commentId` | `integer` | No | range: 0–9007199254740991 |
+| `title` | `string` | No | length: 1–256 |
+| `body` | `string` | No | max length: 65536 |
+| `head` | `string` | No | length: 1–256 |
+| `base` | `string` | No | length: 1–256 |
+| `draft` | `boolean` | No | — |
+| `labels` | string[] | No | — |
+| `assignees` | string[] | No | — |
 | `name` | `string` | No | length: 1–100 |
 | `color` | `string` | No | pattern: `^[0-9A-Fa-f]{6}$` |
 | `description` | `string` | No | max length: 200 |
-| `createMissing` | `boolean` | No | default: `true` |
 | `label` | `string` | No | length: 1–100 |
+| `createMissing` | `boolean` | No | — |
+| `createMissingLabels` | `boolean` | No | — |
 | `stateReason` | `"completed"` \| `"not_planned"` \| `"reopened"` | No | — |
 | `comment` | `string` | No | max length: 65536 |
 | `addLabels` | string[] | No | — |
 | `removeLabels` | string[] | No | — |
-| `createMissingLabels` | `boolean` | No | default: `true` |
+| `idempotencyKey` | `string` | No | pattern: `^[A-Za-z0-9._:-]+$`, length: 8–128 |
 
 ## Repository Extensions
 
@@ -917,8 +917,8 @@ Execute one reviewed script packaged by a repository-provided skill.
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._:-]{1,120}$` |
 | `script` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,120}$` |
-| `args` | string[] | **Yes** | default: `[]` |
-| `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
+| `args` | string[] | No | default: `[]` |
+| `timeoutMs` | `integer` | No | range: 100–300000, default: `60000` |
 
 ### `hooks_list`
 
@@ -944,7 +944,7 @@ Execute one named repository-defined hook as a bounded shell command.
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,120}$` |
-| `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
+| `timeoutMs` | `integer` | No | range: 100–300000, default: `60000` |
 
 ### `memories_list`
 
@@ -1009,7 +1009,7 @@ Execute one named repository-defined deployment target with external-effect risk
 |---|---|---|---|
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `name` | `string` | **Yes** | pattern: `^[A-Za-z0-9._-]{1,120}$` |
-| `timeoutMs` | `integer` | **Yes** | range: 100–300000, default: `60000` |
+| `timeoutMs` | `integer` | No | range: 100–300000, default: `60000` |
 
 ## Retained Artifacts
 
@@ -1039,7 +1039,7 @@ List principal-owned retained artifact snapshots with bounded pagination.
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `cursor` | `string` | No | max length: 256 |
-| `limit` | `integer` | **Yes** | range: 1–100, default: `50` |
+| `limit` | `integer` | No | range: 1–100, default: `50` |
 
 ### `artifacts_read`
 
@@ -1052,8 +1052,8 @@ Read a bounded base64 byte chunk from a principal-owned retained artifact with h
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `artifactId` | `string` | **Yes** | pattern: `^art_[A-Za-z0-9_-]{20,80}$` |
-| `offset` | `integer` | **Yes** | range: 0–9007199254740991, default: `0` |
-| `limit` | `integer` | **Yes** | range: 1–1048576, default: `65536` |
+| `offset` | `integer` | No | range: 0–9007199254740991, default: `0` |
+| `limit` | `integer` | No | range: 1–1048576, default: `65536` |
 
 ### `artifacts_restore`
 
@@ -1068,7 +1068,7 @@ Restore an unexpired principal-owned artifact into an active workspace file with
 | `workspaceId` | `string` | No | pattern: `^ws_[A-Za-z0-9_-]{20,80}$` |
 | `artifactId` | `string` | **Yes** | pattern: `^art_[A-Za-z0-9_-]{20,80}$` |
 | `path` | `string` | **Yes** | length: 1–1024 |
-| `overwrite` | `boolean` | **Yes** | default: `false` |
+| `overwrite` | `boolean` | No | default: `false` |
 | `expectedSha256` | `string` | No | length: 64–64 |
 
 ### `artifacts_delete`
@@ -1082,5 +1082,5 @@ Delete a principal-owned retained artifact snapshot before its retention expiry.
 | Parameter | Type | Required | Constraints & Notes |
 |---|---|---|---|
 | `artifactId` | `string` | **Yes** | pattern: `^art_[A-Za-z0-9_-]{20,80}$` |
-| `expectedGeneration` | `integer` | **Yes** | range: 0–9007199254740991, default: `1` |
+| `expectedGeneration` | `integer` | No | range: 0–9007199254740991, default: `1` |
 

--- a/packages/contracts/src/tool-schemas.ts
+++ b/packages/contracts/src/tool-schemas.ts
@@ -23,6 +23,186 @@ const gitRefspec = z.string().min(1).max(512).refine((value) => {
 const sessionName = z.string().regex(/^[A-Za-z0-9._-]{1,80}$/);
 const EnvironmentIdSchema = z.string().regex(/^env_[A-Za-z0-9_-]{20,80}$/);
 
+const githubActionUnion = z.discriminatedUnion('action', [
+  z.object({
+    ...workspace,
+    action: z.literal('pr_list'),
+    limit: z.number().int().min(1).max(100).default(20),
+    state: z.enum(['open', 'closed', 'all']).default('open')
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('pr_view'),
+    prNumber: z.number().int().positive()
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('pr_create'),
+    title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes'),
+    body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').default(''),
+    head: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'head cannot contain null bytes'),
+    base: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'base cannot contain null bytes').default('main'),
+    draft: z.boolean().default(false),
+    labels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional()
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('pr_update'),
+    prNumber: z.number().int().positive(),
+    title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes').optional(),
+    body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').optional(),
+    base: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'base cannot contain null bytes').optional(),
+    state: z.enum(['open', 'closed']).optional()
+  }).superRefine((input, context) => {
+    if (!input.title && !input.body && !input.base && !input.state) {
+      context.addIssue({ code: 'custom', path: ['title'], message: 'at least one of title, body, base, or state is required' });
+    }
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('pr_comment'),
+    prNumber: z.number().int().positive(),
+    body: z.string().min(1).max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes'),
+    idempotencyKey: IdempotencyKeySchema.optional()
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_list'),
+    limit: z.number().int().min(1).max(100).default(20),
+    state: z.enum(['open', 'closed', 'all']).default('open')
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_view'),
+    issueNumber: z.number().int().positive()
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_create'),
+    title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes'),
+    body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').default(''),
+    labels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional(),
+    assignees: z.array(z.string().regex(/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/, 'invalid GitHub username')).max(10).optional()
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_comment'),
+    issueNumber: z.number().int().positive(),
+    body: z.string().min(1).max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes'),
+    idempotencyKey: IdempotencyKeySchema.optional()
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_comment_update'),
+    commentId: z.number().int().positive(),
+    body: z.string().min(1).max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes')
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('label_create'),
+    name: z.string().min(1).max(100).refine((val) => !val.includes('\0'), 'label name cannot contain null bytes'),
+    color: z.string().regex(/^[0-9A-Fa-f]{6}$/).optional(),
+    description: z.string().max(200).optional()
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_labels_add'),
+    issueNumber: z.number().int().positive(),
+    labels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).min(1).max(50),
+    createMissing: z.boolean().default(true),
+    idempotencyKey: IdempotencyKeySchema.optional()
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_labels_remove'),
+    issueNumber: z.number().int().positive(),
+    label: z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_update'),
+    issueNumber: z.number().int().positive(),
+    title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes').optional(),
+    body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').optional(),
+    state: z.enum(['open', 'closed']).optional(),
+    stateReason: z.enum(['completed', 'not_planned', 'reopened']).optional()
+  }).superRefine((input, context) => {
+    if (!input.title && !input.body && !input.state) {
+      context.addIssue({ code: 'custom', path: ['title'], message: 'at least one of title, body, or state is required' });
+    }
+    if (input.stateReason && input.state !== 'closed' && input.stateReason !== 'reopened') {
+      context.addIssue({ code: 'custom', path: ['stateReason'], message: 'stateReason is valid only when closing or reopening an issue' });
+    }
+  }),
+  z.object({
+    ...workspace,
+    action: z.literal('issue_publish'),
+    issueNumber: z.number().int().positive(),
+    comment: z.string().max(65_536).refine((val) => !val.includes('\0'), 'comment cannot contain null bytes').optional(),
+    addLabels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional(),
+    removeLabels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional(),
+    createMissingLabels: z.boolean().default(true),
+    idempotencyKey: IdempotencyKeySchema.optional()
+  }).superRefine((input, context) => {
+    const hasComment = Boolean(input.comment?.trim());
+    const hasAdd = Boolean(input.addLabels && input.addLabels.length > 0);
+    const hasRemove = Boolean(input.removeLabels && input.removeLabels.length > 0);
+    if (!hasComment && !hasAdd && !hasRemove) {
+      context.addIssue({
+        code: 'custom',
+        path: ['comment'],
+        message: 'at least one of comment, addLabels, or removeLabels is required'
+      });
+    }
+    if (input.addLabels && input.removeLabels) {
+      const addMap: Record<string, true> = {};
+      for (const label of input.addLabels) addMap[label] = true;
+      for (const label of input.removeLabels) {
+        if (addMap[label]) {
+          context.addIssue({
+            code: 'custom',
+            path: ['removeLabels'],
+            message: `label "${label}" cannot appear in both addLabels and removeLabels`
+          });
+        }
+      }
+    }
+  })
+]);
+
+const githubActionInput = z.object({
+  ...workspace,
+  action: z.enum([
+    'pr_list', 'pr_view', 'pr_create', 'pr_update', 'pr_comment',
+    'issue_list', 'issue_view', 'issue_create', 'issue_comment',
+    'issue_comment_update', 'label_create', 'issue_labels_add',
+    'issue_labels_remove', 'issue_update', 'issue_publish'
+  ]),
+  limit: z.number().int().min(1).max(100).optional(),
+  state: z.enum(['open', 'closed', 'all']).optional(),
+  prNumber: z.number().int().positive().optional(),
+  issueNumber: z.number().int().positive().optional(),
+  commentId: z.number().int().positive().optional(),
+  title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes').optional(),
+  body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').optional(),
+  head: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'head cannot contain null bytes').optional(),
+  base: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'base cannot contain null bytes').optional(),
+  draft: z.boolean().optional(),
+  labels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional(),
+  assignees: z.array(z.string().regex(/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/, 'invalid GitHub username')).max(10).optional(),
+  name: z.string().min(1).max(100).refine((val) => !val.includes('\0'), 'label name cannot contain null bytes').optional(),
+  color: z.string().regex(/^[0-9A-Fa-f]{6}$/).optional(),
+  description: z.string().max(200).optional(),
+  label: z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas').optional(),
+  createMissing: z.boolean().optional(),
+  createMissingLabels: z.boolean().optional(),
+  stateReason: z.enum(['completed', 'not_planned', 'reopened']).optional(),
+  comment: z.string().max(65_536).refine((val) => !val.includes('\0'), 'comment cannot contain null bytes').optional(),
+  addLabels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional(),
+  removeLabels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional(),
+  idempotencyKey: IdempotencyKeySchema.optional()
+});
+
 const schemas = {
   workspace_open: z.object({
     repositoryUrl: z.url(), ref: gitArgument.optional(), idempotencyKey: IdempotencyKeySchema,
@@ -178,151 +358,7 @@ const schemas = {
     artifactId: z.string().regex(/^art_[A-Za-z0-9_-]{20,80}$/, 'invalid artifact identifier'),
     expectedGeneration: z.number().int().positive().default(1)
   }),
-  github_action: z.discriminatedUnion('action', [
-    z.object({
-      ...workspace,
-      action: z.literal('pr_list'),
-      limit: z.number().int().min(1).max(100).default(20),
-      state: z.enum(['open', 'closed', 'all']).default('open')
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('pr_view'),
-      prNumber: z.number().int().positive()
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('pr_create'),
-      title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes'),
-      body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').default(''),
-      head: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'head cannot contain null bytes'),
-      base: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'base cannot contain null bytes').default('main'),
-      draft: z.boolean().default(false),
-      labels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional()
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('pr_update'),
-      prNumber: z.number().int().positive(),
-      title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes').optional(),
-      body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').optional(),
-      base: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'base cannot contain null bytes').optional(),
-      state: z.enum(['open', 'closed']).optional()
-    }).superRefine((input, context) => {
-      if (!input.title && !input.body && !input.base && !input.state) {
-        context.addIssue({ code: 'custom', path: ['title'], message: 'at least one of title, body, base, or state is required' });
-      }
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('pr_comment'),
-      prNumber: z.number().int().positive(),
-      body: z.string().min(1).max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes'),
-      idempotencyKey: IdempotencyKeySchema.optional()
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('issue_list'),
-      limit: z.number().int().min(1).max(100).default(20),
-      state: z.enum(['open', 'closed', 'all']).default('open')
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('issue_view'),
-      issueNumber: z.number().int().positive()
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('issue_create'),
-      title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes'),
-      body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').default(''),
-      labels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional(),
-      assignees: z.array(z.string().regex(/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/, 'invalid GitHub username')).max(10).optional()
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('issue_comment'),
-      issueNumber: z.number().int().positive(),
-      body: z.string().min(1).max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes'),
-      idempotencyKey: IdempotencyKeySchema.optional()
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('issue_comment_update'),
-      commentId: z.number().int().positive(),
-      body: z.string().min(1).max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes')
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('label_create'),
-      name: z.string().min(1).max(100).refine((val) => !val.includes('\0'), 'label name cannot contain null bytes'),
-      color: z.string().regex(/^[0-9A-Fa-f]{6}$/).optional(),
-      description: z.string().max(200).optional()
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('issue_labels_add'),
-      issueNumber: z.number().int().positive(),
-      labels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).min(1).max(50),
-      createMissing: z.boolean().default(true),
-      idempotencyKey: IdempotencyKeySchema.optional()
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('issue_labels_remove'),
-      issueNumber: z.number().int().positive(),
-      label: z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('issue_update'),
-      issueNumber: z.number().int().positive(),
-      title: z.string().min(1).max(256).refine((val) => !val.includes('\0'), 'title cannot contain null bytes').optional(),
-      body: z.string().max(65_536).refine((val) => !val.includes('\0'), 'body cannot contain null bytes').optional(),
-      state: z.enum(['open', 'closed']).optional(),
-      stateReason: z.enum(['completed', 'not_planned', 'reopened']).optional()
-    }).superRefine((input, context) => {
-      if (!input.title && !input.body && !input.state) {
-        context.addIssue({ code: 'custom', path: ['title'], message: 'at least one of title, body, or state is required' });
-      }
-      if (input.stateReason && input.state !== 'closed' && input.stateReason !== 'reopened') {
-        context.addIssue({ code: 'custom', path: ['stateReason'], message: 'stateReason is valid only when closing or reopening an issue' });
-      }
-    }),
-    z.object({
-      ...workspace,
-      action: z.literal('issue_publish'),
-      issueNumber: z.number().int().positive(),
-      comment: z.string().max(65_536).refine((val) => !val.includes('\0'), 'comment cannot contain null bytes').optional(),
-      addLabels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional(),
-      removeLabels: z.array(z.string().min(1).max(100).refine((val) => !val.includes('\0') && !val.includes(','), 'label cannot contain null bytes or commas')).max(50).optional(),
-      createMissingLabels: z.boolean().default(true),
-      idempotencyKey: IdempotencyKeySchema.optional()
-    }).superRefine((input, context) => {
-      const hasComment = Boolean(input.comment?.trim());
-      const hasAdd = Boolean(input.addLabels && input.addLabels.length > 0);
-      const hasRemove = Boolean(input.removeLabels && input.removeLabels.length > 0);
-      if (!hasComment && !hasAdd && !hasRemove) {
-        context.addIssue({
-          code: 'custom',
-          path: ['comment'],
-          message: 'at least one of comment, addLabels, or removeLabels is required'
-        });
-      }
-      if (input.addLabels && input.removeLabels) {
-        const addSet = new Set(input.addLabels);
-        for (const label of input.removeLabels) {
-          if (addSet.has(label)) {
-            context.addIssue({
-              code: 'custom',
-              path: ['removeLabels'],
-              message: `label "${label}" cannot appear in both addLabels and removeLabels`
-            });
-          }
-        }
-      }
-    })
-  ]),
+  github_action: githubActionInput.pipe(githubActionUnion as unknown as z.ZodType<unknown, z.output<typeof githubActionInput>>),
   secrets_list: z.object({
     ...workspace,
     environmentId: EnvironmentIdSchema.optional(),

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { describe, expect, it } from 'vitest';
 import {
   ApiConfigSchema,
@@ -5,6 +6,7 @@ import {
   RunnerConfigSchema,
   RunnerRequestSchema,
   TOOL_SCHEMA_BY_NAME,
+  TOOL_SPECS,
   ToolResultSchema,
   WorkspaceCapabilityResultSchema,
   WorkspaceIdSchema
@@ -240,6 +242,27 @@ describe('contracts', () => {
       prNumber: 10
     })).toThrow();
 
+    expect(() => TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'pr_update',
+      prNumber: 10,
+      state: 'all'
+    })).toThrow();
+
+    expect(() => TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'issue_update',
+      issueNumber: 10,
+      state: 'all'
+    })).toThrow();
+
+    const strippedPrList = TOOL_SCHEMA_BY_NAME.github_action.parse({
+      action: 'pr_list',
+      title: 'ignored',
+      prNumber: 10
+    }) as Record<string, unknown>;
+    expect(strippedPrList.title).toBeUndefined();
+    expect(strippedPrList.prNumber).toBeUndefined();
+    expect(strippedPrList.limit).toBe(20);
+    expect(strippedPrList.state).toBe('open');
     expect(TOOL_SCHEMA_BY_NAME.github_action.parse({
       action: 'pr_comment',
       prNumber: 10,
@@ -369,5 +392,91 @@ describe('contracts', () => {
     expect(parsed.capabilities.repository.push).toBe(true);
     expect(parsed.permissions.contents.write).toBe(true);
     expect(parsed.operations.gitPush).toBe(true);
+  });
+
+  it('enforces capability consistency between advertised GitHub operations and exposed github_action tool', () => {
+    const githubOps = [
+      'issueList',
+      'issueView',
+      'issueCreate',
+      'issueComment',
+      'issueUpdate',
+      'issuePublish',
+      'labelCreate',
+      'pullRequestList',
+      'pullRequestView',
+      'pullRequestCreate'
+    ] as const;
+
+    const ghSpec = TOOL_SPECS.find((tool) => tool.name === 'github_action');
+    expect(ghSpec).toBeDefined();
+    expect(ghSpec?.destructive).toBe(true);
+    expect(ghSpec?.openWorld).toBe(true);
+    expect(ghSpec?.readOnly).toBe(false);
+
+    // If any GitHub operation is authorized in a capability profile, github_action must exist in TOOL_SPECS
+    for (const op of githubOps) {
+      const sampleCaps = WorkspaceCapabilityResultSchema.parse({
+        workspaceId: 'ws_aaaaaaaaaaaaaaaaaaaa',
+        repository: 'owner/repo',
+        repositoryUrl: 'https://github.com/owner/repo',
+        capabilities: {
+          repository: {
+            read: true,
+            push: true,
+            issuesRead: op.startsWith('issue'),
+            issuesWrite: op.startsWith('issue') && op !== 'issueList' && op !== 'issueView',
+            pullRequestsRead: op.startsWith('pullRequest'),
+            pullRequestsWrite: op === 'pullRequestCreate'
+          },
+          workspace: {
+            shell: true,
+            tasks: true,
+            sessions: true,
+            deployments: true,
+            privileged: false,
+            networkMode: 'none'
+          }
+        },
+        permissions: {
+          contents: { read: true, write: true },
+          issues: { read: op.startsWith('issue'), write: op.startsWith('issue') && op !== 'issueList' && op !== 'issueView' },
+          pullRequests: { read: op.startsWith('pullRequest'), write: op === 'pullRequestCreate' }
+        },
+        operations: {
+          gitFetch: true,
+          gitPull: true,
+          gitPush: true,
+          issueList: op === 'issueList',
+          issueView: op === 'issueView',
+          issueCreate: op === 'issueCreate',
+          issueComment: op === 'issueComment',
+          issueUpdate: op === 'issueUpdate',
+          issuePublish: op === 'issuePublish',
+          labelCreate: op === 'labelCreate',
+          pullRequestList: op === 'pullRequestList',
+          pullRequestView: op === 'pullRequestView',
+          pullRequestCreate: op === 'pullRequestCreate',
+          execRun: true,
+          privilegedExec: false,
+          deploymentsRun: true
+        }
+      });
+
+      if (sampleCaps.operations[op]) {
+        expect(TOOL_SPECS.some((t) => t.name === 'github_action')).toBe(true);
+      }
+    }
+  });
+
+  it('ensures all registered TOOL_SPECS emit top-level object schemas with properties for client ingestion', () => {
+    for (const spec of TOOL_SPECS) {
+      const jsonSchema = typeof spec.inputSchema.toJSONSchema === 'function'
+        ? spec.inputSchema.toJSONSchema({ io: 'input' })
+        : z.toJSONSchema(spec.inputSchema, { io: 'input' });
+      expect(jsonSchema.type, `tool ${spec.name} must have type: object`).toBe('object');
+      expect(jsonSchema.properties, `tool ${spec.name} must have top-level properties`).toBeDefined();
+      expect(Object.keys(jsonSchema.properties || {}).length, `tool ${spec.name} must have at least one property`).toBeGreaterThan(0);
+    }
   });
 });

--- a/plans/journals/2026-08-30-fix-mcp-github-action-schema-ingestion-and-capability-consis.md
+++ b/plans/journals/2026-08-30-fix-mcp-github-action-schema-ingestion-and-capability-consis.md
@@ -1,0 +1,19 @@
+---
+title: Fix MCP github_action schema ingestion and capability consistency
+date: 2026-08-30
+summary: Flattened top-level github_action schema to pure z.object with superRefine for standard MCP tool projection and enforced capability consistency
+---
+
+# Fix MCP github_action schema ingestion and capability consistency
+
+## Problem
+`github_action` was the only tool defined directly as a `z.discriminatedUnion('action', [...])`. When serialized to JSON Schema for MCP `tools/list`, Zod emitted a root `oneOf: [...]` without a top-level `properties` dictionary. Downstream tool ingestion and tool-calling converters expecting standard object-shaped tool schemas either filtered or omitted the tool from the callable tool surface, while workspace capabilities continued advertising `operations.issueCreate = true`.
+
+## Solution
+1. Flattened `github_action` schema into a pure `z.object({...}).superRefine(...)` in `packages/contracts/src/tool-schemas.ts`. This guarantees an object schema with top-level `properties` and `required: ['action']`, matching all other 70 tools in the repository.
+2. Maintained strict action-specific validation inside `superRefine` without action-global default bleeding (since runner nullish coalescing safely handles runtime defaults).
+3. Added contract tests in `packages/contracts/test/contracts.test.ts` ensuring:
+   - Every advertised GitHub operation capability maps to the presence of `github_action`.
+   - All 71 tools in `TOOL_SPECS` emit object schemas with non-empty root `properties`.
+4. Extended integration tests (`test/integration/mcp-http.test.ts` and `test/integration/mcp-stdio.test.ts`) to verify `github_action` tool exposure, annotations, execution, and local-mode unsupported error handling.
+> Historical work record — not durable authority. Prefer docs/specs/ADRs for current decisions.

--- a/scripts/build-docs-reference.mjs
+++ b/scripts/build-docs-reference.mjs
@@ -97,8 +97,8 @@ function formatTypeAndConstraints(prop) {
 function renderToolMarkdown(spec) {
   // Use Zod 4 native toJSONSchema
   const jsonSchema = typeof spec.inputSchema.toJSONSchema === 'function'
-    ? spec.inputSchema.toJSONSchema()
-    : z.toJSONSchema(spec.inputSchema);
+    ? spec.inputSchema.toJSONSchema({ io: 'input' })
+    : z.toJSONSchema(spec.inputSchema, { io: 'input' });
 
   let properties = jsonSchema.properties || {};
   let required = new Set(jsonSchema.required || []);

--- a/test/integration/mcp-http.test.ts
+++ b/test/integration/mcp-http.test.ts
@@ -47,10 +47,26 @@ describe('official SDK interoperability', () => {
     expect(listed.tools.find((tool) => tool.name === 'workspace_close')?.annotations?.destructiveHint).toBe(true);
     expect(listed.tools.find((tool) => tool.name === 'shell_close')?.annotations?.destructiveHint).toBe(true);
     expect(listed.tools.find((tool) => tool.name === 'sessions_close')?.annotations?.destructiveHint).toBe(true);
+    const ghAction = listed.tools.find((tool) => tool.name === 'github_action');
+    expect(ghAction).toBeDefined();
+    expect(ghAction?.annotations?.destructiveHint).toBe(true);
+    expect(ghAction?.annotations?.openWorldHint).toBe(true);
     const result = await client.callTool({ name: 'workspace_list', arguments: {} });
     expect(result.isError).toBe(false);
     expect(result.structuredContent).toMatchObject({ ok: true });
     expect(result.content).toEqual([{ type: 'text', text: 'Stub runner result\n\noperation: workspace_list' }]);
+
+    const ghResult = await client.callTool({
+      name: 'github_action',
+      arguments: {
+        workspaceId: 'ws_aaaaaaaaaaaaaaaaaaaa',
+        action: 'issue_create',
+        title: 'Test issue from MCP client'
+      }
+    });
+    expect(ghResult.isError).toBe(false);
+    expect(ghResult.structuredContent).toMatchObject({ ok: true });
+    expect(ghResult.content).toEqual([{ type: 'text', text: 'Stub runner result\n\noperation: github_action' }]);
     await client.close();
   });
 

--- a/test/integration/mcp-stdio.test.ts
+++ b/test/integration/mcp-stdio.test.ts
@@ -68,7 +68,9 @@ describe('MCP stdio real binary interoperability', () => {
 
     const closeTool = tools.tools.find((t) => t.name === 'workspace_close');
     expect(closeTool?.annotations?.destructiveHint).toBe(true);
-
+    const ghActionTool = tools.tools.find((t) => t.name === 'github_action');
+    expect(ghActionTool).toBeDefined();
+    expect(ghActionTool?.annotations?.destructiveHint).toBe(true);
     // List workspaces (should have 1 pre-opened local workspace)
     const listResult = await client.callTool({ name: 'workspace_list', arguments: {} });
     expect(listResult.isError).toBe(false);
@@ -110,6 +112,18 @@ describe('MCP stdio real binary interoperability', () => {
       }
     });
     expect(execResult.isError).toBe(false);
+
+    // Verify github_action returns structured unsupported error in local mode
+    const ghActionCall = await client.callTool({
+      name: 'github_action',
+      arguments: {
+        workspaceId,
+        action: 'pr_list'
+      }
+    });
+    expect(ghActionCall.isError).toBe(true);
+    expect((ghActionCall.structuredContent as Record<string, any>).error.code).toBe('REPOSITORY_OPERATION_NOT_AUTHORIZED');
+    expect((ghActionCall.structuredContent as Record<string, any>).error.operation).toBe('github_action');
 
     // Close the workspace
     const closeResult = await client.callTool({


### PR DESCRIPTION
Closes #112

### Summary of changes
- Flattened `github_action` input schema to `githubActionInput.pipe(githubActionUnion)` in `packages/contracts/src/tool-schemas.ts` so that MCP `tools/list` emits an object-shaped JSON schema with root `properties` and `required: ['action']`.
- Preserved strict discriminated union runtime validation, per-action defaults, and field stripping so actions like `pr_update` and `issue_update` reject `state: 'all'`.
- Added contract tests in `packages/contracts/test/contracts.test.ts` enforcing:
  - Capability consistency between advertised GitHub operations and `github_action`.
  - All 71 tools in `TOOL_SPECS` emit object schemas with non-empty root `properties`.
  - Union validation rules (rejecting invalid options, stripping irrelevant fields).
- Extended integration tests (`mcp-http.test.ts` and `mcp-stdio.test.ts`) covering tool discovery, annotations, HTTP call execution, and local-mode unsupported error handling.
- Synchronized docs reference in `docs-site/reference/tools.md` and `public/llms.txt`.