### PR TITLE
docs(skill): reflect durable git idempotency and task reconciliation in cloudharness skill (#14)

### DIFF
--- a/.agents/skills/cloudharness/SKILL.md
+++ b/.agents/skills/cloudharness/SKILL.md
@@ -55,6 +55,9 @@ not require a source checkout.
    - Use `exec_run` for synchronous, bounded single commands.
    - Use `tasks_run` with `dependsOn` for background builds, tests, or multi-step
      task graphs. Monitor progress via `tasks_status` or `operation_wait`.
+   - Task records and output survive a runner restart (`tasks_list` /
+     `tasks_status`); an interrupted task ends as `RUNNER_RESTARTED`. Interactive
+     `shell_*` / `sessions_*` handles do not survive restart.
    - Use interactive `shell_*` or `sessions_*` only when terminal state is required.
    - For `privileged: true` commands in Cloudflare Access mode, expect
      `PRIVILEGE_APPROVAL_REQUIRED` and wait for the operator to approve the
@@ -65,6 +68,13 @@ not require a source checkout.
    - Inspect status and diff using `git_status` and `git_diff`.
    - Use `workspace_finalize` for streamlined transactional staging, preflight
      diff checks, committing, and pushing to origin in a single step.
+   - Pass an `idempotencyKey` on `git_commit`, `git_push`, and
+     `workspace_finalize`. On `UNKNOWN_REMOTE_STATE`, retry the identical request
+     with the same key to reconcile; treat `alreadyFinalized: true` as success
+     and never re-push. `git_commit` `expectedHeadOid` is a HEAD compare-and-set
+     returning `STALE_HEAD` on mismatch; `git_push` `expectedRemoteOid`
+     (force-with-lease) returns `CONFLICT` with current/expected remote OIDs
+     when the remote ref has moved.
    - Use `github_action` for brokered issue and pull request operations.
 8. **Manage lifecycle and lease.** If work approaches the idle timeout, call
    `workspace_lease_renew`. If disconnected or recovering unpushed work, call
@@ -102,8 +112,11 @@ not require a source checkout.
 - `bridge` enables broad egress; it is not an allowlist or strong isolation.
 - Arbitrary commands, interactive I/O, tasks, skill scripts, hooks, and
   deployments execute repository-controlled code. Review intent and scope.
-- Do not retry an unknown mutation blindly. Only creation operations documented
-  as idempotent should reuse the same key after a lost response.
+- Do not retry an unknown mutation blindly. Reuse the same idempotency key only
+  for the identical operation and parameters — to recover a lost creation
+  response, or to reconcile a `git_commit`, `git_push`, or `workspace_finalize`
+  whose outcome is unverified (e.g. `UNKNOWN_REMOTE_STATE`). A changed request
+  needs a new key.
 - Do not claim a push, private clone, deployment, or production outcome without
   current owner-authorized evidence from the corresponding operation.
 

--- a/.agents/skills/cloudharness/references/execution-and-tasks.md
+++ b/.agents/skills/cloudharness/references/execution-and-tasks.md
@@ -104,6 +104,10 @@ only ASCII letters, digits, `.`, `_`, and `-`, with length 1–80.
   prevent unsafe blind continuation.
 - Reuse the key only to recover the same task creation. A timeout can leave
   file or external effects made before process termination.
+- Task records and bounded output are durable. After a runner restart, query
+  them with `tasks_list`/`tasks_status` rather than re-running; an interrupted
+  task becomes terminal with `RUNNER_RESTARTED` and is not resumed. Retained
+  task output may later be discovered through the artifact tools.
 
 <!-- cloudharness-example:tasks_run
 {"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","command":"npm run verify","cwd":".","idempotencyKey":"verify-20260817-01","timeoutMs":900000,"dependsOn":[]}
@@ -173,4 +177,5 @@ Wait for an operation to reach a terminal state with a server timeout.
 2. For timeout, cancellation, or disconnect, inspect status and side effects.
 3. Poll with the latest cursor; never derive or share cursors across handles.
 4. Close shells/sessions and cancel unwanted tasks before closing a workspace.
-5. After a runner restart, assume old interactive process handles are gone.
+5. After a runner restart, interactive shell/session handles are gone, but task
+   records and output persist; re-read task state before restarting work.

--- a/.agents/skills/cloudharness/references/git-and-worktrees.md
+++ b/.agents/skills/cloudharness/references/git-and-worktrees.md
@@ -53,8 +53,13 @@ Read branch, index, and working-tree status for `workspaceId`.
 <!-- cloudharness-tool:git_commit -->
 ### `git_commit`
 
-- Required: `workspaceId`, `message` (1–10,000 characters), `authorName`
-  (1–200), and valid `authorEmail`; `all` defaults to `false`.
+- Required: `workspaceId`, `message` (1–10,000 characters); `all` defaults to
+  `false`. `authorName`/`authorEmail` are optional and fall back to the
+  configured or default Git identity.
+- Optional `expectedHeadOid` is a compare-and-set guard: the commit is rejected
+  with `STALE_HEAD` if the current HEAD no longer matches. Optional
+  `idempotencyKey` makes a lost-response retry safe; a same-key replay does not
+  create a second commit.
 - `all: true` runs an all-path staging step and includes untracked files as well
   as tracked modifications/deletions. Inspect status for secrets and unrelated
   files first. The tool creates a local commit and does not sign or push it.
@@ -91,6 +96,10 @@ Transactionally stage changes, run preflights, commit, and push to origin in one
 - Required: `commitMessage` (1–10,000 characters).
 - Optional: `workspaceId`, `paths`, `all` (default true), `branch`, `push` (default true), `authorName`, `authorEmail`, `preflight`, `idempotencyKey`.
 - Returns commit SHA, target branch, push result, and final workspace status.
+- Provide `idempotencyKey` before the first call. Finalize is crash-durable: a
+  commit may exist even when the push outcome is unknown. On a same-key retry
+  after `UNKNOWN_REMOTE_STATE`, the service reconciles against the destination
+  ref and returns `alreadyFinalized: true` instead of pushing again.
 
 <!-- cloudharness-example:workspace_finalize
 {"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","commitMessage":"feat(core): implement feature","push":true}
@@ -127,6 +136,12 @@ URL. Network access for these tools is separate from executor egress.
   syntax are rejected.
 - Force-with-lease requires `expectedRemoteOid`, a lowercase 40- or 64-hex
   object ID. With a refspec it also requires an explicit destination branch.
+- Supply `idempotencyKey` on the initial push, not only after a failure. If the
+  network drops mid-push the result is `UNKNOWN_REMOTE_STATE` with
+  `resumeAction: "reconcile_push"`; retry the identical request with the same
+  key. The service checks the destination ref's remote OID before deciding
+  whether another push is needed, returning `alreadyFinalized: true` when the
+  earlier push had already landed.
 - Push changes an external repository. Verify the target ref and inspect the
   returned result; a local commit is not evidence of a successful push.
 

--- a/.agents/skills/cloudharness/references/workspace-lifecycle-and-results.md
+++ b/.agents/skills/cloudharness/references/workspace-lifecycle-and-results.md
@@ -24,6 +24,10 @@ in standard text content, while `structuredContent` carries the machine envelope
 256 characters. Not every truncated operation supports continuation; if no
 cursor is returned, narrow the request rather than inventing one.
 
+On failure `error` may also carry actionable detail fields: `resumeAction`
+(the safe next step, e.g. `reconcile_push`), and the compare-and-set operands
+`currentHeadOid`/`expectedHeadOid` and `currentRemoteOid`/`expectedRemoteOid`.
+
 ## Error codes
 
 | Code | Response |
@@ -39,14 +43,29 @@ cursor is returned, narrow the request rather than inventing one.
 | `CANCELLED` | Inspect current files/Git/process state before deciding next action. |
 | `UNAVAILABLE` | Retry only when marked retryable and after checking external prerequisites. |
 | `INTERNAL_ERROR` | Preserve bounded evidence and stop repeated retries. |
+| `UNKNOWN_REMOTE_STATE` | A push or finalize was interrupted before its remote outcome was confirmed. Do not start a new mutation; follow `error.resumeAction` and retry the identical request with the same idempotency key so the service reconciles against the destination ref. |
+| `STALE_HEAD` | `git_commit` `expectedHeadOid` no longer matches HEAD; inspect the returned `currentHeadOid`/`expectedHeadOid`, rebuild on the new base, then retry. A diverged remote ref on `git_push` force-with-lease returns `CONFLICT` with current/expected remote OIDs instead. |
+| `RUNNER_RESTARTED` | An in-flight task was interrupted by a runner restart and its record is terminal. Re-list/read task state; start fresh work rather than resuming the old process. |
 
 ## Idempotency keys
 
-Keys are 8–128 characters and may contain ASCII letters, digits, `.`, `_`, `:`,
-and `-`. Use a fresh semantic key for a new resource. Reuse the same key only to
-recover a lost response from `workspace_open`, `shell_open`, `sessions_open`, or
-`tasks_run`. Reuse returns the previously created resource in that workspace;
-it does not create a replacement.
+Use a fresh semantic key for each new resource or intended mutation. A key of
+8–128 characters using ASCII letters, digits, `.`, `_`, `:`, and `-` is the
+recommended safe subset; creation ops and `workspace_finalize` enforce it, while
+`git_commit` and `git_push` accept a broader 1–256-character string.
+
+Reuse the same key only to recover the identical operation with identical
+parameters after a lost response or an `UNKNOWN_REMOTE_STATE`:
+
+- Creation ops (`workspace_open`, `shell_open`, `sessions_open`, `tasks_run`)
+  return the previously created resource; reuse never creates a replacement.
+- Git mutations (`git_commit`, `git_push`, `workspace_finalize`) take the key
+  before the first attempt and reuse it to reconcile an unverified outcome. A
+  same-key replay reporting `alreadyFinalized: true` is confirmed success; do
+  not issue another mutation.
+
+Changing the operation or its parameters requires a new key; a mismatched reuse
+returns `CONFLICT`.
 
 ## Workspace operations
 
@@ -184,10 +203,12 @@ List available global and environment secret names and descriptions without reve
 - Active workspace calls refresh idle expiry but cannot extend beyond the
   configured absolute lifetime.
 - Workspace metadata is durable; executor files exist only until close/expiry.
-- Shell, session, task handles and buffered output are in runner memory. After a
-  runner restart, surviving executors are restarted so lost processes do not
-  continue invisibly; old process handles are not recoverable.
-- Closing a workspace evicts every shell/session/task record for that workspace.
+- Task records and their bounded output are durable: they remain queryable via
+  `tasks_list`/`tasks_status` across a runner restart. An interrupted task
+  process is not resumed and becomes terminal with `RUNNER_RESTARTED`; its
+  output may be retained as an artifact during workspace cleanup.
+- Shell and session handles and buffered output live in runner memory only.
+  After a runner restart those interactive processes and handles are gone.
 - If a workspace is `EXPIRED`, never reuse its handle. Open a new authorized
   workspace and reconstruct state from durable repository history.
 
@@ -197,5 +218,7 @@ List available global and environment secret names and descriptions without reve
 2. Recheck workspace status.
 3. Inspect the affected file, Git state, task list, or external result.
 4. Retry only when the desired effect is absent and the operation is safe.
-5. For create operations with an idempotency key, reuse the original key.
+5. For a lost creation response, reuse its original idempotency key; for an
+   unverified `git_push`/`workspace_finalize` outcome, retry the identical
+   request with the same key so the service reconciles instead of re-pushing.
 6. Report any outcome that remains unverifiable.

--- a/plugins/cloud-harness/skills/cloudharness/SKILL.md
+++ b/plugins/cloud-harness/skills/cloudharness/SKILL.md
@@ -55,6 +55,9 @@ not require a source checkout.
    - Use `exec_run` for synchronous, bounded single commands.
    - Use `tasks_run` with `dependsOn` for background builds, tests, or multi-step
      task graphs. Monitor progress via `tasks_status` or `operation_wait`.
+   - Task records and output survive a runner restart (`tasks_list` /
+     `tasks_status`); an interrupted task ends as `RUNNER_RESTARTED`. Interactive
+     `shell_*` / `sessions_*` handles do not survive restart.
    - Use interactive `shell_*` or `sessions_*` only when terminal state is required.
    - For `privileged: true` commands in Cloudflare Access mode, expect
      `PRIVILEGE_APPROVAL_REQUIRED` and wait for the operator to approve the
@@ -65,6 +68,13 @@ not require a source checkout.
    - Inspect status and diff using `git_status` and `git_diff`.
    - Use `workspace_finalize` for streamlined transactional staging, preflight
      diff checks, committing, and pushing to origin in a single step.
+   - Pass an `idempotencyKey` on `git_commit`, `git_push`, and
+     `workspace_finalize`. On `UNKNOWN_REMOTE_STATE`, retry the identical request
+     with the same key to reconcile; treat `alreadyFinalized: true` as success
+     and never re-push. `git_commit` `expectedHeadOid` is a HEAD compare-and-set
+     returning `STALE_HEAD` on mismatch; `git_push` `expectedRemoteOid`
+     (force-with-lease) returns `CONFLICT` with current/expected remote OIDs
+     when the remote ref has moved.
    - Use `github_action` for brokered issue and pull request operations.
 8. **Manage lifecycle and lease.** If work approaches the idle timeout, call
    `workspace_lease_renew`. If disconnected or recovering unpushed work, call
@@ -102,8 +112,11 @@ not require a source checkout.
 - `bridge` enables broad egress; it is not an allowlist or strong isolation.
 - Arbitrary commands, interactive I/O, tasks, skill scripts, hooks, and
   deployments execute repository-controlled code. Review intent and scope.
-- Do not retry an unknown mutation blindly. Only creation operations documented
-  as idempotent should reuse the same key after a lost response.
+- Do not retry an unknown mutation blindly. Reuse the same idempotency key only
+  for the identical operation and parameters — to recover a lost creation
+  response, or to reconcile a `git_commit`, `git_push`, or `workspace_finalize`
+  whose outcome is unverified (e.g. `UNKNOWN_REMOTE_STATE`). A changed request
+  needs a new key.
 - Do not claim a push, private clone, deployment, or production outcome without
   current owner-authorized evidence from the corresponding operation.
 

--- a/plugins/cloud-harness/skills/cloudharness/references/execution-and-tasks.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/execution-and-tasks.md
@@ -104,6 +104,10 @@ only ASCII letters, digits, `.`, `_`, and `-`, with length 1–80.
   prevent unsafe blind continuation.
 - Reuse the key only to recover the same task creation. A timeout can leave
   file or external effects made before process termination.
+- Task records and bounded output are durable. After a runner restart, query
+  them with `tasks_list`/`tasks_status` rather than re-running; an interrupted
+  task becomes terminal with `RUNNER_RESTARTED` and is not resumed. Retained
+  task output may later be discovered through the artifact tools.
 
 <!-- cloudharness-example:tasks_run
 {"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","command":"npm run verify","cwd":".","idempotencyKey":"verify-20260817-01","timeoutMs":900000,"dependsOn":[]}
@@ -173,4 +177,5 @@ Wait for an operation to reach a terminal state with a server timeout.
 2. For timeout, cancellation, or disconnect, inspect status and side effects.
 3. Poll with the latest cursor; never derive or share cursors across handles.
 4. Close shells/sessions and cancel unwanted tasks before closing a workspace.
-5. After a runner restart, assume old interactive process handles are gone.
+5. After a runner restart, interactive shell/session handles are gone, but task
+   records and output persist; re-read task state before restarting work.

--- a/plugins/cloud-harness/skills/cloudharness/references/git-and-worktrees.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/git-and-worktrees.md
@@ -53,8 +53,13 @@ Read branch, index, and working-tree status for `workspaceId`.
 <!-- cloudharness-tool:git_commit -->
 ### `git_commit`
 
-- Required: `workspaceId`, `message` (1–10,000 characters), `authorName`
-  (1–200), and valid `authorEmail`; `all` defaults to `false`.
+- Required: `workspaceId`, `message` (1–10,000 characters); `all` defaults to
+  `false`. `authorName`/`authorEmail` are optional and fall back to the
+  configured or default Git identity.
+- Optional `expectedHeadOid` is a compare-and-set guard: the commit is rejected
+  with `STALE_HEAD` if the current HEAD no longer matches. Optional
+  `idempotencyKey` makes a lost-response retry safe; a same-key replay does not
+  create a second commit.
 - `all: true` runs an all-path staging step and includes untracked files as well
   as tracked modifications/deletions. Inspect status for secrets and unrelated
   files first. The tool creates a local commit and does not sign or push it.
@@ -91,6 +96,10 @@ Transactionally stage changes, run preflights, commit, and push to origin in one
 - Required: `commitMessage` (1–10,000 characters).
 - Optional: `workspaceId`, `paths`, `all` (default true), `branch`, `push` (default true), `authorName`, `authorEmail`, `preflight`, `idempotencyKey`.
 - Returns commit SHA, target branch, push result, and final workspace status.
+- Provide `idempotencyKey` before the first call. Finalize is crash-durable: a
+  commit may exist even when the push outcome is unknown. On a same-key retry
+  after `UNKNOWN_REMOTE_STATE`, the service reconciles against the destination
+  ref and returns `alreadyFinalized: true` instead of pushing again.
 
 <!-- cloudharness-example:workspace_finalize
 {"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","commitMessage":"feat(core): implement feature","push":true}
@@ -127,6 +136,12 @@ URL. Network access for these tools is separate from executor egress.
   syntax are rejected.
 - Force-with-lease requires `expectedRemoteOid`, a lowercase 40- or 64-hex
   object ID. With a refspec it also requires an explicit destination branch.
+- Supply `idempotencyKey` on the initial push, not only after a failure. If the
+  network drops mid-push the result is `UNKNOWN_REMOTE_STATE` with
+  `resumeAction: "reconcile_push"`; retry the identical request with the same
+  key. The service checks the destination ref's remote OID before deciding
+  whether another push is needed, returning `alreadyFinalized: true` when the
+  earlier push had already landed.
 - Push changes an external repository. Verify the target ref and inspect the
   returned result; a local commit is not evidence of a successful push.
 

--- a/plugins/cloud-harness/skills/cloudharness/references/workspace-lifecycle-and-results.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/workspace-lifecycle-and-results.md
@@ -24,6 +24,10 @@ in standard text content, while `structuredContent` carries the machine envelope
 256 characters. Not every truncated operation supports continuation; if no
 cursor is returned, narrow the request rather than inventing one.
 
+On failure `error` may also carry actionable detail fields: `resumeAction`
+(the safe next step, e.g. `reconcile_push`), and the compare-and-set operands
+`currentHeadOid`/`expectedHeadOid` and `currentRemoteOid`/`expectedRemoteOid`.
+
 ## Error codes
 
 | Code | Response |
@@ -39,14 +43,29 @@ cursor is returned, narrow the request rather than inventing one.
 | `CANCELLED` | Inspect current files/Git/process state before deciding next action. |
 | `UNAVAILABLE` | Retry only when marked retryable and after checking external prerequisites. |
 | `INTERNAL_ERROR` | Preserve bounded evidence and stop repeated retries. |
+| `UNKNOWN_REMOTE_STATE` | A push or finalize was interrupted before its remote outcome was confirmed. Do not start a new mutation; follow `error.resumeAction` and retry the identical request with the same idempotency key so the service reconciles against the destination ref. |
+| `STALE_HEAD` | `git_commit` `expectedHeadOid` no longer matches HEAD; inspect the returned `currentHeadOid`/`expectedHeadOid`, rebuild on the new base, then retry. A diverged remote ref on `git_push` force-with-lease returns `CONFLICT` with current/expected remote OIDs instead. |
+| `RUNNER_RESTARTED` | An in-flight task was interrupted by a runner restart and its record is terminal. Re-list/read task state; start fresh work rather than resuming the old process. |
 
 ## Idempotency keys
 
-Keys are 8–128 characters and may contain ASCII letters, digits, `.`, `_`, `:`,
-and `-`. Use a fresh semantic key for a new resource. Reuse the same key only to
-recover a lost response from `workspace_open`, `shell_open`, `sessions_open`, or
-`tasks_run`. Reuse returns the previously created resource in that workspace;
-it does not create a replacement.
+Use a fresh semantic key for each new resource or intended mutation. A key of
+8–128 characters using ASCII letters, digits, `.`, `_`, `:`, and `-` is the
+recommended safe subset; creation ops and `workspace_finalize` enforce it, while
+`git_commit` and `git_push` accept a broader 1–256-character string.
+
+Reuse the same key only to recover the identical operation with identical
+parameters after a lost response or an `UNKNOWN_REMOTE_STATE`:
+
+- Creation ops (`workspace_open`, `shell_open`, `sessions_open`, `tasks_run`)
+  return the previously created resource; reuse never creates a replacement.
+- Git mutations (`git_commit`, `git_push`, `workspace_finalize`) take the key
+  before the first attempt and reuse it to reconcile an unverified outcome. A
+  same-key replay reporting `alreadyFinalized: true` is confirmed success; do
+  not issue another mutation.
+
+Changing the operation or its parameters requires a new key; a mismatched reuse
+returns `CONFLICT`.
 
 ## Workspace operations
 
@@ -184,10 +203,12 @@ List available global and environment secret names and descriptions without reve
 - Active workspace calls refresh idle expiry but cannot extend beyond the
   configured absolute lifetime.
 - Workspace metadata is durable; executor files exist only until close/expiry.
-- Shell, session, task handles and buffered output are in runner memory. After a
-  runner restart, surviving executors are restarted so lost processes do not
-  continue invisibly; old process handles are not recoverable.
-- Closing a workspace evicts every shell/session/task record for that workspace.
+- Task records and their bounded output are durable: they remain queryable via
+  `tasks_list`/`tasks_status` across a runner restart. An interrupted task
+  process is not resumed and becomes terminal with `RUNNER_RESTARTED`; its
+  output may be retained as an artifact during workspace cleanup.
+- Shell and session handles and buffered output live in runner memory only.
+  After a runner restart those interactive processes and handles are gone.
 - If a workspace is `EXPIRED`, never reuse its handle. Open a new authorized
   workspace and reconstruct state from durable repository history.
 
@@ -197,5 +218,7 @@ List available global and environment secret names and descriptions without reve
 2. Recheck workspace status.
 3. Inspect the affected file, Git state, task list, or external result.
 4. Retry only when the desired effect is absent and the operation is safe.
-5. For create operations with an idempotency key, reuse the original key.
+5. For a lost creation response, reuse its original idempotency key; for an
+   unverified `git_push`/`workspace_finalize` outcome, retry the identical
+   request with the same key so the service reconciles instead of re-pushing.
 6. Report any outcome that remains unverifiable.


### PR DESCRIPTION
## Summary
Updates the operator-facing `cloudharness` Claude skill (and its byte-mirrored plugin copy) to reflect the merged #14 durable-state tool contract. Docs-only; no code changes.

### SKILL.md
- Step 6: task records/output survive runner restart (`tasks_list`/`tasks_status`; interrupted -> `RUNNER_RESTARTED`); interactive `shell_*`/`sessions_*` handles do not.
- Step 7: pass `idempotencyKey` on `git_commit`/`git_push`/`workspace_finalize`; on `UNKNOWN_REMOTE_STATE` retry the identical request with the same key and treat `alreadyFinalized: true` as success. `expectedHeadOid` -> `STALE_HEAD` CAS on commit; `expectedRemoteOid` force-with-lease -> `CONFLICT` on remote divergence.
- Safety rule rewritten from creation-only key reuse to identical-operation reconciliation.

### references/workspace-lifecycle-and-results.md
- Result envelope: documented `error.resumeAction` + current/expected HEAD & remote OID detail fields.
- Error codes: added `UNKNOWN_REMOTE_STATE`, `STALE_HEAD`, `RUNNER_RESTARTED`.
- Idempotency-keys section: corrected the creation-only reuse claim to the identical-op recovery rule; framed 8–128 `[A-Za-z0-9._:-]` as the recommended safe subset (creation ops + `workspace_finalize` enforce it; `git_commit`/`git_push` accept broader 1–256).
- Lifecycle details: replaced the stale in-memory-task claim — task records/output are durable across restart; interactive handles remain ephemeral.

### references/git-and-worktrees.md
- `git_commit`: required = `workspaceId`+`message`; author optional with identity fallback; `expectedHeadOid` CAS guard; `idempotencyKey` replay.
- `workspace_finalize`: crash-durable finalize + same-key remote reconciliation.
- `git_push`: initial `idempotencyKey` + `UNKNOWN_REMOTE_STATE`/`reconcile_push` retry semantics.

### references/execution-and-tasks.md
- Durable task persistence/reconciliation note; restart-recovery distinguishes ephemeral interactive handles from durable task state.

## Verification
- `npm run plugin:sync` + `npm run plugin:check`: byte parity pass.
- `packages/contracts/test/cloudharness-skill-contract.test.ts`: 5/5 pass (examples, internal links, 300-line limits, parity).
- Line budgets: SKILL.md 130, all references <300.
- No internal mechanics (SQLite/ledger/nested key/probe command/repo cache) leaked into the operator contract.