### PR TITLE
fix(provenance): enforce trusted scan partitions and eliminate worker-asserted source promotion (#15)

### DIFF
--- a/apps/api/src/local/local-workspace-backend.ts
+++ b/apps/api/src/local/local-workspace-backend.ts
@@ -242,7 +242,7 @@ export class LocalWorkspaceBackend implements OperationBackend {
           const rawManifest = scanRes.data.manifest as Record<string, unknown>;
           const rawItems = Array.isArray(rawManifest.items) ? rawManifest.items : [];
           const maxBytes = Math.min(Math.max(Number((input as { maxBytes?: number }).maxBytes || 32768), 4096), 131072);
-          const sanitizedItems = [];
+          const sanitizedItems: any[] = [];
           let accumulatedBytes = 0;
           let truncated = Boolean(rawManifest.truncated);
           const truncationReasons = Array.isArray(rawManifest.truncationReasons) ? [...rawManifest.truncationReasons] : [];
@@ -261,6 +261,31 @@ export class LocalWorkspaceBackend implements OperationBackend {
             sanitizedItems.push(item);
             accumulatedBytes += itemBytes;
           }
+
+          const precedenceRank: Record<string, number> = {
+            'built-in': 4,
+            'owner': 3,
+            'workspace': 2,
+            'repository': 1
+          };
+
+          const mergeSkillItem = (sItem: any) => {
+            const existingIdx = sanitizedItems.findIndex(it => it.id === sItem.id);
+            if (existingIdx === -1) {
+              const sBytes = Buffer.byteLength(JSON.stringify(sItem));
+              if (accumulatedBytes + sBytes <= maxBytes) {
+                sanitizedItems.push(sItem);
+                accumulatedBytes += sBytes;
+              }
+            } else {
+              const existing = sanitizedItems[existingIdx]!;
+              const newRank = precedenceRank[sItem.provenance.source] || 0;
+              const existingRank = precedenceRank[existing.provenance.source] || 0;
+              if (newRank > existingRank) {
+                sanitizedItems[existingIdx] = sItem;
+              }
+            }
+          };
 
           // Scan trusted external owner and built-in skill partitions from local host
           const include = Array.isArray((input as any).include) ? (input as any).include : ['instructions', 'languages', 'test_commands', 'skills'];
@@ -286,19 +311,39 @@ export class LocalWorkspaceBackend implements OperationBackend {
                       partitionSource: 'owner',
                       trustedRoot: ownerRoot
                     });
-                    const sBytes = Buffer.byteLength(JSON.stringify(sItem));
-                    if (accumulatedBytes + sBytes <= maxBytes) {
-                      const existingIdx = sanitizedItems.findIndex(it => it.id === sItem.id);
-                      if (existingIdx >= 0) sanitizedItems.splice(existingIdx, 1);
-                      sanitizedItems.unshift(sItem);
-                      accumulatedBytes += sBytes;
-                    }
+                    mergeSkillItem(sItem);
                   } catch { /* skip */ }
                 }
               }
             } catch { /* owner root absent */ }
-          }
 
