### PR TITLE
docs: clarify ChatGPT Developer Mode lifecycle and resolve FORBIDDEN gating (#171)

### DIFF
--- a/.agents/skills/cloudharness/references/installation-and-security.md
+++ b/.agents/skills/cloudharness/references/installation-and-security.md
@@ -92,6 +92,14 @@ Inspect with `claude mcp get cloud-harness`, then confirm it in `/mcp`.
   authorization flow. The owner deployment at `https://harness.zuey.me/mcp`
   uses Cloudflare Access Managed OAuth with allowlisted mutually trusted
   operators; it is not a hostile multi-tenant service.
+- In ChatGPT, custom MCP connectors operate in **Developer Mode (Draft)** or
+  **Workspace Published (Custom Connector)** mode. Draft apps execute only in
+  standard 1-on-1 ChatGPT Web chats with Developer Mode enabled. Invocations
+  rejected with `FORBIDDEN: This conversation does not support developer MCPs`
+  indicate an unsupported conversation surface (e.g. Custom GPTs, Projects,
+  Canvas, Mobile apps, or disabled Developer Mode); see the
+  [ChatGPT Configuration Guide](https://docs.harness.agentkit.best/ai-tools/chatgpt.md)
+  and [Troubleshooting Guide](https://docs.harness.agentkit.best/troubleshooting.md).
 - Marketplace installation and marketplace review/publication are different
   states. Local validation does not prove an approved public listing.
 

--- a/README.md
+++ b/README.md
@@ -356,15 +356,22 @@ Granting either form of access grants remote execution authority. Read the
 ChatGPT custom MCP apps are configured in the web app and must be reachable
 from OpenAI's infrastructure. Enable Developer mode, then go to **Settings or
 Workspace settings → Apps → Create**, enter the endpoint above, scan its tools,
-and create the app. The exact availability and controls depend on the ChatGPT
-plan and workspace role; follow [OpenAI's current Developer mode guide](https://help.openai.com/en/articles/12584461-developer-mode-and-full-mcp-connectors-in-chatgpt).
+and create the app. Initially, the connector is in **Draft (Dev)** state and
+can be tested in standard 1-on-1 ChatGPT Web chats with Developer Mode enabled.
+To enable access across team members without Developer Mode constraints, a
+Workspace Admin/Owner can publish the connector under **Workspace settings →
+Apps → Drafts → Publish**. The exact availability and controls depend on the
+ChatGPT plan (Business, Enterprise, or Edu beta for full MCP actions) and
+workspace role; follow [OpenAI's current Developer mode guide](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt)
+and the [ChatGPT Configuration Guide](https://docs.harness.agentkit.best/ai-tools/chatgpt.md).
 
 The `owner-bearer` mode is not a documented direct path because the custom-app
 flow has no arbitrary-header field. In `cloudflare-access` mode, use the
 owner-controlled Access URL and complete its OAuth flow; keep the connection
 provisional until the live compatibility checklist passes. Never place the
-owner bearer in an app definition or a chat.
-
+owner bearer in an app definition or a chat. If invocation fails with
+`FORBIDDEN: This conversation does not support developer MCPs`, consult the
+[Troubleshooting Guide](https://docs.harness.agentkit.best/troubleshooting.md).
 </details>
 
 <details>

--- a/docs-site/ai-tools/chatgpt.md
+++ b/docs-site/ai-tools/chatgpt.md
@@ -28,6 +28,8 @@ Always scope ChatGPT redirect URIs to `https://chatgpt.com/connector/oauth/*` ra
 
 ## 2. Setup Instructions in ChatGPT
 
+### Step-by-Step Connector Setup
+
 1. In ChatGPT Web, click your avatar → **Settings** (or **Workspace Settings**) → **Connected apps** / **Create new plugin / connector**.
 2. Name the connector (e.g. `CloudHarness`).
 3. Set the **Server URL** to:
@@ -37,11 +39,48 @@ Always scope ChatGPT redirect URIs to `https://chatgpt.com/connector/oauth/*` ra
 4. Select **OAuth** as the Authentication method.
 5. Click **Create** (or **Connect & Authorize**).
 6. A browser popup will open the Cloudflare Access login page (GitHub or Google SSO). Complete authentication to link the connector.
-7. Once authorized, ChatGPT registers the Cloud Harness MCP tools.
+7. Once authorized, ChatGPT scans and registers the Cloud Harness MCP tool definitions.
+
+### Developer Mode (Draft) vs. Published Custom Connector
+
+ChatGPT provides two distinct execution modes for custom MCP apps:
+
+1. **Developer Mode (Draft / Dev Connector):**
+   - When first created, the connector is in **Draft (Dev)** state, visible under **Settings → Apps → Enabled Apps** with a **Dev** label.
+   - **Prerequisites:** Developer Mode must be actively enabled for your user account (**Settings → Apps → Advanced Settings → Developer mode**).
+   - **Supported Surfaces:** Testing is supported in standard 1-on-1 ChatGPT Web conversations with the draft app selected.
+2. **Workspace Published (Custom Connector):**
+   - To make CloudHarness accessible across your workspace without requiring each member to manage Developer Mode, a Workspace Admin/Owner must publish the connector.
+   - Navigate to **Workspace Settings → Apps → Drafts**, select the connector, configure allowed actions and group access via RBAC, and click **Publish**.
+   - Once published, the connector displays the **custom** label and is available to all authorized workspace members according to workspace action controls.
+
+::: tip Plan & Feature Availability
+Full MCP execution (including write/execute operations such as `workspace_open` and `exec_run`) is provided in beta for ChatGPT **Business, Enterprise, and Edu** plans. Feature availability, UI paths, and permissions follow OpenAI's [Developer mode and MCP apps in ChatGPT guide](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+:::
 
 ---
 
 ## 3. Troubleshooting
+
+### `FORBIDDEN: This conversation does not support developer MCPs`
+
+**Cause:** ChatGPT discovered the MCP tool schemas, but the active conversation context or account configuration prohibits executing draft/developer-mode MCP tools. This occurs in any of the following conditions:
+
+1. **Unsupported Conversation Context:** Developer MCPs (draft apps) cannot be invoked in Custom GPTs, Project chats (unless permitted by project settings), Canvas mode, temporary chats, or ChatGPT mobile apps.
+2. **Developer Mode Disabled:** The connector is in draft state, but Developer Mode is toggled off in the current user account settings.
+3. **Draft State in Workspace Conversations:** The connector has not yet been published by a Workspace Admin/Owner and is being accessed in a standard team conversation.
+4. **Plan Tier Gating:** The ChatGPT plan tier does not support full MCP write actions in developer mode.
+5. **Stale Thread Cache:** An existing chat thread started prior to connector authorization retained an earlier tool configuration.
+
+**Fix:**
+
+1. **Use Standard 1-on-1 Web Chats:** Open a fresh conversation on ChatGPT Web, mention `@CloudHarness` or select the connector from the tools menu, and initiate the task.
+2. **Enable Developer Mode:** Go to **Settings → Apps → Advanced Settings** (or **Workspace Settings → Permissions & Roles**) and ensure **Developer mode** is toggled **ON**.
+3. **Publish to Workspace (Admins):** In **Workspace Settings → Apps → Drafts**, review the tool actions and click **Publish** to convert the draft into an approved workspace **Custom Connector**.
+4. **Verify Plan Support:** Confirm your workspace has access to full MCP support (Business, Enterprise, or Edu plan).
+5. **Start a Fresh Thread:** If the connector was just created or re-authorized, open a new chat session to refresh conversation capabilities.
+
+---
 
 ### `Dynamic client registration failed (invalid_client_metadata: redirect_uri is not allowed)`
 **Cause:** Cloudflare Access rejected ChatGPT's callback URL during Dynamic Client Registration.

--- a/docs-site/troubleshooting.md
+++ b/docs-site/troubleshooting.md
@@ -69,3 +69,15 @@ docker compose --profile images build executor-image
 ### 7. Local Stdio: `--workspace path must be absolute` or Directory Error
 **Cause:** The `--workspace` argument provided to `cloud-harness-mcp --transport stdio` is relative, does not exist, or points to a regular file instead of a directory.
 **Fix:** Provide a valid, existing absolute directory path (e.g. `/home/user/project` or `/mnt/c/Users/user/project` in WSL). Native Windows path formats (like `C:\...`) are unsupported in v1 local stdio mode; run the process inside WSL instead.
+
+---
+
+### 8. ChatGPT: `FORBIDDEN: This conversation does not support developer MCPs`
+**Cause:** ChatGPT allows tool discovery, but blocks invocation because the active conversation surface (e.g. Custom GPT, Project chat, Canvas, Mobile app, or temporary chat) or user account restricts draft developer MCPs, or the connector is in draft state without workspace publishing.
+**Fix:**
+1. **Open Standard 1-on-1 Web Chat:** Use ChatGPT Web in a standard chat thread and select or `@mention` CloudHarness.
+2. **Enable Developer Mode:** Verify that **Settings → Apps → Advanced Settings → Developer mode** is enabled for your account.
+3. **Publish Connector (Workspace Admins):** In **Workspace Settings → Apps → Drafts**, select CloudHarness and click **Publish** to promote it from a draft Developer MCP to an approved workspace **Custom Connector**.
+4. **Verify Plan Support:** Full MCP write actions (such as `workspace_open`) are in beta for ChatGPT Business, Enterprise, and Edu plans.
+5. **Start Fresh Thread:** If the connector was recently created or authorized, open a new chat session to clear stale conversation state.
+6. See [ChatGPT Configuration Guide](/ai-tools/chatgpt) for complete setup steps.

--- a/plans/journals/2026-09-01-resolve-chatgpt-developer-mcp-forbidden-gating.md
+++ b/plans/journals/2026-09-01-resolve-chatgpt-developer-mcp-forbidden-gating.md
@@ -1,0 +1,26 @@
+---
+title: Resolve ChatGPT Developer MCP FORBIDDEN gating and documentation parity
+date: 2026-09-01
+summary: Documented ChatGPT Developer Mode draft lifecycle, published custom connector workflow, conversation capability constraints, and troubleshooting for FORBIDDEN developer MCP rejections
+---
+
+# Resolve ChatGPT Developer MCP FORBIDDEN gating and documentation parity
+
+## Problem
+In issue #171, users reported that CloudHarness MCP tools are successfully scanned and discovered in ChatGPT after OAuth registration, but tool execution (e.g. `workspace_open`) is rejected with `FORBIDDEN: This conversation does not support developer MCPs`.
+
+## Diagnosis & Root Cause
+ChatGPT distinguishes between draft Developer MCPs (custom apps created in Developer Mode with the `Dev` tag) and approved workspace Custom Connectors (published by admins with the `custom` tag).
+1. When registered as a custom app, ChatGPT places it in Draft state. In this mode, tool execution is restricted to standard 1-on-1 ChatGPT Web conversations where Developer Mode is explicitly enabled in the user's account settings.
+2. Attempting to invoke developer MCPs within unsupported conversation contexts (Custom GPTs, Project chats, Canvas, Mobile apps, Temporary chats, or accounts with Developer Mode disabled) triggers `FORBIDDEN: This conversation does not support developer MCPs` on the ChatGPT platform before or during tool invocation.
+3. OpenAI restricts full MCP execution (write actions) to Business, Enterprise, and Edu plans (beta).
+4. CloudHarness's documentation lacked guidance on Developer Mode vs. Published Connector lifecycles, conversation surface constraints, and troubleshooting playbooks for this error. Note that server-side hiding of tools at discovery time is not feasible within MCP protocol constraints because `tools/list` responses are session-static and ChatGPT does not transmit per-conversation developer mode capability state during tool discovery.
+
+## Solution
+1. **Enhanced `docs-site/ai-tools/chatgpt.md`**: Added detailed breakdowns of Developer Mode (Draft) vs. Workspace Published Custom Connector lifecycles, conversation prerequisites, and a comprehensive troubleshooting section for `FORBIDDEN: This conversation does not support developer MCPs` detailing root causes and concrete fixes.
+2. **Updated `docs-site/troubleshooting.md`**: Added item #8 detailing cause, verification, and resolution steps for ChatGPT developer MCP invocation rejections.
+3. **Updated `README.md`**: Clarified the ChatGPT client setup to cover draft testing vs. workspace publishing and direct links to the troubleshooting playbook.
+4. **Updated skill references & synced plugin**: Added concise ChatGPT execution mode guidance with public URLs in `.agents/skills/cloudharness/references/installation-and-security.md` and synchronized byte-identically with `plugins/cloud-harness/`.
+5. **Verified**: Validated via `npm run docs:links`, `npm run docs:build`, `npm test packages/contracts/test/cloudharness-skill-contract.test.ts`, `npm run typecheck`, `npm run lint`, and `npm run test:unit`.
+
+> Historical work record — not durable authority. Prefer docs/specs/ADRs for current decisions.

--- a/plugins/cloud-harness/skills/cloudharness/references/installation-and-security.md
+++ b/plugins/cloud-harness/skills/cloudharness/references/installation-and-security.md
@@ -92,6 +92,14 @@ Inspect with `claude mcp get cloud-harness`, then confirm it in `/mcp`.
   authorization flow. The owner deployment at `https://harness.zuey.me/mcp`
   uses Cloudflare Access Managed OAuth with allowlisted mutually trusted
   operators; it is not a hostile multi-tenant service.
+- In ChatGPT, custom MCP connectors operate in **Developer Mode (Draft)** or
+  **Workspace Published (Custom Connector)** mode. Draft apps execute only in
+  standard 1-on-1 ChatGPT Web chats with Developer Mode enabled. Invocations
+  rejected with `FORBIDDEN: This conversation does not support developer MCPs`
+  indicate an unsupported conversation surface (e.g. Custom GPTs, Projects,
+  Canvas, Mobile apps, or disabled Developer Mode); see the
+  [ChatGPT Configuration Guide](https://docs.harness.agentkit.best/ai-tools/chatgpt.md)
+  and [Troubleshooting Guide](https://docs.harness.agentkit.best/troubleshooting.md).
 - Marketplace installation and marketplace review/publication are different
   states. Local validation does not prove an approved public listing.
 


### PR DESCRIPTION
## Summary

Addresses #171 by providing comprehensive documentation and troubleshooting guidance for ChatGPT Custom MCP Apps, specifically explaining the difference between Developer Mode (Draft) and Workspace Published (Custom Connector) states, and detailing the resolution for `FORBIDDEN: This conversation does not support developer MCPs`.

## Root Cause & Investigation
- When CloudHarness MCP is connected to ChatGPT in Developer Mode, it is initially registered as a Draft (Dev) app.
- ChatGPT restricts Developer MCP tool execution to standard 1-on-1 ChatGPT Web chats where Developer Mode is enabled in user settings.
- Invoking Developer MCPs in unsupported conversation contexts (Custom GPTs, Projects, Canvas, Mobile apps, Temporary chats, or accounts with Developer Mode turned off) results in `FORBIDDEN: This conversation does not support developer MCPs` returned directly by the ChatGPT platform before the request reaches the server.
- Full MCP write execution (`workspace_open`, `exec_run`, etc.) is in beta for Business, Enterprise, and Edu plans.
- *Protocol Limitation:* MCP `tools/list` responses are session-static and ChatGPT does not transmit per-conversation developer mode capability state during tool discovery, making server-side conditional tool hiding at discovery time impossible.

## Changes
- **`docs-site/ai-tools/chatgpt.md`**: Added Developer Mode (Draft) vs. Workspace Published Custom Connector lifecycle guide, conversation prerequisites, and a dedicated troubleshooting section for `FORBIDDEN: This conversation does not support developer MCPs`.
- **`docs-site/troubleshooting.md`**: Added entry #8 detailing causes and actionable resolution steps.
- **`README.md`**: Updated ChatGPT setup guidance and linked directly to the troubleshooting guide.
- **`.agents/skills/cloudharness/` & `plugins/cloud-harness/`**: Updated skill installation and security reference with absolute public docs links and verified byte-identical synchronization.
- **`plans/journals/`**: Recorded technical journal entry.

## Verification
- `npm run docs:links`: Passed (14 external links verified across 39 pages)
- `npm run docs:build`: Passed (VitePress build succeeded; emitted 38 twins)
- `npm test packages/contracts/test/cloudharness-skill-contract.test.ts`: Passed (5/5 tests passed; byte-identical plugin sync verified)
- `npm run test:unit`: Passed (95 test files, 659 tests passed)
- `npm run typecheck`: Passed (6 packages typechecked cleanly)
- `npm run lint`: Passed (0 errors)

Closes #171