### PR TITLE
fix(deploy): install service-compose and reload systemd unit after checkout and rollback

### DIFF
--- a/deploy/scripts/deploy-release.sh
+++ b/deploy/scripts/deploy-release.sh
@@ -66,6 +66,16 @@ fi
 
 git checkout --detach --force "$release_sha"
 [[ -z $(git status --porcelain --untracked-files=all) ]] || { echo "deployment checkout is dirty" >&2; false; }
+if [[ -f deploy/scripts/service-compose.sh ]]; then
+  install -m 0755 deploy/scripts/service-compose.sh /usr/local/sbin/cloud-harness-service-compose
+fi
+if [[ -f deploy/systemd/cloud-harness-mcp.service ]]; then
+  install -m 0644 deploy/systemd/cloud-harness-mcp.service /etc/systemd/system/cloud-harness-mcp.service
+  systemctl daemon-reload
+fi
+if [[ -f deploy/scripts/release-runtime.sh ]]; then
+  source deploy/scripts/release-runtime.sh
+fi
 compose --profile images build executor-image agent-image network-guard-image api runner model-gateway
 systemctl enable --now cloud-harness-mcp.service
 wait_ready
@@ -115,9 +125,6 @@ fi
 install -m 0755 deploy/scripts/deploy-release.sh /usr/local/sbin/cloud-harness-deploy
 install -m 0755 deploy/scripts/rollback-release.sh /usr/local/sbin/cloud-harness-rollback
 install -m 0755 deploy/scripts/upgrade-nginx-dashboard.sh /usr/local/sbin/cloud-harness-upgrade-nginx
-if [[ -f deploy/scripts/service-compose.sh ]]; then
-  install -m 0755 deploy/scripts/service-compose.sh /usr/local/sbin/cloud-harness-service-compose
-fi
 printf '%s\n' "$release_sha" > "$state/release-current"
 trap - ERR
 echo "deployed $release_sha"

--- a/deploy/scripts/release-runtime.sh
+++ b/deploy/scripts/release-runtime.sh
@@ -54,6 +54,18 @@ stop_release() {
   return "$failed"
 }
 