+            const builtinRoot = process.env.CH_BUILTIN_SKILLS_ROOT || '/opt/cloud-harness/skills';
+            try {
+              const builtinEntries = await readdir(builtinRoot, { withFileTypes: true });
+              for (const be of builtinEntries) {
+                if (be.isDirectory()) {
+                  const sFile = join(builtinRoot, be.name, 'SKILL.md');
+                  try {
+                    const sRaw = await readFile(sFile);
+                    const sHash = createHash('sha256').update(sRaw).digest('hex');
+                    const sItem = sanitizeAndAttributeProvenance({
+                      id: `ctx_skill_${be.name}`,
+                      kind: 'skill-summary',
+                      format: 'skill-md',
+                      path: sFile,
+                      clients: ['all'],
+                      contentSha256: sHash,
+                      excerpt: `Skill "${be.name}" (built-in)`
+                    }, {
+                      partitionSource: 'built-in',
+                      trustedRoot: builtinRoot
+                    });
+                    mergeSkillItem(sItem);
+                  } catch { /* skip */ }
+                }
+              }
+            } catch { /* builtin root absent */ }
+          }
           manifest = {
             contractVersion: 1,
             returnedBytes: accumulatedBytes,

--- a/apps/api/src/local/local-workspace-backend.ts
+++ b/apps/api/src/local/local-workspace-backend.ts
@@ -1,5 +1,7 @@
-import { randomBytes } from 'node:crypto';
-import type { RunnerOperation, RunnerResponse } from '@cloud-harness/contracts';
+import { createHash, randomBytes } from 'node:crypto';
+import { join } from 'node:path';
+import { readdir, readFile } from 'node:fs/promises';
+import { sanitizeAndAttributeProvenance, type RunnerOperation, type RunnerResponse } from '@cloud-harness/contracts';
 import type { OperationBackend } from '../operation-backend.js';
 import type { CliOptions } from '../cli-options.js';
 import { LocalPathPolicy } from './local-path-policy.js';
@@ -246,31 +248,10 @@ export class LocalWorkspaceBackend implements OperationBackend {
           const truncationReasons = Array.isArray(rawManifest.truncationReasons) ? [...rawManifest.truncationReasons] : [];
 
           for (const rawItem of rawItems as Record<string, unknown>[]) {
-            const pathStr = typeof rawItem.path === 'string' ? rawItem.path : undefined;
-            const hashStr = typeof rawItem.contentSha256 === 'string' && rawItem.contentSha256.length === 64
-              ? rawItem.contentSha256
-              : '0'.repeat(64);
-            const item = {
-              id: typeof rawItem.id === 'string' ? rawItem.id : `ctx_${hashStr.slice(0, 12)}`,
-              kind: typeof rawItem.kind === 'string' ? rawItem.kind : 'instruction',
-              format: typeof rawItem.format === 'string' ? rawItem.format : 'plain',
-              clients: Array.isArray(rawItem.clients) ? rawItem.clients : ['all'],
-              path: pathStr,
-              appliesTo: typeof rawItem.appliesTo === 'string' ? rawItem.appliesTo : undefined,
-              activeForClient: Boolean(rawItem.activeForClient ?? true),
-              contentSha256: hashStr,
-              byteCount: typeof rawItem.byteCount === 'number' ? rawItem.byteCount : 0,
-              excerpt: typeof rawItem.excerpt === 'string' ? rawItem.excerpt.slice(0, 8192) : undefined,
-              references: Array.isArray(rawItem.references) ? rawItem.references : undefined,
-              provenance: {
-                source: 'repository',
-                trust: 'untrusted-executor',
-                mutableBy: 'repository-commit',
-                path: pathStr,
-                contentSha256: hashStr,
-                discoveredAt: new Date().toISOString()
-              }
-            };
+            const item = sanitizeAndAttributeProvenance(rawItem, {
+              partitionSource: 'repository',
+              repositoryRoot: this.canonicalRoot
+            });
             const itemBytes = Buffer.byteLength(JSON.stringify(item));
             if (accumulatedBytes + itemBytes > maxBytes) {
               truncated = true;
@@ -279,6 +260,43 @@ export class LocalWorkspaceBackend implements OperationBackend {
             }
             sanitizedItems.push(item);
             accumulatedBytes += itemBytes;
+          }
+
+          // Scan trusted external owner and built-in skill partitions from local host
+          const include = Array.isArray((input as any).include) ? (input as any).include : ['instructions', 'languages', 'test_commands', 'skills'];
+          if (include.includes('skills')) {
+            const ownerRoot = process.env.CH_OWNER_SKILLS_ROOT || '/opt/cloud-harness/owner-skills';
+            try {
+              const ownerEntries = await readdir(ownerRoot, { withFileTypes: true });
+              for (const oe of ownerEntries) {
+                if (oe.isDirectory()) {
+                  const sFile = join(ownerRoot, oe.name, 'SKILL.md');
+                  try {
+                    const sRaw = await readFile(sFile);
+                    const sHash = createHash('sha256').update(sRaw).digest('hex');
+                    const sItem = sanitizeAndAttributeProvenance({
+                      id: `ctx_skill_${oe.name}`,
+                      kind: 'skill-summary',
+                      format: 'skill-md',
+                      path: sFile,
+                      clients: ['all'],
+                      contentSha256: sHash,
+                      excerpt: `Skill "${oe.name}" (owner)`
+                    }, {
+                      partitionSource: 'owner',
+                      trustedRoot: ownerRoot
+                    });
+                    const sBytes = Buffer.byteLength(JSON.stringify(sItem));
+                    if (accumulatedBytes + sBytes <= maxBytes) {
+                      const existingIdx = sanitizedItems.findIndex(it => it.id === sItem.id);
+                      if (existingIdx >= 0) sanitizedItems.splice(existingIdx, 1);
+                      sanitizedItems.unshift(sItem);
+                      accumulatedBytes += sBytes;
+                    }
+                  } catch { /* skip */ }
+                }
+              }
+            } catch { /* owner root absent */ }
           }
 
           manifest = {

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -2330,7 +2330,7 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
           const rawManifest = scanRes.data.manifest as Record<string, unknown>;
           const rawItems = Array.isArray(rawManifest.items) ? rawManifest.items : [];
           const maxBytes = Math.min(Math.max(Number((validated as { maxBytes?: number }).maxBytes || 32768), 4096), 131072);
-          const sanitizedItems = [];
+          const sanitizedItems: any[] = [];
           let accumulatedBytes = 0;
           let truncated = Boolean(rawManifest.truncated);
           const truncationReasons = Array.isArray(rawManifest.truncationReasons) ? [...rawManifest.truncationReasons] : [];
@@ -2350,7 +2350,31 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
             accumulatedBytes += itemBytes;
           }
 
-          // Scan trusted external owner and built-in skill partitions from Runner control plane
+          const precedenceRank: Record<string, number> = {
+            'built-in': 4,
+            'owner': 3,
+            'workspace': 2,
+            'repository': 1
+          };
+
+          const mergeSkillItem = (sItem: any) => {
+            const existingIdx = sanitizedItems.findIndex((it) => it.id === sItem.id);
+            if (existingIdx === -1) {
+              const sBytes = Buffer.byteLength(JSON.stringify(sItem));
+              if (accumulatedBytes + sBytes <= maxBytes) {
+                sanitizedItems.push(sItem);
+                accumulatedBytes += sBytes;
+              }
+            } else {
+              const existing = sanitizedItems[existingIdx]!;
+              const newRank = precedenceRank[sItem.provenance.source] || 0;
+              const existingRank = precedenceRank[existing.provenance.source] || 0;
+              if (newRank > existingRank) {
+                sanitizedItems[existingIdx] = sItem;
+              }
+            }
+          };
+
           const include = Array.isArray((validated as any).include) ? (validated as any).include : ['instructions', 'languages', 'test_commands', 'skills'];
           if (include.includes('skills')) {
             const ownerRoot = process.env.CH_OWNER_SKILLS_ROOT || '/opt/cloud-harness/owner-skills';
@@ -2374,17 +2398,38 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
                       partitionSource: 'owner',
                       trustedRoot: ownerRoot
                     });
-                    const sBytes = Buffer.byteLength(JSON.stringify(sItem));
-                    if (accumulatedBytes + sBytes <= maxBytes) {
-                      const existingIdx = sanitizedItems.findIndex(it => it.id === sItem.id);
-                      if (existingIdx >= 0) sanitizedItems.splice(existingIdx, 1);
-                      sanitizedItems.unshift(sItem);
-                      accumulatedBytes += sBytes;
-                    }
+                    mergeSkillItem(sItem);
                   } catch { /* skip */ }
                 }
               }
             } catch { /* owner root absent */ }
