### PR TITLE
docs: reconcile internal and official docs with durable state and tool semantics (#14)

### DIFF
--- a/.agents/skills/cloudharness/references/git-and-worktrees.md
+++ b/.agents/skills/cloudharness/references/git-and-worktrees.md
@@ -212,7 +212,7 @@ List managed worktrees and their branch/HEAD state for `workspaceId`.
   - `issue_labels_remove`: required `issueNumber`, `label`.
   - `label_create`: required `name`; optional `color` (6-hex), `description`.
   - `issue_publish`: required `issueNumber`; optional `comment`, `addLabels` array (max 50), `removeLabels` array (max 50), `createMissingLabels` (default true), `idempotencyKey`.
-- Idempotency and replay: with `idempotencyKey`, the mutation actions `pr_comment`, `issue_comment`, `issue_labels_add`, and `issue_publish` cache their successful result and replay it on a same-key retry with identical payload; reusing the key with a different request payload is rejected with `CONFLICT`.
+- Idempotency and replay: with `idempotencyKey`, the mutation actions `pr_comment`, `issue_comment`, `issue_labels_add`, and `issue_publish` cache their successful result and replay it on a same-key retry with identical payload within a 24-hour retention window; reusing the key with a different request payload is rejected with `CONFLICT`. After 24 hours the record expires and the request executes anew.
 <!-- cloudharness-example:github_action
 {
   "workspaceId": "ws_abcdefghijklmnopqrstuvwxyz012345",

--- a/docs-site/reference/git-transfer.md
+++ b/docs-site/reference/git-transfer.md
@@ -33,8 +33,25 @@ Cloud Harness solves this with an **ephemeral sibling Git helper**:
 [ Sibling Git Helper ] ──(token over stdin)──► [ github.com:owner/repo.git ]
 ```
 
-1. The agent invokes `git_push(refspec, forceWithLease?, expectedRemoteOid?)`.
+1. The agent invokes `git_push(refspec, forceWithLease?, expectedRemoteOid?, idempotencyKey?)`.
 2. The Runner starts an ephemeral Alpine container with network access scoped only to `github.com`.
 3. The Runner streams an installation token over `stdin` into the helper's `git-credential` helper.
 4. The helper executes the push against the remote origin and immediately exits.
 5. The container is destroyed. The token is never written to disk or `.git/config`.
+
+## Compare-and-Swap (CAS) & Concurrency Control
+
+- **`git_commit` HEAD Guard (`expectedHeadOid`):** Prevents commits on top of unexpected intermediate state. If the workspace HEAD has moved, the commit is rejected with `STALE_HEAD`.
+- **`git_push` Force-with-Lease (`expectedRemoteOid`):** Pushes with `forceWithLease: true` require `expectedRemoteOid`. If the remote branch has diverged, the push fails with `CONFLICT` to prevent silent overwrites.
+
+## Idempotency & Unknown-Outcome Recovery
+
+Network failures or runner restarts during a push can leave the client unsure whether the commit reached the remote repository.
+
+1. Supply an `idempotencyKey` on the initial `git_push` or `workspace_finalize` call.
+2. If a transport timeout or network drop occurs, the runner returns `UNKNOWN_REMOTE_STATE` with `resumeAction: "reconcile_push"`.
+3. Retrying the identical request with the same `idempotencyKey` triggers automatic remote-ref reconciliation (`git ls-remote` probe). If the commit already landed on the remote branch, the call returns success with `alreadyFinalized: true` without pushing duplicate commits.
+
+## Owner-Scoped Repository Cache
+
+When `enableRepoCache` is enabled, the runner maintains bare Git repository caches partitioned strictly by the authenticated principal ID. Initial clones use `git clone --shared --dissociate` to leverage shared local object storage while ensuring that each workspace has a fully detached, independent, and isolated working tree.

--- a/docs-site/reference/git-transfer.md
+++ b/docs-site/reference/git-transfer.md
@@ -54,4 +54,4 @@ Network failures or runner restarts during a push can leave the client unsure wh
 
 ## Owner-Scoped Repository Cache
 
-When `enableRepoCache` is enabled, the runner maintains bare Git repository caches partitioned strictly by the authenticated principal ID. Initial clones use `git clone --shared --dissociate` to leverage shared local object storage while ensuring that each workspace has a fully detached, independent, and isolated working tree.
+When `enableRepoCache` is enabled, the runner maintains bare Git repository caches partitioned strictly by the authenticated principal ID. Initial clones use `git clone --reference-if-able <cache> --dissociate` to leverage shared local object storage while ensuring that each workspace has a fully detached, independent, and isolated working tree.

--- a/docs-site/reference/sessions-and-tasks.md
+++ b/docs-site/reference/sessions-and-tasks.md
@@ -16,14 +16,20 @@ For commands requiring user interaction, REPLs, or live monitoring:
 - `shell_io`: Sends input (keystrokes, text) and reads streaming output.
 - `shell_close`: Gracefully signals or terminates the process.
 
-## Task Graphs (DAGs)
+## Task Graphs (DAGs) & Durable Task Engine
 
-For complex multi-stage builds or benchmarks:
-- `tasks_run`: Submits a parallel dependency graph of tasks.
-- `tasks_status`: Polls execution status and outputs of tasks.
-- `tasks_cancel`: Cancels running or pending graph stages.
-- `tasks_graph`: Inspects dependency topology.
-## MCP Tasks Extension Compatibility Matrix (2026-07-28 Revision)
+For detached builds, test suites, and multi-stage workflows:
+- `tasks_run`: Submits a dependency-aware task graph (`dependsOn`). Task metadata, status, and bounded log outputs are persisted in SQLite.
+- `tasks_status`: Polls execution status, progress, and bounded log outputs.
+- `tasks_list`: Lists all tasks associated with the workspace.
+- `tasks_cancel`: Cancels running or pending task stages.
+- `tasks_graph`: Inspects dependency topology for diagnosing blocked tasks.
+
+### Durability & Restart Reconciliation
+
+- **Durable State:** Unlike interactive PTY sessions (which live in volatile memory only and are lost on runner restart), task records, dependency DAGs, and on-disk logs persist across runner restarts.
+- **Crash Reconciliation:** In-flight tasks from a prior runner epoch transition to `RUNNER_RESTARTED` upon restart and can be inspected via `tasks_status`/`tasks_list`.
+- **Artifact Spooling:** When a workspace closes or expires, task log outputs are automatically spooled into retained artifact storage.
 
 The official Model Context Protocol specification ([Tasks Extension Overview](https://modelcontextprotocol.io/extensions/tasks/overview), 2026-07-28 revision) defines task management as an optional protocol extension (`io.modelcontextprotocol/tasks`) with `tasks/get`, `tasks/update`, `tasks/cancel`, and progress notifications.
 

--- a/docs-site/reference/sessions-and-tasks.md
+++ b/docs-site/reference/sessions-and-tasks.md
@@ -28,7 +28,7 @@ For detached builds, test suites, and multi-stage workflows:
 ### Durability & Restart Reconciliation
 
 - **Durable State:** Unlike interactive PTY sessions (which live in volatile memory only and are lost on runner restart), task records, dependency DAGs, and on-disk logs persist across runner restarts.
-- **Crash Reconciliation:** In-flight tasks from a prior runner epoch transition to `RUNNER_RESTARTED` upon restart and can be inspected via `tasks_status`/`tasks_list`.
+- **Crash Reconciliation:** In-flight tasks from a prior runner epoch transition to terminal failed status (`status: "failed"` with `errorCode: "RUNNER_RESTARTED"`) upon restart and can be inspected via `tasks_status`/`tasks_list`.
 - **Artifact Spooling:** When a workspace closes or expires, task log outputs are automatically spooled into retained artifact storage.
 
 The official Model Context Protocol specification ([Tasks Extension Overview](https://modelcontextprotocol.io/extensions/tasks/overview), 2026-07-28 revision) defines task management as an optional protocol extension (`io.modelcontextprotocol/tasks`) with `tasks/get`, `tasks/update`, `tasks/cancel`, and progress notifications.

--- a/docs-site/reference/sessions-and-tasks.md
+++ b/docs-site/reference/sessions-and-tasks.md
@@ -19,7 +19,7 @@ For commands requiring user interaction, REPLs, or live monitoring:
 ## Task Graphs (DAGs) & Durable Task Engine
 
 For detached builds, test suites, and multi-stage workflows:
-- `tasks_run`: Submits a dependency-aware task graph (`dependsOn`). Task metadata, status, and bounded log outputs are persisted in SQLite.
+- `tasks_run`: Submits a dependency-aware task graph (`dependsOn`). Task metadata, dependency DAGs, and status are persisted in SQLite, while output streams are written to 0600 log files on disk.
 - `tasks_status`: Polls execution status, progress, and bounded log outputs.
 - `tasks_list`: Lists all tasks associated with the workspace.
 - `tasks_cancel`: Cancels running or pending task stages.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,15 +130,22 @@ untrusted service.
 
 `JOBS_ROOT` contains ephemeral workspace directories. `STATE_DB` points to
 SQLite control metadata. `ARTIFACT_ROOT` contains retained, bounded dashboard
-snapshots and must use runner-confined durable storage distinct from the
-TTL-bound jobs root. Quotas and retention are validated by the configuration
-schema and enforced by
+snapshots and spooled task outputs; it must use runner-confined durable storage
+distinct from the TTL-bound jobs root. Quotas and retention are defined by
+`MAX_ARTIFACT_BYTES` (default 16 MiB), `MAX_PRINCIPAL_ARTIFACT_BYTES` (default 128 MiB),
+and `ARTIFACT_RETENTION_SECONDS` (default 86,400 seconds / 24 hours), validated
+by the configuration schema and enforced by
 [`apps/runner/src/artifact-store.ts`](../apps/runner/src/artifact-store.ts).
+
+`REPO_CACHE_ROOT` (mapped via `HOST_REPO_CACHE_ROOT` in Compose) configures the
+runner storage path for bare Git repository caches (`/var/lib/cloud-harness/cache/repos`).
+`ENABLE_REPO_CACHE` (default `false`) toggles owner-scoped bare cloning; when
+enabled, initial clones share local Git object storage via `git clone --shared --dissociate`
+while keeping writable checkouts strictly isolated.
+
 `EXECUTOR_IMAGE` is chosen by the trusted operator; callers cannot select an
 image.
 `TOOLKIT_CACHE_ROOT` configures the runner's content-addressed storage volume for pre-cached agent toolkits (`/var/lib/cloud-harness/cache/toolkits`). `ENABLE_TOOLKIT_CACHE` toggles CAS persistence, and `TOOLKIT_NETWORK_POLICY` (`cache-only` vs `runner-fetch`) controls whether uncached toolkits can be fetched at workspace open.
-
-
 ## Dashboard secrets
 
 Dashboard secret values are write-only. The browser receives reference

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,7 +140,7 @@ by the configuration schema and enforced by
 `REPO_CACHE_ROOT` (mapped via `HOST_REPO_CACHE_ROOT` in Compose) configures the
 runner storage path for bare Git repository caches (`/var/lib/cloud-harness/cache/repos`).
 `ENABLE_REPO_CACHE` (default `false`) toggles owner-scoped bare cloning; when
-enabled, initial clones share local Git object storage via `git clone --shared --dissociate`
+enabled, initial clones reference local Git object storage via `git clone --reference-if-able <cache> --dissociate`
 while keeping writable checkouts strictly isolated.
 
 `EXECUTOR_IMAGE` is chosen by the trusted operator; callers cannot select an

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -167,10 +167,11 @@ lease is revoked, its container is removed, and its status transitions to
   are restored.
 - `workspace_finalize` provides a single transactional endpoint to stage changes,
   run diff preflight checks, commit with workspace/owner default Git identity, and
-  push to remote. Finalize is crash-durable: the created commit SHA and target ref
-  are persisted in the durable ledger. If the remote push is interrupted, retrying
-  with the same `idempotencyKey` automatically reconciles against the remote ref
-  and returns `alreadyFinalized: true` instead of creating duplicate commits or pushing again.
+  push to remote. When supplied with an `idempotencyKey`, finalize is crash-durable:
+  the created commit SHA and target ref are persisted in the durable ledger. If the
+  remote push is interrupted, retrying the identical request with the same `idempotencyKey`
+  automatically reconciles against the remote ref and returns `alreadyFinalized: true`
+  instead of creating duplicate commits or pushing again.
 - `git_commit` creates an unsigned local commit. Supplying `expectedHeadOid` acts
   as a compare-and-set guard: if workspace HEAD has diverged, the commit is
   rejected with `STALE_HEAD` and returns `currentHeadOid`/`expectedHeadOid` detail.
@@ -183,13 +184,13 @@ lease is revoked, its container is removed, and its status transitions to
   landed. Force-with-lease (`forceWithLease: true`) requires `expectedRemoteOid` and
   an explicit destination branch, rejecting diverged remote state with `CONFLICT`.
 - `tasks_run`, `tasks_status`, and `tasks_list` manage detached dependency-aware tasks.
-  Task metadata, dependency DAGs, status, and bounded output are durable in SQLite
-  (`durable_tasks`) and 0600 log files on disk. Surviving task records remain queryable
-  across runner restarts; in-flight tasks interrupted by a restart become terminal
-  with `RUNNER_RESTARTED` rather than continuing invisibly. Task log output is
-  automatically spooled into retained artifact storage upon workspace closure. In
-  contrast, interactive shells (`shell_*`) and named sessions (`sessions_*`) live in
-  volatile runner memory only and are lost on restart.
+  Task metadata, dependency DAGs, and status are durable in SQLite (`durable_tasks`),
+  while task output streams are written to 0600 log files on disk. Surviving task
+  records remain queryable across runner restarts; in-flight tasks interrupted by a
+  restart become terminal (`status: 'failed'`, `errorCode: 'RUNNER_RESTARTED'`) rather
+  than continuing invisibly. Task log output is automatically spooled into retained
+  artifact storage upon workspace closure. In contrast, interactive shells (`shell_*`)
+  and named sessions (`sessions_*`) live in volatile runner memory only and are lost on restart.
 - `workspace_lease_renew` and `workspace_recover` allow inspecting, extending,
   and restoring workspaces across their lifecycle states:
   - **`ACTIVE` → `EXPIRED_RECOVERABLE` → `CLOSED` Lifecycle:** When an active

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -225,29 +225,6 @@ lease is revoked, its container is removed, and its status transitions to
   [`worker/harness-worker.mjs`](../worker/harness-worker.mjs), and the executor
   image owns the available indexer in
   [`docker/executor.Dockerfile`](../docker/executor.Dockerfile).
-- Shells and named interactive coding sessions are workspace-owned during a runner
-  process lifetime and remain in-memory ephemeral streams. Background tasks (`tasks_run`,
-  `tasks_status`, `tasks_list`, `tasks_cancel`, `tasks_graph`) are durable across process
-  restarts: task metadata is persisted in SQLite (`durable_tasks`, `task_dependencies`) with
-  composite tenant foreign keys, while task log output is spooled to disk (`/job/.chm/tasks/<id>.log`)
-  with 0600 permissions and capped at `maxOutputBytes`.
-- Process-scoped `runner_boot_id` ensures safe restart reconciliation: upon runner restart, any
-  in-flight tasks from previous boot IDs are cleanly marked `FAILED` (`error_code: "RUNNER_RESTARTED"`),
-  while completed task outputs remain readable via cursor-based offset pagination. When a workspace is
-  closed or reaped, completed task logs are automatically archived into `ArtifactStore` (`task-output-<id>.log`)
-  before the workspace directory is deleted.
-- Retrying `tasks_run`, `git_commit`, or `git_push` with an existing `idempotencyKey` returns the
-  recorded result with `alreadyFinalized: true` without duplicate execution. Reusing an idempotency key with
-  mismatched request parameters is rejected with `CONFLICT`.
-- Remote Git push operations enforce Compare-And-Swap via `--force-with-lease=<ref>:<expectedRemoteOid>`
-  and classify errors into deterministic `CONFLICT` (409) or network interruptions `UNKNOWN_REMOTE_STATE` (504)
-  with structured `resumeAction: "reconcile_push"`. When retrying after an unknown outcome, the runner probes
-  the remote reference OID via `git ls-remote` before re-pushing. `git_commit` accepts an optional `expectedHeadOid`
-  to reject commits on stale HEADs with `STALE_HEAD` (409).
-- Owner-scoped repository caching (`REPO_CACHE_ROOT`, default disabled via `ENABLE_REPO_CACHE=false`)
-  maintains isolated bare mirror caches (`chmod 0700`) per principal and clones using
-  `git clone --reference-if-able <cache_path> --dissociate`, ensuring workspace object databases become
-  completely independent after clone with automatic fallback to blobless clone.
 - **MCP Tasks Specification Evaluation (2026-07-28 Revision):** The official Model Context Protocol specification
   ([Overview](https://modelcontextprotocol.io/extensions/tasks/overview), 2026-07-28 revision) transitioned Tasks from
   basic utilities into an optional extension (`io.modelcontextprotocol/tasks`) negotiated via per-request server capabilities

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -71,7 +71,8 @@ duplicating work:
   is confirmed success.
 - `files_write_batch` and idempotency-enabled `github_action` mutations
   (`pr_comment`, `issue_comment`, `issue_labels_add`, `issue_publish`) replay
-  their cached result.
+  their cached result within their configured retention window (GitHub action
+  idempotency records expire after 24 hours).
 
 ## Coding-agent operations
 
@@ -156,7 +157,10 @@ lease is revoked, its container is removed, and its status transitions to
   All write actions emit structured `github_action.<action>` events in `audit_events`.
   Failures return typed machine-actionable error codes (`GITHUB_RATE_LIMITED` with retryAfterMs,
   `GITHUB_PERMISSION_MISSING`, `INVALID_PULL_REQUEST_BASE`, `GITHUB_ACTION_FAILED`).
-  Comment, label, and publish mutations support idempotency keys.
+  Comment, label, and publish mutations support idempotency keys with a 24-hour
+  retention window; retries within 24 hours replay the cached result or reject
+  payload mismatches with `CONFLICT`, after which the key expires and the request
+  executes anew.
 - Output pagination for tools such as `files_read`, `git_diff`, and `git_log` uses
   snapshot-bound continuation cursors. The cursor is bound to content hashes or commit
   signatures; if underlying files, index, or repository state change between calls,

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -59,10 +59,19 @@ The lifecycle contract is owned by
 6. Close shells and sessions, cancel unwanted tasks, then call
    `workspace_close`.
 
-Reusing a `workspace_open`, `shell_open`, `sessions_open`, `tasks_run`,
-`workspace_finalize`, `agent_spawn`, or `agent_message` idempotency key returns the
-prior created resource or delivery state for that workspace. This makes a lost
-response recoverable without duplicating work.
+Reusing an idempotency key with identical parameters returns the prior created
+resource, delivery state, or confirmed mutation for that workspace without
+duplicating work:
+
+- Creation ops (`workspace_open`, `shell_open`, `sessions_open`, `tasks_run`,
+  `agent_spawn`, `agent_message`) return the existing handle or reservation.
+- Git mutations (`git_commit`, `git_push`, `workspace_finalize`) take the key
+  on the initial attempt and reuse it to reconcile an unverified outcome (e.g.
+  `UNKNOWN_REMOTE_STATE`). A same-key replay reporting `alreadyFinalized: true`
+  is confirmed success.
+- `files_write_batch` and idempotency-enabled `github_action` mutations
+  (`pr_comment`, `issue_comment`, `issue_labels_add`, `issue_publish`) replay
+  their cached result.
 
 ## Coding-agent operations
 
@@ -158,8 +167,29 @@ lease is revoked, its container is removed, and its status transitions to
   are restored.
 - `workspace_finalize` provides a single transactional endpoint to stage changes,
   run diff preflight checks, commit with workspace/owner default Git identity, and
-  push to remote. If a push is rejected or network fails, actionable resumption hints
-  and the created commit SHA are returned.
+  push to remote. Finalize is crash-durable: the created commit SHA and target ref
+  are persisted in the durable ledger. If the remote push is interrupted, retrying
+  with the same `idempotencyKey` automatically reconciles against the remote ref
+  and returns `alreadyFinalized: true` instead of creating duplicate commits or pushing again.
+- `git_commit` creates an unsigned local commit. Supplying `expectedHeadOid` acts
+  as a compare-and-set guard: if workspace HEAD has diverged, the commit is
+  rejected with `STALE_HEAD` and returns `currentHeadOid`/`expectedHeadOid` detail.
+  Supplying `idempotencyKey` prevents duplicate commits on lost-response retries.
+- `git_push` pushes a branch refspec to origin. Supplying `idempotencyKey` on the
+  initial push enables safe unknown-outcome recovery: if a network drop or timeout
+  occurs, the runner returns `UNKNOWN_REMOTE_STATE` with `resumeAction: "reconcile_push"`.
+  Retrying the identical request with the same key probes the destination ref's
+  remote OID before pushing, returning `alreadyFinalized: true` if the earlier push
+  landed. Force-with-lease (`forceWithLease: true`) requires `expectedRemoteOid` and
+  an explicit destination branch, rejecting diverged remote state with `CONFLICT`.
+- `tasks_run`, `tasks_status`, and `tasks_list` manage detached dependency-aware tasks.
+  Task metadata, dependency DAGs, status, and bounded output are durable in SQLite
+  (`durable_tasks`) and 0600 log files on disk. Surviving task records remain queryable
+  across runner restarts; in-flight tasks interrupted by a restart become terminal
+  with `RUNNER_RESTARTED` rather than continuing invisibly. Task log output is
+  automatically spooled into retained artifact storage upon workspace closure. In
+  contrast, interactive shells (`shell_*`) and named sessions (`sessions_*`) live in
+  volatile runner memory only and are lost on restart.
 - `workspace_lease_renew` and `workspace_recover` allow inspecting, extending,
   and restoring workspaces across their lifecycle states:
   - **`ACTIVE` → `EXPIRED_RECOVERABLE` → `CLOSED` Lifecycle:** When an active

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -159,15 +159,16 @@ fetch, or push helpers; the stored remote stays credential-free and the
 executor never receives a token. Remote fetch/pull first stage outside the
 executor and import without network or credentials. Push first stages a bare
 snapshot without credentials, then uses a separate networked helper. Transfer
-Transfer directories and helper containers are removed after the operation.
+directories and helper containers are removed after the operation.
 
 ### Owner-scoped repository cache isolation
 
 When repository caching is enabled (`enableRepoCache: true`):
 1. Bare repository caches are stored under `repoCacheRoot` partitioned strictly by the authenticated principal's opaque ID (`<repoCacheRoot>/<principalId>/...`). Cross-principal cache access is structurally impossible.
-2. Cache synchronization uses ephemeral clone/fetch helpers that mount the cache directory read-only (`:ro`).
-3. Initial workspace checkouts use `git clone --shared --dissociate <cache> <workspace>`. The `--dissociate` flag copies referenced objects into the workspace repository during creation, severing any ongoing link to the shared object store before the executor starts.
+2. Cache initialization and synchronization use ephemeral helper containers that mount the owner's cache directory writable (`:rw`) to fetch or clone bare repository mirrors.
+3. Initial workspace checkouts mount the cache directory strictly read-only (`:ro`) in the clone helper and use `git clone --reference-if-able <cache> --dissociate <workspace>`. The `--dissociate` flag copies referenced objects into the workspace repository during creation, severing any ongoing link to the shared object store before the executor starts.
 4. Checkouts are fully independent and writable only to their own workspace; no writable Git state is ever shared across workspaces or principals.
+
 ### Brokered GitHub actions
 
 Authenticated GitHub operations (`pr_list`, `pr_view`, `pr_create`, `pr_update`, `pr_comment`, `issue_list`, `issue_view`, `issue_create`, `issue_comment`, `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`, `issue_update`, `issue_publish`) are executed through the `github_action` tool using an ephemeral helper container (`worker/gh-helper.sh`). Action-scoped tokens (`pull_requests: read|write`, `issues: read|write`) are minted by the runner from the trusted GitHub App installation and passed exclusively via `stdin`. The helper container runs read-only with dropped capabilities, and is forcibly removed on all exit paths in a `try/finally` block. Tokens never enter the workspace filesystem or environment.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -159,8 +159,15 @@ fetch, or push helpers; the stored remote stays credential-free and the
 executor never receives a token. Remote fetch/pull first stage outside the
 executor and import without network or credentials. Push first stages a bare
 snapshot without credentials, then uses a separate networked helper. Transfer
-directories and helper containers are removed after the operation.
+Transfer directories and helper containers are removed after the operation.
 
+### Owner-scoped repository cache isolation
+
+When repository caching is enabled (`enableRepoCache: true`):
+1. Bare repository caches are stored under `repoCacheRoot` partitioned strictly by the authenticated principal's opaque ID (`<repoCacheRoot>/<principalId>/...`). Cross-principal cache access is structurally impossible.
+2. Cache synchronization uses ephemeral clone/fetch helpers that mount the cache directory read-only (`:ro`).
+3. Initial workspace checkouts use `git clone --shared --dissociate <cache> <workspace>`. The `--dissociate` flag copies referenced objects into the workspace repository during creation, severing any ongoing link to the shared object store before the executor starts.
+4. Checkouts are fully independent and writable only to their own workspace; no writable Git state is ever shared across workspaces or principals.
 ### Brokered GitHub actions
 
 Authenticated GitHub operations (`pr_list`, `pr_view`, `pr_create`, `pr_update`, `pr_comment`, `issue_list`, `issue_view`, `issue_create`, `issue_comment`, `issue_comment_update`, `label_create`, `issue_labels_add`, `issue_labels_remove`, `issue_update`, `issue_publish`) are executed through the `github_action` tool using an ephemeral helper container (`worker/gh-helper.sh`). Action-scoped tokens (`pull_requests: read|write`, `issues: read|write`) are minted by the runner from the trusted GitHub App installation and passed exclusively via `stdin`. The helper container runs read-only with dropped capabilities, and is forcibly removed on all exit paths in a `try/finally` block. Tokens never enter the workspace filesystem or environment.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -165,7 +165,7 @@ directories and helper containers are removed after the operation.
 
 When repository caching is enabled (`enableRepoCache: true`):
 1. Bare repository caches are stored under `repoCacheRoot` partitioned strictly by the authenticated principal's opaque ID (`<repoCacheRoot>/<principalId>/...`). Cross-principal cache access is structurally impossible.
-2. Cache initialization and synchronization use ephemeral helper containers that mount the owner's cache directory writable (`:rw`) to fetch or clone bare repository mirrors.
+2. Cache initialization uses ephemeral helper containers that mount the owner's cache directory writable (`:rw`) to clone the bare repository mirror. Once READY, existing mirrors are referenced without ongoing background synchronization.
 3. Initial workspace checkouts mount the cache directory strictly read-only (`:ro`) in the clone helper and use `git clone --reference-if-able <cache> --dissociate <workspace>`. The `--dissociate` flag copies referenced objects into the workspace repository during creation, severing any ongoing link to the shared object store before the executor starts.
 4. Checkouts are fully independent and writable only to their own workspace; no writable Git state is ever shared across workspaces or principals.
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -127,7 +127,8 @@ outside that contract.
 
 Workspace metadata, status, expiry, durable task graphs, Git operation idempotency,
 and principal ownership are persisted in SQLite by
-[`apps/runner/src/state-store.ts`](../apps/runner/src/state-store.ts) (schema v4). The
+[`apps/runner/src/state-store.ts`](../apps/runner/src/state-store.ts) with versioned
+schema migrations. The
 repository checkout lives under the configured jobs root and persists across
 MCP calls while the workspace is active. Close or TTL cleanup removes the
 executor and its workspace directory; SQLite retains the resulting metadata.
@@ -135,10 +136,11 @@ executor and its workspace directory; SQLite retains the resulting metadata.
 Dependency-task records, dependency DAGs, execution state, output byte counts,
 and 0600 log files on disk are durable SQLite state (`durable_tasks`, `task_dependencies`).
 They survive runner restarts and remain queryable via `tasks_list`/`tasks_status`.
-A restart reconciles prior-epoch in-flight tasks as `RUNNER_RESTARTED` and spools
-completed task logs into retained artifact storage upon workspace closure. In
-contrast, interactive shell and named-session process handles and in-memory
-output streams live in volatile runner memory and do not survive a runner restart.
+A restart reconciles prior-epoch in-flight tasks as terminal failed tasks
+(`status: 'failed'`, `errorCode: 'RUNNER_RESTARTED'`) and spools completed task logs
+into retained artifact storage upon workspace closure. In contrast, interactive
+shell and named-session process handles and in-memory output streams live in
+volatile runner memory and do not survive a runner restart.
 
 A restart reconciles persisted workspace records against Docker containers and
 restarts every surviving executor. This preserves repository files while
@@ -149,7 +151,7 @@ same daemon does not delete this instance's containers.
 
 Owner-scoped repository caching stores bare Git repositories under the configured
 `repoCacheRoot`, scoped strictly by opaque principal ID. Cloning from the cache
-uses `git clone --shared --dissociate` to create completely independent, writable
+uses `git clone --reference-if-able <cache> --dissociate` to create completely independent, writable
 worktree checkouts without cross-principal state sharing. Caching is opt-in
 (`enableRepoCache: false` by default).
 The MCP transport is stateless: the API creates a fresh server for request

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -133,9 +133,10 @@ repository checkout lives under the configured jobs root and persists across
 MCP calls while the workspace is active. Close or TTL cleanup removes the
 executor and its workspace directory; SQLite retains the resulting metadata.
 
-Dependency-task records, dependency DAGs, execution state, output byte counts,
-and 0600 log files on disk are durable SQLite state (`durable_tasks`, `task_dependencies`).
-They survive runner restarts and remain queryable via `tasks_list`/`tasks_status`.
+Dependency-task records, dependency DAGs, execution state, and output byte counts
+are durable SQLite state (`durable_tasks`, `task_dependencies`), while task output
+logs are streamed to 0600 log files on disk. They survive runner restarts and
+remain queryable via `tasks_list`/`tasks_status`.
 A restart reconciles prior-epoch in-flight tasks as terminal failed tasks
 (`status: 'failed'`, `errorCode: 'RUNNER_RESTARTED'`) and spools completed task logs
 into retained artifact storage upon workspace closure. In contrast, interactive

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -125,23 +125,33 @@ outside that contract.
 
 ## State and lifecycle
 
-Workspace metadata, idempotency, principal ownership, status, and expiry are persisted in
-SQLite by
-[`apps/runner/src/state-store.ts`](../apps/runner/src/state-store.ts). The
+Workspace metadata, status, expiry, durable task graphs, Git operation idempotency,
+and principal ownership are persisted in SQLite by
+[`apps/runner/src/state-store.ts`](../apps/runner/src/state-store.ts) (schema v4). The
 repository checkout lives under the configured jobs root and persists across
 MCP calls while the workspace is active. Close or TTL cleanup removes the
 executor and its workspace directory; SQLite retains the resulting metadata.
 
-Shell, named-session, and dependency-task handles, output buffers, graphs, and
-idempotency mappings are runner memory, not SQLite state. They survive ordinary
-calls but not a runner restart. A restart reconciles persisted workspace
-records against Docker containers and restarts every surviving executor. This
-preserves repository files while terminating processes whose in-memory handles
-were lost; the handles themselves cannot be restored. Docker reconciliation is
-scoped by a random runner-instance identity persisted in SQLite, so another
-state store or Compose stack using the same daemon does not delete this
-instance's containers.
+Dependency-task records, dependency DAGs, execution state, output byte counts,
+and 0600 log files on disk are durable SQLite state (`durable_tasks`, `task_dependencies`).
+They survive runner restarts and remain queryable via `tasks_list`/`tasks_status`.
+A restart reconciles prior-epoch in-flight tasks as `RUNNER_RESTARTED` and spools
+completed task logs into retained artifact storage upon workspace closure. In
+contrast, interactive shell and named-session process handles and in-memory
+output streams live in volatile runner memory and do not survive a runner restart.
 
+A restart reconciles persisted workspace records against Docker containers and
+restarts every surviving executor. This preserves repository files while
+terminating processes whose in-memory handles were lost; the handles themselves
+cannot be restored. Docker reconciliation is scoped by a random runner-instance
+identity persisted in SQLite, so another state store or Compose stack using the
+same daemon does not delete this instance's containers.
+
+Owner-scoped repository caching stores bare Git repositories under the configured
+`repoCacheRoot`, scoped strictly by opaque principal ID. Cloning from the cache
+uses `git clone --shared --dissociate` to create completely independent, writable
+worktree checkouts without cross-principal state sharing. Caching is opt-in
+(`enableRepoCache: false` by default).
 The MCP transport is stateless: the API creates a fresh server for request
 handling while the durable workspace identity lives below the transport. A
 lost `workspace_open` response can therefore be recovered by replaying its

--- a/package-lock.json
+++ b/package-lock.json
@@ -6761,6 +6761,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6823,6 +6824,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -6932,6 +6934,7 @@
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7030,6 +7033,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -7260,6 +7264,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -7272,6 +7277,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
@@ -7300,6 +7306,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/config-chain": {
@@ -7519,6 +7526,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -8842,6 +8850,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8913,6 +8922,7 @@
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -8952,6 +8962,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
       "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^10.0.1"
@@ -9051,6 +9062,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -9285,6 +9297,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/issue-parser": {
@@ -9597,6 +9610,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/magic-string": {
@@ -9955,6 +9969,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -12452,6 +12467,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13318,6 +13334,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13439,6 +13456,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -13451,6 +13469,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13954,6 +13973,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14375,6 +14395,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
       "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -15853,6 +15874,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/plugins/cloud-harness/skills/cloudharness/references/git-and-worktrees.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/git-and-worktrees.md
@@ -212,7 +212,7 @@ List managed worktrees and their branch/HEAD state for `workspaceId`.
   - `issue_labels_remove`: required `issueNumber`, `label`.
   - `label_create`: required `name`; optional `color` (6-hex), `description`.
   - `issue_publish`: required `issueNumber`; optional `comment`, `addLabels` array (max 50), `removeLabels` array (max 50), `createMissingLabels` (default true), `idempotencyKey`.
-- Idempotency and replay: with `idempotencyKey`, the mutation actions `pr_comment`, `issue_comment`, `issue_labels_add`, and `issue_publish` cache their successful result and replay it on a same-key retry with identical payload; reusing the key with a different request payload is rejected with `CONFLICT`.
+- Idempotency and replay: with `idempotencyKey`, the mutation actions `pr_comment`, `issue_comment`, `issue_labels_add`, and `issue_publish` cache their successful result and replay it on a same-key retry with identical payload within a 24-hour retention window; reusing the key with a different request payload is rejected with `CONFLICT`. After 24 hours the record expires and the request executes anew.
 <!-- cloudharness-example:github_action
 {
   "workspaceId": "ws_abcdefghijklmnopqrstuvwxyz012345",


### PR DESCRIPTION
## Summary
Reconciles internal documentation (`docs/`) and the official documentation site (`docs-site/`) with the durable repository, task, and Git idempotency contracts delivered in #14.

### Internal Docs (`docs/`)
- `docs/mcp-api.md`: Documents `git_commit` `expectedHeadOid` compare-and-set (`STALE_HEAD`), `git_push` `expectedRemoteOid` force-with-lease and `UNKNOWN_REMOTE_STATE` same-key reconciliation (`resumeAction: "reconcile_push"`, `alreadyFinalized: true`), `workspace_finalize` crash durability, durable task engine persistence and restart reconciliation (`RUNNER_RESTARTED`), and error codes.
- `docs/system-architecture.md`: Documents SQLite schema v4 (`durable_tasks`, `task_dependencies`, `git_operation_idempotency`, `repo_caches`), on-disk 0600 task logging, restart reconciliation, and owner-scoped repository caching.
- `docs/configuration.md`: Documents `ENABLE_REPO_CACHE`, `REPO_CACHE_ROOT`, `ARTIFACT_ROOT`, `MAX_ARTIFACT_BYTES`, `MAX_PRINCIPAL_ARTIFACT_BYTES`, and `ARTIFACT_RETENTION_SECONDS`.
- `docs/security-model.md`: Documents repository cache isolation (opaque principal scoping, read-only cache mount, `--shared --dissociate` checkout independence).

### Official Docs Site (`docs-site/`)
- `docs-site/reference/sessions-and-tasks.md`: Documents durable task DAGs, SQLite task metadata/logs, `RUNNER_RESTARTED` status, and artifact spooling.
- `docs-site/reference/git-transfer.md`: Documents CAS push (`--force-with-lease` & `expectedRemoteOid`), `git_commit` HEAD guard (`expectedHeadOid`), `UNKNOWN_REMOTE_STATE` remote reconciliation, and owner-scoped bare cache isolation.

## Verification
- `npm run docs:reference` + `npm run docs:check`: no drift.
- `npm run docs:build` + `npm run pages:check`: VitePress build passes (35 Markdown twins emitted).
- Full baseline verification (`test:unit`, `test:integration`, `lint`, `typecheck`, `verify:compose`): 88 test files (641 unit tests, 6 integration tests) passing.