### PR TITLE
fix(security): explicitly deny multicast (224/4), class E (240/4), and 0/8 in egress chain

### DIFF
--- a/apps/runner/src/host-firewall-attestor.ts
+++ b/apps/runner/src/host-firewall-attestor.ts
@@ -145,7 +145,17 @@ export class HostFirewallAttestor {
     }
 
     // Required deny CIDRs
-    const requiredDenyCidrs = ['169.254.0.0/16', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', '127.0.0.0/8', '100.64.0.0/10'];
+    const requiredDenyCidrs = [
+      '169.254.0.0/16',
+      '10.0.0.0/8',
+      '172.16.0.0/12',
+      '192.168.0.0/16',
+      '127.0.0.0/8',
+      '100.64.0.0/10',
+      '0.0.0.0/8',
+      '224.0.0.0/4',
+      '240.0.0.0/4'
+    ];
     const denyIndices: number[] = [];
     for (const cidr of requiredDenyCidrs) {
       const idx = egressRules.findIndex((l) => l.includes(`-d ${cidr}`) && (l.includes('-j REJECT') || l.includes('-j DROP')));

--- a/apps/runner/test/host-firewall-attestor.test.ts
+++ b/apps/runner/test/host-firewall-attestor.test.ts
@@ -95,6 +95,9 @@ describe('HostFirewallAttestor', () => {
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p udp -m udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1/32 -p udp -m udp --dport 53 -j ACCEPT
@@ -125,6 +128,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p udp -m udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1/32 -p udp -m udp --dport 53 -j ACCEPT
@@ -165,6 +171,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p udp -m udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1/32 -p udp -m udp --dport 53 -j ACCEPT
@@ -194,6 +203,15 @@ COMMIT
       const missingRfc1918 = validIptables.replace('-A CHM-EGRESS-v1 -d 10.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited', '');
       expect(attestor.parseFirewallRules(missingRfc1918).ok).toBe(false);
 
+      const missingMulticast = validIptables.replace('-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited', '');
+      expect(attestor.parseFirewallRules(missingMulticast).ok).toBe(false);
+
+      const missingClassE = validIptables.replace('-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited', '');
+      expect(attestor.parseFirewallRules(missingClassE).ok).toBe(false);
+
+      const missingCurrentNet = validIptables.replace('-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited', '');
+      expect(attestor.parseFirewallRules(missingCurrentNet).ok).toBe(false);
+
       const missingPort443 = validIptables.replace('-A CHM-EGRESS-v1 -p tcp -m tcp --dport 443 -j ACCEPT', '');
       expect(attestor.parseFirewallRules(missingPort443).ok).toBe(false);
 
@@ -219,6 +237,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1 -p udp --dport 53 -j ACCEPT
@@ -247,6 +268,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1 -p udp --dport 53 -j ACCEPT
@@ -274,6 +298,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1 -p udp --dport 53 -j ACCEPT
@@ -302,6 +329,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1 -p udp --dport 53 -j ACCEPT
@@ -333,6 +363,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1 -p udp --dport 53 -j ACCEPT
@@ -375,6 +408,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p udp -m udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1/32 -p udp -m udp --dport 53 -j ACCEPT
@@ -417,6 +453,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1 -p udp --dport 53 -j ACCEPT
@@ -445,6 +484,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1 -p udp --dport 53 -j ACCEPT
@@ -482,6 +524,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8 -p tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1 -p udp --dport 53 -j ACCEPT
@@ -516,6 +561,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p udp -m udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1/32 -p udp -m udp --dport 53 -j ACCEPT
@@ -561,6 +609,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p udp -m udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1/32 -p udp -m udp --dport 53 -j ACCEPT
@@ -606,6 +657,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p udp -m udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1/32 -p udp -m udp --dport 53 -j ACCEPT
@@ -652,6 +706,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p udp -m udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1/32 -p udp -m udp --dport 53 -j ACCEPT
@@ -697,6 +754,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p udp -m udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1/32 -p udp -m udp --dport 53 -j ACCEPT
@@ -743,6 +803,9 @@ COMMIT
 -A CHM-EGRESS-v1 -d 192.168.0.0/16 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
+-A CHM-EGRESS-v1 -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p udp -m udp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 8.8.8.8/32 -p tcp -m tcp --dport 53 -j ACCEPT
 -A CHM-EGRESS-v1 -d 1.1.1.1/32 -p udp -m udp --dport 53 -j ACCEPT

--- a/deploy/scripts/setup-dependency-firewall.sh
+++ b/deploy/scripts/setup-dependency-firewall.sh
@@ -50,6 +50,8 @@ trap 'rm -f "$TMP_RESTORE"' EXIT
   echo "-A $EGRESS_CHAIN -d 127.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited"
   echo "-A $EGRESS_CHAIN -d 100.64.0.0/10 -j REJECT --reject-with icmp-admin-prohibited"
   echo "-A $EGRESS_CHAIN -d 0.0.0.0/8 -j REJECT --reject-with icmp-admin-prohibited"
+  echo "-A $EGRESS_CHAIN -d 224.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited"
+  echo "-A $EGRESS_CHAIN -d 240.0.0.0/4 -j REJECT --reject-with icmp-admin-prohibited"
   
   for resolver in $DNS_RESOLVERS; do
     echo "-A $EGRESS_CHAIN -p udp -d $resolver --dport 53 -j ACCEPT"

--- a/test/integration/dependency-egress.docker.test.ts
+++ b/test/integration/dependency-egress.docker.test.ts
@@ -122,6 +122,9 @@ describe.skipIf(!enabled)('dependency-access egress boundary', () => {
       { label: 'metadata', command: 'curl -s -o /dev/null -w "%{http_code}" --max-time 4 http://169.254.169.254/ || echo BLOCKED' },
       { label: 'rfc1918-canary', command: 'curl -s -o /dev/null -w "%{http_code}" --max-time 4 http://10.88.0.10/ || echo BLOCKED' },
       { label: 'private-192', command: 'curl -s -o /dev/null -w "%{http_code}" --max-time 4 http://192.168.0.1/ || echo BLOCKED' },
+      { label: 'multicast-224', command: 'curl -s -o /dev/null -w "%{http_code}" --max-time 4 http://224.0.0.1/ || echo BLOCKED' },
+      { label: 'reserved-240', command: 'curl -s -o /dev/null -w "%{http_code}" --max-time 4 http://240.0.0.1/ || echo BLOCKED' },
+      { label: 'current-0', command: 'curl -s -o /dev/null -w "%{http_code}" --max-time 4 http://0.0.0.1/ || echo BLOCKED' },
       { label: 'disallowed-port', command: 'curl -s -o /dev/null -w "%{http_code}" --max-time 4 http://93.184.216.34:22/ || echo BLOCKED' }
     ];
     for (const probe of negativeProbes) {


### PR DESCRIPTION
## Summary
- Adds explicit deny rules in `deploy/scripts/setup-dependency-firewall.sh` for:
  - `0.0.0.0/8` (Current network)
  - `224.0.0.0/4` (Multicast)
  - `240.0.0.0/4` (Reserved / Class E)
- Enforces `0.0.0.0/8`, `224.0.0.0/4`, and `240.0.0.0/4` in `apps/runner/src/host-firewall-attestor.ts`'s `requiredDenyCidrs` list before any port 80/443 allow rule.
- Adds unit tests in `apps/runner/test/host-firewall-attestor.test.ts` verifying that omitting any of these deny CIDRs causes attestation to fail.
- Adds negative integration probes for `224.0.0.1`, `240.0.0.1`, and `0.0.0.1` in `test/integration/dependency-egress.docker.test.ts`.