+
+            const builtinRoot = process.env.CH_BUILTIN_SKILLS_ROOT || '/opt/cloud-harness/skills';
+            try {
+              const builtinEntries = await readdir(builtinRoot, { withFileTypes: true });
+              for (const be of builtinEntries) {
+                if (be.isDirectory()) {
+                  const sFile = join(builtinRoot, be.name, 'SKILL.md');
+                  try {
+                    const sRaw = await readFile(sFile);
+                    const sHash = createHash('sha256').update(sRaw).digest('hex');
+                    const sItem = sanitizeAndAttributeProvenance({
+                      id: `ctx_skill_${be.name}`,
+                      kind: 'skill-summary',
+                      format: 'skill-md',
+                      path: sFile,
+                      clients: ['all'],
+                      contentSha256: sHash,
+                      excerpt: `Skill "${be.name}" (built-in)`
+                    }, {
+                      partitionSource: 'built-in',
+                      trustedRoot: builtinRoot
+                    });
+                    mergeSkillItem(sItem);
+                  } catch { /* skip */ }
+                }
+              }
+            } catch { /* builtin root absent */ }
           }
 
           manifest = {

--- a/apps/runner/src/workspace-service.ts
+++ b/apps/runner/src/workspace-service.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { existsSync, lstatSync, readFileSync, realpathSync, rmSync, statSync } from 'node:fs';
-import { chmod, chown, cp, mkdir, readdir, realpath, rm, stat, statfs, writeFile } from 'node:fs/promises';
+import { chmod, chown, cp, mkdir, readFile, readdir, realpath, rm, stat, statfs, writeFile } from 'node:fs/promises';
 import { join, relative, resolve, sep } from 'node:path';
 import {
   AgentProxyOperationSchema,
@@ -9,6 +9,7 @@ import {
   RunnerOperationSchema,
   RunnerResponseSchema,
   TOOL_SCHEMA_BY_NAME,
+  sanitizeAndAttributeProvenance,
   type AgentProxyOperation,
   type RunnerConfig,
   type InternalRunnerOperation,
@@ -2335,31 +2336,10 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
           const truncationReasons = Array.isArray(rawManifest.truncationReasons) ? [...rawManifest.truncationReasons] : [];
 
           for (const rawItem of rawItems as Record<string, unknown>[]) {
-            const pathStr = typeof rawItem.path === 'string' ? rawItem.path : undefined;
-            const hashStr = typeof rawItem.contentSha256 === 'string' && rawItem.contentSha256.length === 64
-              ? rawItem.contentSha256
-              : '0'.repeat(64);
-            const item = {
-              id: typeof rawItem.id === 'string' ? rawItem.id : `ctx_${hashStr.slice(0, 12)}`,
-              kind: typeof rawItem.kind === 'string' ? rawItem.kind : 'instruction',
-              format: typeof rawItem.format === 'string' ? rawItem.format : 'plain',
-              clients: Array.isArray(rawItem.clients) ? rawItem.clients : ['all'],
-              path: pathStr,
-              appliesTo: typeof rawItem.appliesTo === 'string' ? rawItem.appliesTo : undefined,
-              activeForClient: Boolean(rawItem.activeForClient ?? true),
-              contentSha256: hashStr,
-              byteCount: typeof rawItem.byteCount === 'number' ? rawItem.byteCount : 0,
-              excerpt: typeof rawItem.excerpt === 'string' ? rawItem.excerpt.slice(0, 8192) : undefined,
-              references: Array.isArray(rawItem.references) ? rawItem.references : undefined,
-              provenance: {
-                source: 'repository',
-                trust: 'untrusted-executor',
-                mutableBy: 'repository-commit',
-                path: pathStr,
-                contentSha256: hashStr,
-                discoveredAt: new Date().toISOString()
-              }
-            };
+            const item = sanitizeAndAttributeProvenance(rawItem, {
+              partitionSource: 'repository',
+              repositoryRoot: record.workspacePath
+            });
             const itemBytes = Buffer.byteLength(JSON.stringify(item));
             if (accumulatedBytes + itemBytes > maxBytes) {
               truncated = true;
@@ -2368,6 +2348,43 @@ git -c http.followRedirects=false -c core.hooksPath=/dev/null ls-remote "$1" "$2
             }
             sanitizedItems.push(item);
             accumulatedBytes += itemBytes;
+          }
+
+          // Scan trusted external owner and built-in skill partitions from Runner control plane
+          const include = Array.isArray((validated as any).include) ? (validated as any).include : ['instructions', 'languages', 'test_commands', 'skills'];
+          if (include.includes('skills')) {
+            const ownerRoot = process.env.CH_OWNER_SKILLS_ROOT || '/opt/cloud-harness/owner-skills';
+            try {
+              const ownerEntries = await readdir(ownerRoot, { withFileTypes: true });
+              for (const oe of ownerEntries) {
+                if (oe.isDirectory()) {
+                  const sFile = join(ownerRoot, oe.name, 'SKILL.md');
+                  try {
+                    const sRaw = await readFile(sFile);
+                    const sHash = createHash('sha256').update(sRaw).digest('hex');
+                    const sItem = sanitizeAndAttributeProvenance({
+                      id: `ctx_skill_${oe.name}`,
+                      kind: 'skill-summary',
+                      format: 'skill-md',
+                      path: sFile,
+                      clients: ['all'],
+                      contentSha256: sHash,
+                      excerpt: `Skill "${oe.name}" (owner)`
+                    }, {
+                      partitionSource: 'owner',
+                      trustedRoot: ownerRoot
+                    });
+                    const sBytes = Buffer.byteLength(JSON.stringify(sItem));
+                    if (accumulatedBytes + sBytes <= maxBytes) {
+                      const existingIdx = sanitizedItems.findIndex(it => it.id === sItem.id);
+                      if (existingIdx >= 0) sanitizedItems.splice(existingIdx, 1);
+                      sanitizedItems.unshift(sItem);
+                      accumulatedBytes += sBytes;
+                    }
+                  } catch { /* skip */ }
+                }
+              }
+            } catch { /* owner root absent */ }
           }
 
           manifest = {

--- a/apps/runner/test/context-provenance.test.ts
+++ b/apps/runner/test/context-provenance.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, symlink, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { isPathContained, sanitizeAndAttributeProvenance } from '@cloud-harness/contracts';
+
+describe('context provenance attribution and partition-based verification', () => {
+  it('correctly checks path containment and prevents sibling prefix bypasses', () => {
+    const root = '/opt/cloud-harness/owner-skills';
+
+    // Direct containment
+    expect(isPathContained(root, '/opt/cloud-harness/owner-skills/deploy/SKILL.md')).toBe(true);
+    expect(isPathContained(root, '/opt/cloud-harness/owner-skills')).toBe(true);
+
+    // Sibling prefix bypasses MUST fail
+    expect(isPathContained(root, '/opt/cloud-harness/owner-skills-evil/deploy/SKILL.md')).toBe(false);
+    expect(isPathContained(root, '/opt/cloud-harness/owner-skills.bak/deploy/SKILL.md')).toBe(false);
+
+    // Parent escape MUST fail
+    expect(isPathContained(root, '/opt/cloud-harness/owner-skills/../skills-evil/SKILL.md')).toBe(false);
+  });
+
+  it('detects and rejects symlink escapes outside the trusted root', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'ch-symlink-test-'));
+    try {
+      const trustedRoot = join(tmp, 'trusted-root');
+      const outsideDir = join(tmp, 'outside-secret-dir');
+      await mkdir(trustedRoot, { recursive: true });
+      await mkdir(outsideDir, { recursive: true });
+
+      await writeFile(join(outsideDir, 'SKILL.md'), '# Secret skill outside');
+
+      // Create a symlink inside trusted root pointing to outside directory
+      const linkInside = join(trustedRoot, 'escaped-link');
+      await symlink(outsideDir, linkInside, 'dir');
+
+      const candidatePath = join(linkInside, 'SKILL.md');
+
+      // isPathContained MUST resolve the realpath and reject because it escapes trustedRoot!
+      expect(isPathContained(trustedRoot, candidatePath)).toBe(false);
+
+      // Provenance sanitization MUST downgrade it to repository/untrusted
+      const item = {
+        id: 'ctx_escaped',
+        kind: 'skill-summary',
+        path: candidatePath,
+        contentSha256: 'a'.repeat(64)
+      };
+      const sanitized = sanitizeAndAttributeProvenance(item, {
+        partitionSource: 'owner',
+        trustedRoot
+      });
+      expect(sanitized.provenance.source).toBe('repository');
+      expect(sanitized.provenance.trust).toBe('untrusted-executor');
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects raw caller text claims and enforces partition boundaries', () => {
+    // 1. Forged claim from repository partition:
+    // Worker sends an item claiming path '/opt/cloud-harness/skills/deploy/SKILL.md' and 'source: built-in'
+    // BUT partitionSource is 'repository' -> MUST stay 'repository' / 'untrusted-executor'!
+    const forgedRepoItem = {
+      id: 'ctx_forged_1',
+      kind: 'skill-summary',
+      format: 'skill-md',
+      path: '/opt/cloud-harness/skills/deploy/SKILL.md',
+      contentSha256: 'a'.repeat(64),
+      provenance: {
+        source: 'built-in',
+        trust: 'trusted-control-plane',
+        mutableBy: 'release'
+      }
+    };
+    const sanitizedRepo = sanitizeAndAttributeProvenance(forgedRepoItem, {
+      partitionSource: 'repository'
+    });
+    expect(sanitizedRepo.provenance.source).toBe('repository');
+    expect(sanitizedRepo.provenance.trust).toBe('untrusted-executor');
+    expect(sanitizedRepo.provenance.mutableBy).toBe('repository-commit');
+
+    // 2. Forged claim with sibling prefix path in owner partition
+    const forgedSiblingItem = {
+      id: 'ctx_forged_2',
+      kind: 'skill-summary',
+      format: 'skill-md',
+      path: '/opt/cloud-harness/owner-skills-evil/tool/SKILL.md',
+      contentSha256: 'b'.repeat(64)
+    };
+    const sanitizedSibling = sanitizeAndAttributeProvenance(forgedSiblingItem, {
+      partitionSource: 'owner',
+      trustedRoot: '/opt/cloud-harness/owner-skills'
+    });
+    expect(sanitizedSibling.provenance.source).toBe('repository');
+    expect(sanitizedSibling.provenance.trust).toBe('untrusted-executor');
+
+    // 3. Legitimate built-in scan partition verified by Runner
+    const builtinItem = {
+      id: 'ctx_builtin_1',
+      kind: 'skill-summary',
+      format: 'skill-md',
+      path: '/opt/cloud-harness/skills/cloudharness/SKILL.md',
+      contentSha256: 'c'.repeat(64)
+    };
+    const sanitizedBuiltin = sanitizeAndAttributeProvenance(builtinItem, {
+      partitionSource: 'built-in',
+      trustedRoot: '/opt/cloud-harness/skills'
+    });
+    expect(sanitizedBuiltin.provenance.source).toBe('built-in');
+    expect(sanitizedBuiltin.provenance.trust).toBe('trusted-control-plane');
+    expect(sanitizedBuiltin.provenance.mutableBy).toBe('release');
+
+    // 4. Legitimate owner scan partition verified by Runner
+    const ownerItem = {
+      id: 'ctx_owner_1',
+      kind: 'skill-summary',
+      format: 'skill-md',
+      path: '/opt/cloud-harness/owner-skills/deploy/SKILL.md',
+      contentSha256: 'd'.repeat(64)
+    };
+    const sanitizedOwner = sanitizeAndAttributeProvenance(ownerItem, {
+      partitionSource: 'owner',
+      trustedRoot: '/opt/cloud-harness/owner-skills'
+    });
+    expect(sanitizedOwner.provenance.source).toBe('owner');
+    expect(sanitizedOwner.provenance.trust).toBe('owner-controlled');
+    expect(sanitizedOwner.provenance.mutableBy).toBe('owner');
+
+    // 5. Default without partition is strictly repository
+    const defaultItem = {
+      id: 'ctx_default',
+      kind: 'instruction',
+      path: 'CLAUDE.md',
+      contentSha256: 'e'.repeat(64)
+    };
+    const sanitizedDefault = sanitizeAndAttributeProvenance(defaultItem);
+    expect(sanitizedDefault.provenance.source).toBe('repository');
+    expect(sanitizedDefault.provenance.trust).toBe('untrusted-executor');
+  });
+});

--- a/apps/runner/test/workspace-context-manifest.test.ts
+++ b/apps/runner/test/workspace-context-manifest.test.ts
@@ -157,4 +157,82 @@ describe('workspace_context manifest and passive scanner', () => {
     const manifest = (res.data as any).manifest;
     expect(manifest.returnedBytes).toBeLessThanOrEqual(4096);
   });
+
+  it('correctly attributes provenance to skills from different roots in workspace_context', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'ch-ctx-skills-'));
+    const ownerDir = await mkdtemp(join(tmpdir(), 'ch-owner-skills-'));
+    const wsToolsDir = await mkdtemp(join(tmpdir(), 'ch-ws-tools-'));
+    tempDirs.push(dir, ownerDir, wsToolsDir);
+    process.env.CH_OWNER_SKILLS_ROOT = ownerDir;
+    process.env.CH_WORKSPACE_SKILLS_ROOT = wsToolsDir;
+
+    try {
+      // 1. Repo skill inside checkout
+      await mkdir(join(dir, '.agents', 'skills', 'repo-tool'), { recursive: true });
+      await writeFile(join(dir, '.agents', 'skills', 'repo-tool', 'SKILL.md'), '# Repo tool');
+
+      // 2. Owner skill outside checkout
+      await mkdir(join(ownerDir, 'owner-tool'), { recursive: true });
+      await writeFile(join(ownerDir, 'owner-tool', 'SKILL.md'), '# Owner tool');
+
+      const backend = new LocalWorkspaceBackend(dir, { transport: 'stdio', workspace: dir });
+      const res = await backend.call('workspace_context', {
+        workspaceId: backend.workspaceId,
+        include: ['skills']
+      });
+
+      expect(res.ok).toBe(true);
+      const manifest = (res.data as any).manifest;
+      expect(manifest).toBeDefined();
+
+      const items = manifest.items;
+      const repoSkill = items.find((it: any) => it.id === 'ctx_skill_repo-tool');
+      expect(repoSkill).toBeDefined();
+      expect(repoSkill.provenance.source).toBe('repository');
+      expect(repoSkill.provenance.trust).toBe('untrusted-executor');
+
+      const ownerSkill = items.find((it: any) => it.id === 'ctx_skill_owner-tool');
+      expect(ownerSkill).toBeDefined();
+      expect(ownerSkill.provenance.source).toBe('owner');
+      expect(ownerSkill.provenance.trust).toBe('owner-controlled');
+    } finally {
+      delete process.env.CH_OWNER_SKILLS_ROOT;
+      delete process.env.CH_WORKSPACE_SKILLS_ROOT;
+    }
+  });
+
+  it('rejects forged sibling prefix paths from claiming owner provenance', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'ch-ctx-sibling-'));
+    const ownerDir = await mkdtemp(join(tmpdir(), 'ch-owner-skills-'));
+    const evilSibling = `${ownerDir}-evil`;
+    tempDirs.push(dir, ownerDir, evilSibling);
+    process.env.CH_OWNER_SKILLS_ROOT = ownerDir;
+
+    try {
+      await mkdir(join(evilSibling, 'fake-tool'), { recursive: true });
+      await writeFile(join(evilSibling, 'fake-tool', 'SKILL.md'), '# Fake tool');
+
+      // Also create inside workspace
+      await mkdir(join(dir, '.agents', 'skills', 'regular-tool'), { recursive: true });
+      await writeFile(join(dir, '.agents', 'skills', 'regular-tool', 'SKILL.md'), '# Regular tool');
+
+      const backend = new LocalWorkspaceBackend(dir, { transport: 'stdio', workspace: dir });
+      const res = await backend.call('workspace_context', {
+        workspaceId: backend.workspaceId,
+        include: ['skills']
+      });
+
+      expect(res.ok).toBe(true);
+      const manifest = (res.data as any).manifest;
+      const items = manifest.items;
+      // Fake tool from sibling prefix path should NOT be found or if injected cannot get owner provenance
+      const fake = items.find((it: any) => it.id === 'ctx_skill_fake-tool');
+      if (fake) {
+        expect(fake.provenance.source).not.toBe('owner');
+        expect(fake.provenance.trust).not.toBe('owner-controlled');
+      }
+    } finally {
+      delete process.env.CH_OWNER_SKILLS_ROOT;
+    }
+  });
 });

