### PR TITLE
docs(skill): document files_write_batch same-key replay semantics (#14)

### DIFF
--- a/.agents/skills/cloudharness/references/files-and-search.md
+++ b/.agents/skills/cloudharness/references/files-and-search.md
@@ -56,6 +56,11 @@ Atomically create or update multiple workspace files in one operation with paren
 - Required: `files` array of 1–100 path/content objects.
 - Optional: `workspaceId`, `createParents` (default true), `atomic` (default true), `idempotencyKey`.
 - Returns created/updated counts, hashes, and per-file write details.
+- With `idempotencyKey`, a successful batch is cached and a same-key retry
+  replays that stored result instead of writing again — use it only to recover a
+  lost response. This replay is not fingerprint-checked: reusing the key with
+  different `files` returns the original result rather than a `CONFLICT`, so
+  always use a fresh key for a changed batch.
 
 <!-- cloudharness-example:files_write_batch
 {"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","files":[{"path":"plans/plan.md","content":"# Plan"}],"createParents":true}

--- a/plugins/cloud-harness/skills/cloudharness/references/files-and-search.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/files-and-search.md
@@ -56,6 +56,11 @@ Atomically create or update multiple workspace files in one operation with paren
 - Required: `files` array of 1–100 path/content objects.
 - Optional: `workspaceId`, `createParents` (default true), `atomic` (default true), `idempotencyKey`.
 - Returns created/updated counts, hashes, and per-file write details.
+- With `idempotencyKey`, a successful batch is cached and a same-key retry
+  replays that stored result instead of writing again — use it only to recover a
+  lost response. This replay is not fingerprint-checked: reusing the key with
+  different `files` returns the original result rather than a `CONFLICT`, so
+  always use a fresh key for a changed batch.
 
 <!-- cloudharness-example:files_write_batch
 {"workspaceId":"ws_aaaaaaaaaaaaaaaaaaaa","files":[{"path":"plans/plan.md","content":"# Plan"}],"createParents":true}


### PR DESCRIPTION
## Summary
The mandatory retry rule (PR #126) cites `files_write_batch` as an example whose tool reference documents same-key replay, but `references/files-and-search.md` only listed the optional `idempotencyKey` field with no replay/parameter semantics.

Adds the actual behavior to the `files_write_batch` entry: a successful batch is cached and a same-key retry replays the stored result (use only to recover a lost response). Crucially, unlike the Git operation ledger, this replay is **not fingerprint-checked** — reusing the key with different `files` returns the original result rather than a `CONFLICT`, so a changed batch must use a fresh key. This keeps the SKILL.md policy example accurate.

## Verification
- `npm run plugin:sync` + `npm run plugin:check`: byte parity pass.
- `packages/contracts/test/cloudharness-skill-contract.test.ts`: 5/5 pass.
- files-and-search.md 161 lines (<300).