+install_release_service_files() {
+  local failed=0
+  if [[ -f deploy/scripts/service-compose.sh ]]; then
+    install -m 0755 deploy/scripts/service-compose.sh /usr/local/sbin/cloud-harness-service-compose || failed=1
+  fi
+  if [[ -f deploy/systemd/cloud-harness-mcp.service ]]; then
+    install -m 0644 deploy/systemd/cloud-harness-mcp.service /etc/systemd/system/cloud-harness-mcp.service || failed=1
+    systemctl daemon-reload || failed=1
+  fi
+  return "$failed"
+}
+
 contain_failed_release() {
   local failed=0 status containers
   systemctl disable --now cloud-harness-mcp.service || failed=1
@@ -139,6 +151,7 @@ rollback() {
   stop_release || rollback_failed=1
   if [[ $rollback_failed -eq 0 && -n $previous_sha && $previous_sha =~ ^[0-9a-f]{40}$ ]]; then
     if ! git checkout --detach --force "$previous_sha"; then rollback_failed=1
+    elif ! install_release_service_files; then rollback_failed=1
     elif [[ -n $backup_dir ]] && ! restore_snapshot "$backup_dir"; then rollback_failed=1
     elif ! compose --profile images build executor-image agent-image network-guard-image api runner model-gateway; then rollback_failed=1
     elif ! systemctl enable --now cloud-harness-mcp.service; then rollback_failed=1

--- a/test/deploy-release-runtime.test.ts
+++ b/test/deploy-release-runtime.test.ts
@@ -24,6 +24,7 @@ fails() { [[ $failure_step == "$1" ]]; }
 stop_release() { echo stop >> "$trace_path"; ! fails stop; }
 contain_failed_release() { echo contain >> "$trace_path"; }
 git() { echo "git:$*" >> "$trace_path"; ! fails checkout; }
+install_release_service_files() { echo service-files >> "$trace_path"; ! fails service-files; }
 restore_snapshot() { echo "restore:$1" >> "$trace_path"; ! fails restore; }
 compose() { echo "compose:$*" >> "$trace_path"; ! fails build; }
 systemctl() { echo "systemctl:$*" >> "$trace_path"; ! fails start; }
@@ -106,6 +107,7 @@ describe.skipIf(process.platform === 'win32')('release rollback orchestration', 
     expect(result.trace).toEqual([
       'stop',
       `git:checkout --detach --force ${previousSha}`,
+      'service-files',
       'restore:/snapshot',
       'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway',
       'systemctl:enable --now cloud-harness-mcp.service',
@@ -142,13 +144,14 @@ describe.skipIf(process.platform === 'win32')('release rollback orchestration', 
 
   it.each([
     ['checkout', ['stop', `git:checkout --detach --force ${previousSha}`, 'contain']],
-    ['restore', ['stop', `git:checkout --detach --force ${previousSha}`, 'restore:/snapshot', 'contain']],
-    ['build', ['stop', `git:checkout --detach --force ${previousSha}`, 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'contain']],
-    ['start', ['stop', `git:checkout --detach --force ${previousSha}`, 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'systemctl:enable --now cloud-harness-mcp.service', 'contain']],
-    ['ready', ['stop', `git:checkout --detach --force ${previousSha}`, 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'systemctl:enable --now cloud-harness-mcp.service', 'ready', 'contain']],
-    ['verify', ['stop', `git:checkout --detach --force ${previousSha}`, 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'systemctl:enable --now cloud-harness-mcp.service', 'ready', 'verify', 'contain']],
-    ['config', ['stop', `git:checkout --detach --force ${previousSha}`, 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'systemctl:enable --now cloud-harness-mcp.service', 'ready', 'verify', 'config', 'contain']],
-    ['record', ['stop', `git:checkout --detach --force ${previousSha}`, 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'systemctl:enable --now cloud-harness-mcp.service', 'ready', 'verify', 'config', 'record:release', 'contain']]
+    ['service-files', ['stop', `git:checkout --detach --force ${previousSha}`, 'service-files', 'contain']],
+    ['restore', ['stop', `git:checkout --detach --force ${previousSha}`, 'service-files', 'restore:/snapshot', 'contain']],
+    ['build', ['stop', `git:checkout --detach --force ${previousSha}`, 'service-files', 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'contain']],
+    ['start', ['stop', `git:checkout --detach --force ${previousSha}`, 'service-files', 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'systemctl:enable --now cloud-harness-mcp.service', 'contain']],
+    ['ready', ['stop', `git:checkout --detach --force ${previousSha}`, 'service-files', 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'systemctl:enable --now cloud-harness-mcp.service', 'ready', 'contain']],
+    ['verify', ['stop', `git:checkout --detach --force ${previousSha}`, 'service-files', 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'systemctl:enable --now cloud-harness-mcp.service', 'ready', 'verify', 'contain']],
+    ['config', ['stop', `git:checkout --detach --force ${previousSha}`, 'service-files', 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'systemctl:enable --now cloud-harness-mcp.service', 'ready', 'verify', 'config', 'contain']],
+    ['record', ['stop', `git:checkout --detach --force ${previousSha}`, 'service-files', 'restore:/snapshot', 'compose:--profile images build executor-image agent-image network-guard-image api runner model-gateway', 'systemctl:enable --now cloud-harness-mcp.service', 'ready', 'verify', 'config', 'record:release', 'contain']]
   ])('does not advance after a failed %s transition', (step, expectedTrace) => {
     const result = runRollback(step);
     expect(result.status).toBe(70);

--- a/test/installer-and-caddy.test.ts
+++ b/test/installer-and-caddy.test.ts
@@ -59,8 +59,10 @@ describe('OSS 1-Click Installer & Ingress Templates', () => {
     expect(systemdService).toContain('/usr/local/sbin/cloud-harness-service-compose up --remove-orphans');
     expect(systemdService).toContain('/usr/local/sbin/cloud-harness-service-compose down');
     const deployRelease = readFileSync('deploy/scripts/deploy-release.sh', 'utf8');
-    expect(deployRelease).toContain('if [[ -f deploy/scripts/service-compose.sh ]]; then');
-    expect(deployRelease).toContain('install -m 0755 deploy/scripts/service-compose.sh /usr/local/sbin/cloud-harness-service-compose');
+    expect(deployRelease).toContain('/usr/local/sbin/cloud-harness-service-compose');
+    const releaseRuntime = readFileSync('deploy/scripts/release-runtime.sh', 'utf8');
+    expect(releaseRuntime).toContain('install_release_service_files() {');
+    expect(releaseRuntime).toContain('install_release_service_files');
   });
 
 


### PR DESCRIPTION
Fixes deploy-release.sh and release-runtime.sh to ensure /usr/local/sbin/cloud-harness-service-compose is installed and systemd is reloaded immediately after checkout and during rollback before service start.