--- a/apps/runner/test/workspace-context-manifest.test.ts
+++ b/apps/runner/test/workspace-context-manifest.test.ts
@@ -235,4 +235,45 @@ describe('workspace_context manifest and passive scanner', () => {
       delete process.env.CH_OWNER_SKILLS_ROOT;
     }
   });
+
+  it('strictly preserves built-in > owner > repository precedence when skills collide', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'ch-ctx-collide-'));
+    const ownerDir = await mkdtemp(join(tmpdir(), 'ch-owner-collide-'));
+    const builtinDir = await mkdtemp(join(tmpdir(), 'ch-builtin-collide-'));
+    tempDirs.push(dir, ownerDir, builtinDir);
+    process.env.CH_OWNER_SKILLS_ROOT = ownerDir;
+    process.env.CH_BUILTIN_SKILLS_ROOT = builtinDir;
+
+    try {
+      // 1. Repo skill named 'deploy'
+      await mkdir(join(dir, '.agents', 'skills', 'deploy'), { recursive: true });
+      await writeFile(join(dir, '.agents', 'skills', 'deploy', 'SKILL.md'), '# Repo Deploy');
+
+      // 2. Owner skill named 'deploy'
+      await mkdir(join(ownerDir, 'deploy'), { recursive: true });
+      await writeFile(join(ownerDir, 'deploy', 'SKILL.md'), '# Owner Deploy');
+
+      // 3. Built-in skill named 'deploy'
+      await mkdir(join(builtinDir, 'deploy'), { recursive: true });
+      await writeFile(join(builtinDir, 'deploy', 'SKILL.md'), '# Built-in Deploy');
+
+      const backend = new LocalWorkspaceBackend(dir, { transport: 'stdio', workspace: dir });
+      const res = await backend.call('workspace_context', {
+        workspaceId: backend.workspaceId,
+        include: ['skills']
+      });
+
+      expect(res.ok).toBe(true);
+      const manifest = (res.data as any).manifest;
+      const deploySkill = manifest.items.find((it: any) => it.id === 'ctx_skill_deploy');
+      expect(deploySkill).toBeDefined();
+      // Built-in MUST outrank owner and repository!
+      expect(deploySkill.provenance.source).toBe('built-in');
+      expect(deploySkill.provenance.trust).toBe('trusted-control-plane');
+      expect(deploySkill.provenance.mutableBy).toBe('release');
+    } finally {
+      delete process.env.CH_OWNER_SKILLS_ROOT;
+      delete process.env.CH_BUILTIN_SKILLS_ROOT;
+    }
+  });
 });

--- a/docs-site/concepts.md
+++ b/docs-site/concepts.md
@@ -38,3 +38,20 @@ Output files generated during workspace execution (logs, test reports, build out
 
 ### Sibling Git Transfer Helper
 An ephemeral container spawned by the Runner to handle `git_fetch`, `git_pull`, and `git_push`. It mounts the workspace repository as a sibling, receives a 10-minute GitHub App installation token via `stdin`, talks only to `github.com`, and is immediately destroyed.
+
+### Context Manifest & Provenance
+A bounded, vendor-neutral overview of allowlisted instruction files (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules/*.mdc`, `.aider.conf.yml`), language manifests, and test declarations produced by `workspace_context`. Every item carries immutable provenance (`source`, `trust`, `mutableBy`, `contentSha256`, `discoveredAt`) stamped by the trusted Runner:
+- `built-in`: release-packaged built-ins (`trust: trusted-control-plane`, `mutableBy: release`)
+- `owner`: runner-managed principal catalog (`trust: owner-controlled`, `mutableBy: owner`)
+- `workspace`: workspace-managed tools overlay (`trust: untrusted-executor`, `mutableBy: workspace-process`)
+- `repository`: checkout files (`trust: untrusted-executor`, `mutableBy: repository-commit`)
+
+### Scoped Memories
+Persistent notes stored in SQLite `StateStore` v5 isolated by `principal_id` across 3 scopes:
+- `owner`: Principal-wide notes persistent across all workspaces.
+- `repository`: Notes bound to `(principal_id, repository_key)`, persistent across workspaces for the same repository.
+- `workspace`: Notes bound to `(principal_id, workspace_id)`, reaped when the workspace terminates.
+Enforces Optimistic Concurrency Control via `expectedGeneration` (CAS: 0 for create, positive integer for update/delete) and automatic TTL cleanup.
+
+### Declarative Lifecycle Hooks
+Pre-configured automation commands declared in `.cloud-harness/hooks.json` for named lifecycle events (`on_workspace_open`, `post_checkout`, `pre_commit`, `post_commit`, `manual`). Automatic lifecycle execution requires explicit owner activation (`hooks_activate`) pinned to the manifest SHA-256 digest and runs exclusively inside an unprivileged executor container.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -123,6 +123,37 @@ responses are mapped at the API; runner tokens, Access assertions, raw secret
 values, provider credentials, ciphertext, and artifact filesystem paths are
 outside that contract.
 
+## Provenance, context plane, and automation architecture
+
+Cloud Harness MCP provides a portable coding context plane across agent clients without elevating repository text or scripts to trusted policy:
+
+1. **Passive Context Scanner:**
+   `worker/harness-worker.mjs` executes bounded passive discovery of allowlisted instruction files (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules/*.mdc`, `.aider.conf.yml`), language manifests, and test declarations. The scanner performs zero dynamic execution and enforces strict byte budgets (32 KiB default, 128 KiB max) and a 250ms deadline.
+
+2. **Runner Provenance Resolver:**
+   The trusted Runner control plane (`apps/runner/src/workspace-service.ts`) stamps canonical provenance metadata (`source`, `trust`, `mutableBy`, `contentSha256`, `discoveredAt`) based on physical isolation boundaries:
+   - `built-in` (`trust: trusted-control-plane`, `mutableBy: release`)
+   - `owner` (`trust: owner-controlled`, `mutableBy: owner`)
+   - `workspace` (`trust: untrusted-executor`, `mutableBy: workspace-process`)
+   - `repository` (`trust: untrusted-executor`, `mutableBy: repository-commit`)
+   Repository content claiming owner or built-in status is strictly ignored and attributed as untrusted repository data.
+
+3. **4-Tier Skill Precedence:**
+   Skills resolve deterministically in the fixed order `built-in > owner > workspace > repository` (with repository sub-priority `.agents/skills > .codex/skills > .claude/skills`). Shadowed candidates remain visible. `skills_run` requires matching the approved SHA-256 bundle digest before executing in an isolated container.
+
+4. **Scoped SQLite Memories (StateStore Schema v5):**
+   Memories are persisted in runner-owned SQLite isolated by `principal_id`:
+   - `owner`: Principal-wide, persistent across all workspaces
+   - `repository`: Scoped to `(principal_id, repository_key)`, persistent across workspaces for the same repository
+   - `workspace`: Scoped to `(principal_id, workspace_id)`, automatically reaped upon workspace termination
+   Enforces Optimistic Concurrency Control via `expectedGeneration` (CAS) and TTL expiration.
+
+5. **Declarative Lifecycle Hooks:**
+   Hooks defined in `.cloud-harness/hooks.json` support named lifecycle events (`pre_commit`, `post_checkout`, `on_workspace_open`, `post_commit`). Automatic execution requires explicit owner activation (`hooks_activate`) pinned to the manifest SHA-256 digest and executes in an unprivileged, no-network executor container.
+
+6. **Adversarial Output Boundary:**
+   Structured MCP results keep repository text nested in `data` under `trust: untrusted-executor`. Text projections (`mcp-response-text.ts`) format context items with trusted boundary markers and JSON-escaped excerpts to prevent delimiter breakouts or prompt injection.
+
 ## State and lifecycle
 
 Workspace metadata, idempotency, principal ownership, status, and expiry are persisted in

--- a/packages/contracts/src/context-provenance.ts
+++ b/packages/contracts/src/context-provenance.ts
@@ -1,10 +1,25 @@
 import { isAbsolute, relative, resolve } from 'node:path';
+import { realpathSync } from 'node:fs';
 import type { ContextManifestItem, Provenance } from './runner-api.js';
 
 export function isPathContained(parent: string, candidate: string): boolean {
   try {
     if (!parent || !candidate) return false;
-    const rel = relative(resolve(parent), resolve(candidate));
+    let canonicalParent: string;
+    try {
+      canonicalParent = realpathSync(parent);
+    } catch {
+      canonicalParent = resolve(parent);
+    }
+
+    let canonicalCandidate: string;
+    try {
+      canonicalCandidate = realpathSync(candidate);
+    } catch {
+      canonicalCandidate = resolve(candidate);
+    }
+
+    const rel = relative(canonicalParent, canonicalCandidate);
     return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
   } catch {
     return false;

--- a/packages/contracts/src/context-provenance.ts
+++ b/packages/contracts/src/context-provenance.ts
@@ -1,0 +1,91 @@
+import { isAbsolute, relative, resolve } from 'node:path';
+import type { ContextManifestItem, Provenance } from './runner-api.js';
+
+export function isPathContained(parent: string, candidate: string): boolean {
+  try {
+    if (!parent || !candidate) return false;
+    const rel = relative(resolve(parent), resolve(candidate));
+    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+  } catch {
+    return false;
+  }
+}
+
+export type ScanPartitionSource = 'built-in' | 'owner' | 'workspace' | 'repository';
+
+export interface ScanPartitionContext {
+  /**
+   * Trusted partition source assigned by the Runner control plane.
+   * Items from repository scan partitions can NEVER be promoted to built-in or owner,
+   * regardless of the path strings or metadata they contain.
+   */
+  partitionSource?: ScanPartitionSource;
+  builtinSkillsRoot?: string;
+  ownerSkillsRoot?: string;
+  workspaceSkillsRoot?: string;
+  trustedRoot?: string;
+  repositoryRoot?: string;
+}
+
+export function sanitizeAndAttributeProvenance(
+  rawItem: Record<string, unknown>,
+  context: ScanPartitionContext = {}
+): ContextManifestItem {
+  const builtinRoot = context.builtinSkillsRoot || context.trustedRoot || process.env.CH_BUILTIN_SKILLS_ROOT || '/opt/cloud-harness/skills';
+  const ownerRoot = context.ownerSkillsRoot || context.trustedRoot || process.env.CH_OWNER_SKILLS_ROOT || '/opt/cloud-harness/owner-skills';
+  const workspaceSkillsRoot = context.workspaceSkillsRoot || process.env.CH_WORKSPACE_SKILLS_ROOT;
+
+  const pathStr = typeof rawItem.path === 'string' ? rawItem.path : undefined;
+  const kindStr = (typeof rawItem.kind === 'string' && ['instruction', 'language-manifest', 'test-command', 'skill-summary'].includes(rawItem.kind))
+    ? (rawItem.kind as ContextManifestItem['kind'])
+    : 'instruction';
+
+  const hashStr = typeof rawItem.contentSha256 === 'string' && /^[0-9a-f]{64}$/i.test(rawItem.contentSha256)
+    ? rawItem.contentSha256.toLowerCase()
+    : '0'.repeat(64);
+
+  let source: Provenance['source'] = 'repository';
+  let trust: Provenance['trust'] = 'untrusted-executor';
+  let mutableBy: Provenance['mutableBy'] = 'repository-commit';
+
+  // Trust partition source ONLY from runner context, NEVER from untrusted rawItem
+  const partitionSource = context.partitionSource || 'repository';
+
+  if (kindStr === 'skill-summary' && pathStr) {
+    if (partitionSource === 'built-in' && isPathContained(builtinRoot, pathStr)) {
+      source = 'built-in';
+      trust = 'trusted-control-plane';
+      mutableBy = 'release';
+    } else if (partitionSource === 'owner' && isPathContained(ownerRoot, pathStr)) {
+      source = 'owner';
+      trust = 'owner-controlled';
+      mutableBy = 'owner';
+    } else if (partitionSource === 'workspace' && workspaceSkillsRoot && isPathContained(workspaceSkillsRoot, pathStr)) {
+      source = 'workspace';
+      trust = 'untrusted-executor';
+      mutableBy = 'workspace-process';
+    }
+  }
+
+  return {
+    id: typeof rawItem.id === 'string' ? rawItem.id : `ctx_${hashStr.slice(0, 12)}`,
+    kind: kindStr,
+    format: typeof rawItem.format === 'string' ? rawItem.format : 'plain',
+    clients: Array.isArray(rawItem.clients) ? (rawItem.clients as any) : ['all'],
+    path: pathStr,
+    appliesTo: typeof rawItem.appliesTo === 'string' ? rawItem.appliesTo : undefined,
+    activeForClient: Boolean(rawItem.activeForClient ?? true),
+    contentSha256: hashStr,
+    byteCount: typeof rawItem.byteCount === 'number' ? rawItem.byteCount : 0,
+    excerpt: typeof rawItem.excerpt === 'string' ? rawItem.excerpt.slice(0, 8192) : undefined,
+    references: Array.isArray(rawItem.references) ? (rawItem.references as string[]) : undefined,
+    provenance: {
+      source,
+      trust,
+      mutableBy,
+      path: pathStr,
+      contentSha256: hashStr,
+      discoveredAt: new Date().toISOString()
+    }
+  };
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -6,3 +6,4 @@ export * from './mcp-results.js';
 export * from './runner-api.js';
 export * from './tool-schemas.js';
 export * from './secret-policy.js';
+export * from './context-provenance.js';

--- a/worker/harness-worker.mjs
+++ b/worker/harness-worker.mjs
@@ -623,6 +623,7 @@ async function scanWorkspaceContext(input = {}) {
           id: `ctx_skill_${s.name}`,
           kind: 'skill-summary',
           format: 'skill-md',
+          partition: s.source,
           clients: ['all'],
           path: relPath,
           activeForClient: true,


### PR DESCRIPTION
Follow-up hardening for Issue #15:

## Key Changes
- **Trusted Scan Partitions:** Enforced that only items originating from verified Runner-initiated scan partitions can receive `built-in` or `owner` provenance, eliminating worker-asserted source promotion.
- **Strict Path Containment:** Added `isPathContained` to eliminate sibling prefix path bypasses (e.g. `/opt/cloud-harness/owner-skills-evil`).
- **Clean Separation:** Repository scan partitions always use `partitionSource: 'repository'`, preventing repository text from forging elevated provenance.